### PR TITLE
[3주차] 남유정/[feat] 게시글 도메인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/leets7th/domain/category/entity/Category.java
+++ b/src/main/java/com/example/leets7th/domain/category/entity/Category.java
@@ -1,0 +1,27 @@
+package com.example.leets7th.domain.category.entity;
+
+import com.example.leets7th.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "categories")
+public class Category extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    public static Category create(String name) {
+        Category category = new Category();
+        category.name = name;
+        return category;
+    }
+}

--- a/src/main/java/com/example/leets7th/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/example/leets7th/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.example.leets7th.domain.category.repository;
+
+import com.example.leets7th.domain.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    Optional<Category> findByName(String name);
+}

--- a/src/main/java/com/example/leets7th/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/leets7th/domain/post/controller/PostController.java
@@ -6,6 +6,10 @@ import com.example.leets7th.domain.post.dto.response.PostDetailResponse;
 import com.example.leets7th.domain.post.dto.response.PostListResponse;
 import com.example.leets7th.domain.post.service.PostService;
 import com.example.leets7th.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
+@Tag(name = "Post", description = "게시글 관련 API")
 @RestController
 @RequestMapping("/api/posts")
 @RequiredArgsConstructor
@@ -25,9 +30,15 @@ public class PostController {
     private final PostService postService;
 
     // 게시글 목록 조회
+    @Operation(summary = "게시글 목록 조회", description = "페이지 단위로 게시글 목록을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
     @GetMapping
     public ResponseEntity<ApiResponse<PostListResponse>> getPosts(
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
             @RequestParam(defaultValue = "0") @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.") int page,
+            @Parameter(description = "페이지 크기", example = "10")
             @RequestParam(defaultValue = "10") @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.") int size
     ) {
         PostListResponse response = postService.getPosts(page, size);
@@ -35,17 +46,29 @@ public class PostController {
     }
 
     // 게시글 상세 조회
+    @Operation(summary = "게시글 상세 조회", description = "게시글 ID로 단건 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글 없음")
+    })
     @GetMapping("/{postId}")
-    public ResponseEntity<ApiResponse<PostDetailResponse>> getPost(@PathVariable Long postId) {
+    public ResponseEntity<ApiResponse<PostDetailResponse>> getPost(
+            @Parameter(description = "게시글 ID", example = "1") @PathVariable Long postId) {
         PostDetailResponse response = postService.getPost(postId);
         return ResponseEntity.ok(ApiResponse.success("POST_DETAIL_SUCCESS", "게시글 상세 조회 성공", response));
     }
 
     // 게시글 작성
     // TODO: 실제 인증 구현 시 @AuthenticationPrincipal로 userId 주입
+    @Operation(summary = "게시글 작성", description = "새 게시글을 생성합니다. X-User-Id 헤더로 작성자를 지정합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "생성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값 오류")
+    })
     @PostMapping
     public ResponseEntity<ApiResponse<Map<String, Object>>> createPost(
             @RequestBody @Valid PostCreateRequest request,
+            @Parameter(description = "작성자 ID (임시)", example = "1")
             @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId
     ) {
         Long postId = postService.createPost(request, userId);
@@ -57,10 +80,17 @@ public class PostController {
     }
 
     // 게시글 수정
+    @Operation(summary = "게시글 수정", description = "게시글 제목/내용을 수정합니다. 작성자만 수정 가능합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "수정 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글 없음")
+    })
     @PatchMapping("/{postId}")
     public ResponseEntity<ApiResponse<Map<String, String>>> updatePost(
-            @PathVariable Long postId,
+            @Parameter(description = "게시글 ID", example = "1") @PathVariable Long postId,
             @RequestBody PostUpdateRequest request,
+            @Parameter(description = "요청자 ID (임시)", example = "1")
             @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId
     ) {
         postService.updatePost(postId, request, userId);
@@ -68,9 +98,16 @@ public class PostController {
     }
 
     // 게시글 삭제
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다. 작성자만 삭제 가능합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "삭제 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글 없음")
+    })
     @DeleteMapping("/{postId}")
     public ResponseEntity<ApiResponse<Map<String, String>>> deletePost(
-            @PathVariable Long postId,
+            @Parameter(description = "게시글 ID", example = "1") @PathVariable Long postId,
+            @Parameter(description = "요청자 ID (임시)", example = "1")
             @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId
     ) {
         postService.deletePost(postId, userId);

--- a/src/main/java/com/example/leets7th/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/leets7th/domain/post/controller/PostController.java
@@ -1,0 +1,79 @@
+package com.example.leets7th.domain.post.controller;
+
+import com.example.leets7th.domain.post.dto.request.PostCreateRequest;
+import com.example.leets7th.domain.post.dto.request.PostUpdateRequest;
+import com.example.leets7th.domain.post.dto.response.PostDetailResponse;
+import com.example.leets7th.domain.post.dto.response.PostListResponse;
+import com.example.leets7th.domain.post.service.PostService;
+import com.example.leets7th.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+@Validated
+public class PostController {
+
+    private final PostService postService;
+
+    // 게시글 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<PostListResponse>> getPosts(
+            @RequestParam(defaultValue = "0") @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.") int page,
+            @RequestParam(defaultValue = "10") @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.") int size
+    ) {
+        PostListResponse response = postService.getPosts(page, size);
+        return ResponseEntity.ok(ApiResponse.success("POST_LIST_SUCCESS", "게시글 목록 조회 성공", response));
+    }
+
+    // 게시글 상세 조회
+    @GetMapping("/{postId}")
+    public ResponseEntity<ApiResponse<PostDetailResponse>> getPost(@PathVariable Long postId) {
+        PostDetailResponse response = postService.getPost(postId);
+        return ResponseEntity.ok(ApiResponse.success("POST_DETAIL_SUCCESS", "게시글 상세 조회 성공", response));
+    }
+
+    // 게시글 작성
+    // TODO: 실제 인증 구현 시 @AuthenticationPrincipal로 userId 주입
+    @PostMapping
+    public ResponseEntity<ApiResponse<Map<String, Object>>> createPost(
+            @RequestBody @Valid PostCreateRequest request,
+            @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId
+    ) {
+        Long postId = postService.createPost(request, userId);
+        Map<String, Object> data = Map.of(
+                "postId", postId,
+                "message", "게시글이 생성되었습니다."
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(data));
+    }
+
+    // 게시글 수정
+    @PatchMapping("/{postId}")
+    public ResponseEntity<ApiResponse<Map<String, String>>> updatePost(
+            @PathVariable Long postId,
+            @RequestBody PostUpdateRequest request,
+            @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId
+    ) {
+        postService.updatePost(postId, request, userId);
+        return ResponseEntity.ok(ApiResponse.success(Map.of("message", "게시글이 수정되었습니다.")));
+    }
+
+    // 게시글 삭제
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<ApiResponse<Map<String, String>>> deletePost(
+            @PathVariable Long postId,
+            @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId
+    ) {
+        postService.deletePost(postId, userId);
+        return ResponseEntity.ok(ApiResponse.success(Map.of("message", "게시글이 삭제되었습니다.")));
+    }
+}

--- a/src/main/java/com/example/leets7th/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/example/leets7th/domain/post/dto/request/PostCreateRequest.java
@@ -1,9 +1,10 @@
 package com.example.leets7th.domain.post.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record PostCreateRequest(
-        @NotBlank(message = "카테고리는 필수입니다.") String category,
+        @NotNull(message = "카테고리는 필수입니다.") Long categoryId,
         @NotBlank(message = "제목은 필수입니다.") String title,
         @NotBlank(message = "내용은 필수입니다.") String content
 ) {

--- a/src/main/java/com/example/leets7th/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/example/leets7th/domain/post/dto/request/PostCreateRequest.java
@@ -1,0 +1,10 @@
+package com.example.leets7th.domain.post.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PostCreateRequest(
+        @NotBlank(message = "카테고리는 필수입니다.") String category,
+        @NotBlank(message = "제목은 필수입니다.") String title,
+        @NotBlank(message = "내용은 필수입니다.") String content
+) {
+}

--- a/src/main/java/com/example/leets7th/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/example/leets7th/domain/post/dto/request/PostCreateRequest.java
@@ -1,11 +1,18 @@
 package com.example.leets7th.domain.post.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "게시글 생성 요청")
 public record PostCreateRequest(
+        @Schema(description = "카테고리 ID", example = "1")
         @NotNull(message = "카테고리는 필수입니다.") Long categoryId,
+
+        @Schema(description = "제목", example = "스프링 공부 1일차")
         @NotBlank(message = "제목은 필수입니다.") String title,
+
+        @Schema(description = "내용", example = "오늘은 JPA를 배웠다.")
         @NotBlank(message = "내용은 필수입니다.") String content
 ) {
 }

--- a/src/main/java/com/example/leets7th/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/example/leets7th/domain/post/dto/request/PostUpdateRequest.java
@@ -1,7 +1,10 @@
 package com.example.leets7th.domain.post.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "게시글 수정 요청 (null인 필드는 수정하지 않음)")
 public record PostUpdateRequest(
-        String title,
-        String content
+        @Schema(description = "수정할 제목", example = "수정된 제목") String title,
+        @Schema(description = "수정할 내용", example = "수정된 내용입니다.") String content
 ) {
 }

--- a/src/main/java/com/example/leets7th/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/example/leets7th/domain/post/dto/request/PostUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.example.leets7th.domain.post.dto.request;
+
+public record PostUpdateRequest(
+        String title,
+        String content
+) {
+}

--- a/src/main/java/com/example/leets7th/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/example/leets7th/domain/post/dto/response/PostDetailResponse.java
@@ -1,0 +1,56 @@
+package com.example.leets7th.domain.post.dto.response;
+
+import com.example.leets7th.domain.post.entity.Post;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PostDetailResponse(
+        Long postId,
+        String title,
+        String content,
+        String thumbnailImageUrl,
+        CategoryDto category,
+        AuthorDto author,
+        List<ImageDto> images,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public record CategoryDto(Long categoryId, String name) {
+    }
+
+    public record AuthorDto(Long userId, String nickname) {
+    }
+
+    public record ImageDto(Long imageId, String imageUrl) {
+    }
+
+    public static PostDetailResponse from(Post post) {
+        CategoryDto categoryDto = null;
+        if (post.getCategory() != null) {
+            categoryDto = new CategoryDto(post.getCategory().getId(), post.getCategory().getName());
+        }
+
+        String nickname = post.getUser().getNickname();
+        AuthorDto authorDto = new AuthorDto(
+                post.getUser().getId(),
+                nickname != null ? nickname : "Unknown"
+        );
+
+        List<ImageDto> images = post.getImages().stream()
+                .map(img -> new ImageDto(img.getId(), img.getImageUrl()))
+                .toList();
+
+        return new PostDetailResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getThumbnailImageUrl(),
+                categoryDto,
+                authorDto,
+                images,
+                post.getCreatedAt(),
+                post.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/leets7th/domain/post/dto/response/PostListResponse.java
+++ b/src/main/java/com/example/leets7th/domain/post/dto/response/PostListResponse.java
@@ -1,0 +1,58 @@
+package com.example.leets7th.domain.post.dto.response;
+
+import com.example.leets7th.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PostListResponse(
+        List<PostSummaryDto> posts,
+        PageInfoDto pageInfo
+) {
+    public record PostSummaryDto(
+            Long postId,
+            String title,
+            String content,
+            String thumbnailImageUrl,
+            String author,
+            LocalDateTime createdAt
+    ) {
+        public static PostSummaryDto from(Post post) {
+            String nickname = post.getUser().getNickname();
+            return new PostSummaryDto(
+                    post.getId(),
+                    post.getTitle(),
+                    post.getContent(),
+                    post.getThumbnailImageUrl(),
+                    nickname != null ? nickname : "Unknown",
+                    post.getCreatedAt()
+            );
+        }
+    }
+
+    public record PageInfoDto(
+            int page,
+            int size,
+            long totalElements,
+            int totalPages,
+            boolean hasNext
+    ) {
+    }
+
+    public static PostListResponse from(Page<Post> page) {
+        List<PostSummaryDto> posts = page.getContent().stream()
+                .map(PostSummaryDto::from)
+                .toList();
+
+        PageInfoDto pageInfo = new PageInfoDto(
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.hasNext()
+        );
+
+        return new PostListResponse(posts, pageInfo);
+    }
+}

--- a/src/main/java/com/example/leets7th/domain/post/entity/Post.java
+++ b/src/main/java/com/example/leets7th/domain/post/entity/Post.java
@@ -1,5 +1,6 @@
 package com.example.leets7th.domain.post.entity;
 
+import com.example.leets7th.domain.category.entity.Category;
 import com.example.leets7th.domain.user.entity.User;
 import com.example.leets7th.domain.comment.entity.Comment;
 import com.example.leets7th.global.entity.BaseEntity;
@@ -29,6 +30,14 @@ public class Post extends BaseEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
+    // 썸네일 이미지 URL
+    private String thumbnailImageUrl;
+
+    // 카테고리
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
     // 작성자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -42,6 +51,25 @@ public class Post extends BaseEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("imageOrder ASC")
     private List<PostImage> images = new ArrayList<>();
+
+    public static Post create(String title, String content, String thumbnailImageUrl, User user, Category category) {
+        Post post = new Post();
+        post.title = title;
+        post.content = content;
+        post.thumbnailImageUrl = thumbnailImageUrl;
+        post.user = user;
+        post.category = category;
+        return post;
+    }
+
+    public void update(String title, String content) {
+        if (title != null && !title.isBlank()) {
+            this.title = title;
+        }
+        if (content != null && !content.isBlank()) {
+            this.content = content;
+        }
+    }
 
     // 연관관계 편의 메서드
 

--- a/src/main/java/com/example/leets7th/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/leets7th/domain/post/repository/PostRepository.java
@@ -1,0 +1,10 @@
+package com.example.leets7th.domain.post.repository;
+
+import com.example.leets7th.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    Page<Post> findAll(Pageable pageable);
+}

--- a/src/main/java/com/example/leets7th/domain/post/service/PostService.java
+++ b/src/main/java/com/example/leets7th/domain/post/service/PostService.java
@@ -46,8 +46,8 @@ public class PostService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        Category category = categoryRepository.findByName(request.category())
-                .orElseGet(() -> categoryRepository.save(Category.create(request.category())));
+        Category category = categoryRepository.findById(request.categoryId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다. id=" + request.categoryId()));
 
         Post post = Post.create(request.title(), request.content(), null, user, category);
         postRepository.save(post);

--- a/src/main/java/com/example/leets7th/domain/post/service/PostService.java
+++ b/src/main/java/com/example/leets7th/domain/post/service/PostService.java
@@ -1,0 +1,81 @@
+package com.example.leets7th.domain.post.service;
+
+import com.example.leets7th.domain.category.entity.Category;
+import com.example.leets7th.domain.category.repository.CategoryRepository;
+import com.example.leets7th.domain.post.dto.request.PostCreateRequest;
+import com.example.leets7th.domain.post.dto.request.PostUpdateRequest;
+import com.example.leets7th.domain.post.dto.response.PostDetailResponse;
+import com.example.leets7th.domain.post.dto.response.PostListResponse;
+import com.example.leets7th.domain.post.entity.Post;
+import com.example.leets7th.domain.post.repository.PostRepository;
+import com.example.leets7th.domain.user.entity.User;
+import com.example.leets7th.domain.user.repository.UserRepository;
+import com.example.leets7th.global.exception.ForbiddenException;
+import com.example.leets7th.global.exception.PostNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final CategoryRepository categoryRepository;
+
+    public PostListResponse getPosts(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Post> postPage = postRepository.findAll(pageable);
+        return PostListResponse.from(postPage);
+    }
+
+    public PostDetailResponse getPost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+        return PostDetailResponse.from(post);
+    }
+
+    @Transactional
+    public Long createPost(PostCreateRequest request, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Category category = categoryRepository.findByName(request.category())
+                .orElseGet(() -> categoryRepository.save(Category.create(request.category())));
+
+        Post post = Post.create(request.title(), request.content(), null, user, category);
+        postRepository.save(post);
+        return post.getId();
+    }
+
+    @Transactional
+    public void updatePost(Long postId, PostUpdateRequest request, Long userId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        if (!post.getUser().getId().equals(userId)) {
+            // 수정 spec에서 작성자와 수정자가 다름 -> 400
+            throw new IllegalArgumentException("작성자만 수정할 수 있습니다.");
+        }
+
+        post.update(request.title(), request.content());
+    }
+
+    @Transactional
+    public void deletePost(Long postId, Long userId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        if (!post.getUser().getId().equals(userId)) {
+            throw new ForbiddenException("삭제 권한이 없습니다.");
+        }
+
+        postRepository.delete(post);
+    }
+}

--- a/src/main/java/com/example/leets7th/domain/string/controller/StringController.java
+++ b/src/main/java/com/example/leets7th/domain/string/controller/StringController.java
@@ -1,8 +1,8 @@
-package com.example.leets7th.controller;
+package com.example.leets7th.domain.string.controller;
 
-import com.example.leets7th.dto.StringRequestDto;
-import com.example.leets7th.dto.StringResponseDto;
-import com.example.leets7th.service.StringService;
+import com.example.leets7th.domain.string.dto.StringRequestDto;
+import com.example.leets7th.domain.string.dto.StringResponseDto;
+import com.example.leets7th.domain.string.service.StringService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/example/leets7th/domain/string/controller/StringController.java
+++ b/src/main/java/com/example/leets7th/domain/string/controller/StringController.java
@@ -3,9 +3,12 @@ package com.example.leets7th.domain.string.controller;
 import com.example.leets7th.domain.string.dto.StringRequestDto;
 import com.example.leets7th.domain.string.dto.StringResponseDto;
 import com.example.leets7th.domain.string.service.StringService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "String", description = "문자열 관련 API")
 @RestController
 @RequestMapping("/api/string")
 public class StringController {
@@ -17,12 +20,14 @@ public class StringController {
     }
 
     // 헬스체크
+    @Operation(summary = "헬스체크", description = "서버 상태를 확인합니다.")
     @GetMapping("/health")
     public ResponseEntity<String> healthCheck() {
         return ResponseEntity.ok("ok");
     }
 
     // 문자열 반복
+    @Operation(summary = "문자열 반복", description = "입력한 문자열을 반복 처리하여 반환합니다.")
     @PostMapping("/repeat")
     public ResponseEntity<StringResponseDto> repeatString(
             @RequestBody StringRequestDto requestDto

--- a/src/main/java/com/example/leets7th/domain/string/dto/StringRequestDto.java
+++ b/src/main/java/com/example/leets7th/domain/string/dto/StringRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.leets7th.dto;
+package com.example.leets7th.domain.string.dto;
 
 public record StringRequestDto(
         String value

--- a/src/main/java/com/example/leets7th/domain/string/dto/StringResponseDto.java
+++ b/src/main/java/com/example/leets7th/domain/string/dto/StringResponseDto.java
@@ -1,4 +1,4 @@
-package com.example.leets7th.dto;
+package com.example.leets7th.domain.string.dto;
 
 public record StringResponseDto(
         String string_one,

--- a/src/main/java/com/example/leets7th/domain/string/service/StringService.java
+++ b/src/main/java/com/example/leets7th/domain/string/service/StringService.java
@@ -1,6 +1,6 @@
-package com.example.leets7th.service;
+package com.example.leets7th.domain.string.service;
 
-import com.example.leets7th.dto.StringResponseDto;
+import com.example.leets7th.domain.string.dto.StringResponseDto;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/src/main/java/com/example/leets7th/domain/user/entity/User.java
+++ b/src/main/java/com/example/leets7th/domain/user/entity/User.java
@@ -25,6 +25,8 @@ public class User extends BaseEntity {
     // 선택 정보
     private String username;
 
+    private String nickname;
+
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
@@ -35,6 +37,12 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user")
     private List<Comment> comments = new ArrayList<>();
+
+    public static User create(String nickname) {
+        User user = new User();
+        user.nickname = nickname;
+        return user;
+    }
 
     public void delete() {
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/com/example/leets7th/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/leets7th/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.example.leets7th.domain.user.repository;
+
+import com.example.leets7th.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/example/leets7th/global/common/ApiResponse.java
+++ b/src/main/java/com/example/leets7th/global/common/ApiResponse.java
@@ -1,0 +1,41 @@
+package com.example.leets7th.global.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final String code;
+    private final String message;
+    private final T data;
+    private final List<FieldErrorDetail> errors;
+
+    private ApiResponse(boolean success, String code, String message, T data, List<FieldErrorDetail> errors) {
+        this.success = success;
+        this.code = code;
+        this.message = message;
+        this.data = data;
+        this.errors = errors;
+    }
+
+    public static <T> ApiResponse<T> success(String code, String message, T data) {
+        return new ApiResponse<>(true, code, message, data, null);
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, null, null, data, null);
+    }
+
+    public static <T> ApiResponse<T> error(String code, String message) {
+        return new ApiResponse<>(false, code, message, null, null);
+    }
+
+    public static <T> ApiResponse<T> error(String code, String message, List<FieldErrorDetail> errors) {
+        return new ApiResponse<>(false, code, message, null, errors);
+    }
+}

--- a/src/main/java/com/example/leets7th/global/common/FieldErrorDetail.java
+++ b/src/main/java/com/example/leets7th/global/common/FieldErrorDetail.java
@@ -1,0 +1,25 @@
+package com.example.leets7th.global.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FieldErrorDetail {
+
+    private final String field;
+    private final Object value;
+    private final String reason;
+
+    public FieldErrorDetail(String field, Object value, String reason) {
+        this.field = field;
+        this.value = value;
+        this.reason = reason;
+    }
+
+    public FieldErrorDetail(String field, String reason) {
+        this.field = field;
+        this.value = null;
+        this.reason = reason;
+    }
+}

--- a/src/main/java/com/example/leets7th/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/leets7th/global/config/SwaggerConfig.java
@@ -12,8 +12,8 @@ public class SwaggerConfig {
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .info(new Info()
-                        .title("Leets 7th BE Blog API")
-                        .description("남유정 API 명세서")
-                        .version("v1.0.0"));
+                        .title("Leets-7th BE Blog API")
+                        .description("[남유정] 미션 API 명세서")
+                        .version("3주차"));
     }
 }

--- a/src/main/java/com/example/leets7th/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/leets7th/global/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.example.leets7th.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Leets 7th BE Blog API")
+                        .description("남유정 API 명세서")
+                        .version("v1.0.0"));
+    }
+}

--- a/src/main/java/com/example/leets7th/global/exception/ForbiddenException.java
+++ b/src/main/java/com/example/leets7th/global/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package com.example.leets7th.global.exception;
+
+public class ForbiddenException extends RuntimeException {
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/leets7th/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/leets7th/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,75 @@
+package com.example.leets7th.global.exception;
+
+import com.example.leets7th.global.common.ApiResponse;
+import com.example.leets7th.global.common.FieldErrorDetail;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.List;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(PostNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handlePostNotFound(PostNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error("POST_NOT_FOUND", "해당 게시글을 찾을 수 없습니다."));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ApiResponse<Void>> handleForbidden(ForbiddenException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.error("FORBIDDEN", e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException e) {
+        List<FieldErrorDetail> errors = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> new FieldErrorDetail(fe.getField(), fe.getRejectedValue(), fe.getDefaultMessage()))
+                .toList();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("INVALID_PARAMETER", "잘못된 요청입니다.", errors));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleConstraintViolation(ConstraintViolationException e) {
+        List<FieldErrorDetail> errors = e.getConstraintViolations().stream()
+                .map(cv -> {
+                    String field = cv.getPropertyPath().toString();
+                    // "methodName.paramName" -> "paramName"
+                    if (field.contains(".")) {
+                        field = field.substring(field.lastIndexOf('.') + 1);
+                    }
+                    return new FieldErrorDetail(field, cv.getInvalidValue(), cv.getMessage());
+                })
+                .toList();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("INVALID_PARAMETER", "잘못된 요청입니다.", errors));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        List<FieldErrorDetail> errors = List.of(
+                new FieldErrorDetail(e.getName(), e.getValue(), e.getName() + "는 숫자여야 합니다.")
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("INVALID_PARAMETER", "잘못된 요청입니다.", errors));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("INVALID_PARAMETER", e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."));
+    }
+}

--- a/src/main/java/com/example/leets7th/global/exception/PostNotFoundException.java
+++ b/src/main/java/com/example/leets7th/global/exception/PostNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.leets7th.global.exception;
+
+public class PostNotFoundException extends RuntimeException {
+
+    public PostNotFoundException(Long postId) {
+        super("해당 게시글을 찾을 수 없습니다. id=" + postId);
+    }
+}

--- a/src/main/java/com/example/leets7th/global/init/DataInitializer.java
+++ b/src/main/java/com/example/leets7th/global/init/DataInitializer.java
@@ -1,0 +1,22 @@
+package com.example.leets7th.global.init;
+
+import com.example.leets7th.domain.user.entity.User;
+import com.example.leets7th.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements ApplicationRunner {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (userRepository.count() == 0) {
+            userRepository.save(User.create("Unknown"));
+        }
+    }
+}

--- a/src/main/java/com/example/leets7th/global/init/DataInitializer.java
+++ b/src/main/java/com/example/leets7th/global/init/DataInitializer.java
@@ -1,5 +1,7 @@
 package com.example.leets7th.global.init;
 
+import com.example.leets7th.domain.category.entity.Category;
+import com.example.leets7th.domain.category.repository.CategoryRepository;
 import com.example.leets7th.domain.user.entity.User;
 import com.example.leets7th.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -7,16 +9,27 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class DataInitializer implements ApplicationRunner {
 
     private final UserRepository userRepository;
+    private final CategoryRepository categoryRepository;
 
     @Override
     public void run(ApplicationArguments args) {
         if (userRepository.count() == 0) {
             userRepository.save(User.create("Unknown"));
+        }
+
+        if (categoryRepository.count() == 0) {
+            categoryRepository.saveAll(List.of(
+                    Category.create("자유게시판"),
+                    Category.create("공지사항"),
+                    Category.create("질문게시판")
+            ));
         }
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,3 +10,12 @@ spring:
 
   jpa:
     open-in-view: false
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /api-docs


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

<!-- README의 과제 요구사항 기준으로 이번 PR에서 구현한 범위를 작성해주세요. -->

- [x] 게시글 목록 조회 API (`GET /api/posts`)
- [x] 게시글 상세 조회 API (`GET /api/posts/{postId}`)
- [x] 게시글 작성 API (`POST /api/posts`)
- [x] 게시글 수정 API (`PATCH /api/posts/{postId}`)
- [x] 게시글 삭제 API (`DELETE /api/posts/{postId}`)
- [x] 프로젝트 구조 구성 (Controller/Service 레이어 분리)
- [ x] 헬스체크 API 구현 (`GET /health`)
- [x] 문자열 2개 반환 API 구현 (`POST /string/repeat`)
- [ ] 권장 추가 구현 반영 (선택)


## 2. 핵심 변경 사항

  | 파일 | 변경 내용 |
  |------|-----------|
  | `PostController` | 게시글 CRUD 5개 엔드포인트 추가 |
  | `PostService` | 목록(페이지네이션)/상세/작성/수정/삭제 비즈니스 로직 구현 |
  | `Post` | `category`, `thumbnailImageUrl` 필드 추가, `create()` / `update()` 팩토리·수정 메서드 추가 |
  | `Category` | 카테고리 엔티티 및 `CategoryRepository` 신규 추가 |
  | `ApiResponse` | 공통 응답 래퍼 (`success`, `error`, `errors` 포함) |
  | `GlobalExceptionHandler` | `PostNotFoundException`, `ForbiddenException`, `@Valid` 검증 오류, 타입 불일치 등 전역 처리 |
  | `SwaggerConfig` | SpringDoc OpenAPI 설정 추가 |
  | `DataInitializer` | 앱 시작 시 더미 유저 1명, 카테고리 3개 자동 생성 |
  | `domain/string` 패키지 이동 | 기존 루트 → `domain/string` 으로 이동 (도메인 패키지 구조 정리) |


## 3. 실행 및 검증 결과

- 실패 케이스는 대표적으로 몇개만 스크린샷으로 첨부

| 게시글 목록 조회 성공 |
| --- |
|<img width="718" height="713" alt="스크린샷 2026-04-07 095253" src="https://github.com/user-attachments/assets/408c0318-c46c-45da-b995-c61d7e6ed37e" />|

| 게시글 상세 조회 성공 |
| --- |
|<img width="720" height="652" alt="스크린샷 2026-04-07 095310" src="https://github.com/user-attachments/assets/c4007b40-4151-4766-8cdd-78385842f3e9" />|

| 게시글 상세 조회 실패 |
| --- |
|<img width="1081" height="774" alt="image" src="https://github.com/user-attachments/assets/50b971dc-048c-4fe3-9e5d-856612b80030" />|

| 게시글 작성 성공 |
| --- |
|<img width="727" height="772" alt="스크린샷 2026-04-07 094722" src="https://github.com/user-attachments/assets/2b2ec7cb-5178-448e-8b28-bf22aa8a6fe5" />|

| 게시글 작성 실패 |
| --- |
|<img width="1076" height="1102" alt="image" src="https://github.com/user-attachments/assets/851922a2-cafb-4e3a-ad9d-1b0a5efae280" />
|<img width="1082" height="1223" alt="image" src="https://github.com/user-attachments/assets/cd9ef1ec-aa8d-4457-af3f-6e3578586863" />|
|<img width="1076" height="1101" alt="image" src="https://github.com/user-attachments/assets/8767c01e-5b99-4d94-badc-d1c996f3fe0a" />|

| 게시글 수정 성공 |
| --- |
|<img width="719" height="798" alt="스크린샷 2026-04-07 095341" src="https://github.com/user-attachments/assets/59f4ca87-01d1-4cd3-8a50-f860ed4fc855" />|

| 게시글 수정 실패 |
| --- |
|<img width="1079" height="1157" alt="image" src="https://github.com/user-attachments/assets/c1ad5538-ca04-450c-af06-4ebf3737e7b7" />|

| 게시글 삭제 성공 |
| --- |
|<img width="721" height="565" alt="스크린샷 2026-04-07 095401" src="https://github.com/user-attachments/assets/e5442ecf-2045-45ca-bfeb-6c144a092bd4" />|

| 게시글 삭제 실패 |
| --- |
|<img width="1074" height="832" alt="image" src="https://github.com/user-attachments/assets/72f8c80f-be0f-44cb-a5eb-8d5ca71c2845" />|
|<img width="1080" height="839" alt="image" src="https://github.com/user-attachments/assets/f0c1f6b2-62b5-4efa-bd16-374fead3adb5" />|



## 4. 완료 사항

1. 게시글 CRUD API 5종 구현 (목록/상세/작성/수정/삭제)
2. 공통 응답 포맷(`ApiResponse`) 및 전역 예외 처리(`GlobalExceptionHandler`) 추가
3. Swagger(SpringDoc OpenAPI) 연동 및 API 문서화
4. 카테고리 엔티티 추가 및 DataInitializer로 초기 데이터 자동 세팅
5. 도메인 패키지 구조 정리 (`domain/string`으로 이동)


## 5. 추가 사항

- 관련 이슈: closed #95


## 제출 체크리스트

- [X] PR 제목이 규칙에 맞다
- [X] base가 `{이름}/main` 브랜치다
- [X] compare가 `{이름}/{숫자}주차` 브랜치다
- [X] 프로젝트가 정상 실행된다
- [X] 본인을 Assignee로 지정했다
- [X] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고

<!--
BE: rootTiket, soyesenna
FE: One-HyeWon, woneeee
-->
