### PR TITLE
[2주차] 김다인/[feat] user, post, comment, like Entity 생성

### DIFF
--- a/kimdain/src/main/java/com/leets/blog/entity/BaseEntity.java
+++ b/kimdain/src/main/java/com/leets/blog/entity/BaseEntity.java
@@ -1,0 +1,30 @@
+package com.leets.blog.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/kimdain/src/main/java/com/leets/blog/entity/BaseTimeEntity.java
+++ b/kimdain/src/main/java/com/leets/blog/entity/BaseTimeEntity.java
@@ -1,0 +1,18 @@
+package com.leets.blog.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/kimdain/src/main/java/com/leets/blog/entity/Comment.java
+++ b/kimdain/src/main/java/com/leets/blog/entity/Comment.java
@@ -1,0 +1,33 @@
+package com.leets.blog.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Table(name = "comment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Column(name = "content", nullable = false, length = 255)
+    private String content;
+
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL)
+    private List<CommentLike> commentLikes;
+}

--- a/kimdain/src/main/java/com/leets/blog/entity/CommentLike.java
+++ b/kimdain/src/main/java/com/leets/blog/entity/CommentLike.java
@@ -1,0 +1,25 @@
+package com.leets.blog.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "comment_like")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CommentLike extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+}

--- a/kimdain/src/main/java/com/leets/blog/entity/CommentLike.java
+++ b/kimdain/src/main/java/com/leets/blog/entity/CommentLike.java
@@ -4,13 +4,20 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "comment_like")
+@Table(
+        name = "comment_like",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_comment_like_user_comment",
+                        columnNames = {"user_id", "comment_id"}
+                )
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class CommentLike extends BaseTimeEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/kimdain/src/main/java/com/leets/blog/entity/Post.java
+++ b/kimdain/src/main/java/com/leets/blog/entity/Post.java
@@ -1,0 +1,38 @@
+package com.leets.blog.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Table(name = "post")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "content", nullable = false, length = 255)
+    private String content;
+
+    @Column(name = "image", length = 255)
+    private String image;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<Comment> comments;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<PostLike> postLikes;
+}

--- a/kimdain/src/main/java/com/leets/blog/entity/PostLike.java
+++ b/kimdain/src/main/java/com/leets/blog/entity/PostLike.java
@@ -1,0 +1,25 @@
+package com.leets.blog.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "post_like")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PostLike extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+}

--- a/kimdain/src/main/java/com/leets/blog/entity/PostLike.java
+++ b/kimdain/src/main/java/com/leets/blog/entity/PostLike.java
@@ -4,13 +4,20 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "post_like")
+@Table(
+        name = "post_like",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_post_like_user_post",
+                        columnNames = {"user_id", "post_id"}
+                )
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class PostLike extends BaseTimeEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/kimdain/src/main/java/com/leets/blog/entity/User.java
+++ b/kimdain/src/main/java/com/leets/blog/entity/User.java
@@ -1,0 +1,46 @@
+package com.leets.blog.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Table(name = "user")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "email", nullable = false, length = 255)
+    private String email;
+
+    @Column(name = "password", nullable = false, length = 255)
+    private String password;
+
+    @Column(name = "nickname", nullable = false, length = 50)
+    private String nickname;
+
+    @Column(name = "image", length = 255)
+    private String image;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Post> posts;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Comment> comments;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<PostLike> postLikes;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<CommentLike> commentLikes;
+}

--- a/kimdain/src/main/java/com/leets/blog/entity/User.java
+++ b/kimdain/src/main/java/com/leets/blog/entity/User.java
@@ -2,7 +2,6 @@ package com.leets.blog.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-
 import java.util.List;
 
 @Entity
@@ -12,7 +11,6 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class User extends BaseEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -20,7 +18,7 @@ public class User extends BaseEntity {
     @Column(name = "name", nullable = false, length = 50)
     private String name;
 
-    @Column(name = "email", nullable = false, length = 255)
+    @Column(name = "email", nullable = false, length = 255, unique = true)
     private String email;
 
     @Column(name = "password", nullable = false, length = 255)


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용
User, Post, Comment 엔티티 생성

## 2. 핵심 변경 사항
좋아요 테이블을 분리 : 누가 어떤 게시글에 좋아요를 눌렀는지 식별 가능하도록 설계
유저 soft delete를 위한 deleted_at 도입
공통 필드 추상화 : 엔티티에서 공통적으로 사용하는 생성/수정/삭제 시각을 BaseEntity로 분리하여 코드 중복 최소

## 3. 실행 및 검증 결과
<img width="1787" height="1022" alt="image" src="https://github.com/user-attachments/assets/b41ede79-716f-493b-978b-e1bb580258ec" />
ERD 수정본을 반영하여 Entity 생성


## 4. 완료 사항
1. user, post, comment Entity 코드 작성
2. like테이블 및 공통 BaseEntity 추가 생성


## 5. 추가 사항
- 관련 이슈: closed #74 


## 제출 체크리스트
- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고

