### PR TITLE
[3주차] 이교형/[feat] 게시글 도메인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     runtimeOnly 'com.h2database:h2'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     // Swagger 의존성
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 }

--- a/src/main/java/com/example/leets_project/common/exception/GeneralException.java
+++ b/src/main/java/com/example/leets_project/common/exception/GeneralException.java
@@ -1,0 +1,12 @@
+package com.example.leets_project.common.exception;
+
+import com.example.leets_project.common.response.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException{
+
+    private ErrorCode errorCode;
+}

--- a/src/main/java/com/example/leets_project/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/leets_project/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,70 @@
+package com.example.leets_project.common.exception;
+
+import com.example.leets_project.common.response.ErrorCode;
+import com.example.leets_project.common.response.GlobalResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<GlobalResponse> handleGeneralException(GeneralException e) {
+        ErrorCode errorCode = e.getErrorCode();
+
+        return GlobalResponse.onFailure(errorCode);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<GlobalResponse> handleValidationExceptions(MethodArgumentNotValidException e) {
+        ErrorCode errorCode = ErrorCode.VALIDATION_FAILED;
+
+        String errorMessage = e.getBindingResult()
+                .getAllErrors()
+                .stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.joining(","));
+
+        return GlobalResponse.onFailure(errorCode, errorMessage);
+    }
+
+    @ExceptionHandler(com.fasterxml.jackson.core.JsonParseException.class) // JSON 파싱 오류 처리
+    public ResponseEntity<GlobalResponse> handleJsonParseException(
+            com.fasterxml.jackson.core.JsonParseException e) {
+        log.error("JSON 파싱 오류: {}", e.getMessage());
+        return GlobalResponse.onFailure(ErrorCode.VALIDATION_FAILED);
+    }
+
+    @ExceptionHandler(com.fasterxml.jackson.databind.JsonMappingException.class) // JSON 매핑 오류 처리
+    public ResponseEntity<GlobalResponse> handleJsonMappingException(
+            com.fasterxml.jackson.databind.JsonMappingException e) {
+        log.error("JSON 매핑 오류: {}", e.getMessage());
+        return GlobalResponse.onFailure(ErrorCode.VALIDATION_FAILED);
+    }
+
+    // X-USER-ID 헤더 누락
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<GlobalResponse> handleMissingHeader(MissingRequestHeaderException e) {
+        log.warn("필수 헤더 누락 - {}", e.getHeaderName());
+        return GlobalResponse.onFailure(ErrorCode.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<GlobalResponse> handleGenericException(Exception e) {
+        ErrorCode errorCode =
+                ErrorCode.INTERNAL_ERROR;
+        log.error("Unexpected Error Occured");
+        log.error(e.getMessage(), e);
+        log.error(e.getClass().getSimpleName());
+
+        return GlobalResponse.onFailure(errorCode);
+    }
+}

--- a/src/main/java/com/example/leets_project/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/leets_project/common/exception/GlobalExceptionHandler.java
@@ -16,55 +16,47 @@ import java.util.stream.Collectors;
 @Slf4j
 public class GlobalExceptionHandler {
 
+    // 커스텀 예외
     @ExceptionHandler(GeneralException.class)
     public ResponseEntity<GlobalResponse> handleGeneralException(GeneralException e) {
-        ErrorCode errorCode = e.getErrorCode();
-
-        return GlobalResponse.onFailure(errorCode);
+        log.warn("GeneralException: [{}] {}", e.getErrorCode().getCode(), e.getErrorCode().getMessage());
+        return GlobalResponse.onFailure(e.getErrorCode());
     }
-
+    // Validation 에러
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<GlobalResponse> handleValidationExceptions(MethodArgumentNotValidException e) {
-        ErrorCode errorCode = ErrorCode.VALIDATION_FAILED;
-
-        String errorMessage = e.getBindingResult()
-                .getAllErrors()
+        String errorDetail = e.getBindingResult()
+                .getFieldErrors()
                 .stream()
-                .map(DefaultMessageSourceResolvable::getDefaultMessage)
-                .collect(Collectors.joining(","));
+                .map(error -> "[" + error.getField() + "]: " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
 
-        return GlobalResponse.onFailure(errorCode, errorMessage);
+        log.warn("Validation Failed: {}", errorDetail);
+        return GlobalResponse.onFailure(ErrorCode.VALIDATION_FAILED, errorDetail);
     }
 
-    @ExceptionHandler(com.fasterxml.jackson.core.JsonParseException.class) // JSON 파싱 오류 처리
-    public ResponseEntity<GlobalResponse> handleJsonParseException(
-            com.fasterxml.jackson.core.JsonParseException e) {
-        log.error("JSON 파싱 오류: {}", e.getMessage());
-        return GlobalResponse.onFailure(ErrorCode.VALIDATION_FAILED);
-    }
+    // JSON 처리 에러
+    @ExceptionHandler({com.fasterxml.jackson.core.JsonParseException.class,
+            com.fasterxml.jackson.databind.JsonMappingException.class})
+    public ResponseEntity<GlobalResponse> handleJsonException(Exception e) {
+        log.error("JSON 처리 오류: {}", e.getMessage());
 
-    @ExceptionHandler(com.fasterxml.jackson.databind.JsonMappingException.class) // JSON 매핑 오류 처리
-    public ResponseEntity<GlobalResponse> handleJsonMappingException(
-            com.fasterxml.jackson.databind.JsonMappingException e) {
-        log.error("JSON 매핑 오류: {}", e.getMessage());
-        return GlobalResponse.onFailure(ErrorCode.VALIDATION_FAILED);
+        return GlobalResponse.onFailure(ErrorCode.VALIDATION_FAILED, "잘못된 JSON 형식입니다.");
     }
 
     // X-USER-ID 헤더 누락
     @ExceptionHandler(MissingRequestHeaderException.class)
     public ResponseEntity<GlobalResponse> handleMissingHeader(MissingRequestHeaderException e) {
         log.warn("필수 헤더 누락 - {}", e.getHeaderName());
-        return GlobalResponse.onFailure(ErrorCode.UNAUTHORIZED);
+
+        return GlobalResponse.onFailure(ErrorCode.UNAUTHORIZED, "필수 헤더가 누락되었습니다.");
     }
 
+    // 모든 예외
     @ExceptionHandler(Exception.class)
     public ResponseEntity<GlobalResponse> handleGenericException(Exception e) {
-        ErrorCode errorCode =
-                ErrorCode.INTERNAL_ERROR;
-        log.error("Unexpected Error Occured");
-        log.error(e.getMessage(), e);
-        log.error(e.getClass().getSimpleName());
+        log.error("Unexpected Error", e);
 
-        return GlobalResponse.onFailure(errorCode);
+        return GlobalResponse.onFailure(ErrorCode.INTERNAL_ERROR);
     }
 }

--- a/src/main/java/com/example/leets_project/common/response/ErrorCode.java
+++ b/src/main/java/com/example/leets_project/common/response/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
 
     // USER
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_4040", "사용자를 찾을 수 없습니다."),
-
+    USER_EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER_4001", "이미 사용 중인 이메일입니다."),
+    USER_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER_4002", "이미 사용 중인 닉네임입니다."),
     // POST
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_4040", "게시글을 찾을 수 없습니다."),
     POST_INVALID(HttpStatus.BAD_REQUEST, "POST_4001", "게시글 입력값이 올바르지 않습니다."),

--- a/src/main/java/com/example/leets_project/common/response/ErrorCode.java
+++ b/src/main/java/com/example/leets_project/common/response/ErrorCode.java
@@ -1,0 +1,33 @@
+package com.example.leets_project.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // COMMON
+    VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "COMMON_4000", "유효하지 않은 값입니다."),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "COMMON_4001", "잘못된 입력입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4002", "허용되지 않은 요청입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "서버 오류입니다."),
+
+    // AUTH
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_4000", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_4001", "접근 권한이 없습니다."),
+
+    // USER
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_4040", "사용자를 찾을 수 없습니다."),
+
+    // POST
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_4040", "게시글을 찾을 수 없습니다."),
+    POST_INVALID(HttpStatus.BAD_REQUEST, "POST_4001", "게시글 입력값이 올바르지 않습니다."),
+    POST_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_4003", "작성자만 수정/삭제할 수 있습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/com/example/leets_project/common/response/GlobalResponse.java
+++ b/src/main/java/com/example/leets_project/common/response/GlobalResponse.java
@@ -1,0 +1,46 @@
+package com.example.leets_project.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@RequiredArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class GlobalResponse {
+
+    private final Boolean isSuccess; // 성공, 실패 여부
+
+    private final String code; // 상태 코드
+
+    private final String message; // 구체적인 메시지
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final Object result; //반환할 객체
+
+    public static ResponseEntity<GlobalResponse> onSuccess(SuccessCode successCode, Object result){
+        return new ResponseEntity<>(
+                new GlobalResponse(true, successCode.getCode(), successCode.getMessage(), result),
+                successCode.getStatus());
+    }
+
+    public static ResponseEntity<GlobalResponse> onSuccess(SuccessCode successCode){
+        return new ResponseEntity<>(
+                new GlobalResponse(true, successCode.getCode(), successCode.getMessage(), null),
+                successCode.getStatus());
+    }
+
+    public static ResponseEntity<GlobalResponse> onFailure(ErrorCode errorCode, Object result){
+        return new ResponseEntity<>(
+                new GlobalResponse(false, errorCode.getCode(), errorCode.getMessage(), result),
+                errorCode.getStatus());
+    }
+
+    public static ResponseEntity<GlobalResponse> onFailure(ErrorCode errorCode){
+        return new ResponseEntity<>(
+                new GlobalResponse(false, errorCode.getCode(), errorCode.getMessage(), null),
+                errorCode.getStatus());
+    }
+}

--- a/src/main/java/com/example/leets_project/common/response/SuccessCode.java
+++ b/src/main/java/com/example/leets_project/common/response/SuccessCode.java
@@ -1,0 +1,21 @@
+package com.example.leets_project.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessCode {
+
+    // POST
+    POST_LIST(HttpStatus.OK, "POST_2000", "게시글 목록 조회 성공"),
+    POST_DETAIL(HttpStatus.OK, "POST_2001", "게시글 조회 성공"),
+    POST_CREATE(HttpStatus.CREATED, "POST_2010", "게시글 생성 성공"),
+    POST_UPDATE(HttpStatus.OK, "POST_2002", "게시글 수정 성공"),
+    POST_DELETE(HttpStatus.OK, "POST_2003", "게시글 삭제 성공");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/leets_project/common/response/SuccessCode.java
+++ b/src/main/java/com/example/leets_project/common/response/SuccessCode.java
@@ -8,12 +8,14 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SuccessCode {
 
+    // USER
+    USER_CREATE(HttpStatus.CREATED, "USER_2010", "유저 생성 성공"),
     // POST
     POST_LIST(HttpStatus.OK, "POST_2000", "게시글 목록 조회 성공"),
     POST_DETAIL(HttpStatus.OK, "POST_2001", "게시글 조회 성공"),
-    POST_CREATE(HttpStatus.CREATED, "POST_2010", "게시글 생성 성공"),
     POST_UPDATE(HttpStatus.OK, "POST_2002", "게시글 수정 성공"),
-    POST_DELETE(HttpStatus.OK, "POST_2003", "게시글 삭제 성공");
+    POST_DELETE(HttpStatus.OK, "POST_2003", "게시글 삭제 성공"),
+    POST_CREATE(HttpStatus.CREATED, "POST_2010", "게시글 생성 성공");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/leets_project/domain/comment/Comment.java
+++ b/src/main/java/com/example/leets_project/domain/comment/Comment.java
@@ -1,17 +1,13 @@
 package com.example.leets_project.domain.comment;
 
 import com.example.leets_project.common.entity.BaseEntity;
-import com.example.leets_project.domain.post.Post;
+import com.example.leets_project.domain.post.entity.Post;
 import com.example.leets_project.domain.user.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "comments")

--- a/src/main/java/com/example/leets_project/domain/post/entity/Post.java
+++ b/src/main/java/com/example/leets_project/domain/post/entity/Post.java
@@ -1,6 +1,8 @@
-package com.example.leets_project.domain.post;
+package com.example.leets_project.domain.post.entity;
 
 import com.example.leets_project.common.entity.BaseEntity;
+import com.example.leets_project.common.exception.GeneralException;
+import com.example.leets_project.common.response.ErrorCode;
 import com.example.leets_project.domain.comment.Comment;
 import com.example.leets_project.domain.user.User;
 import jakarta.persistence.*;
@@ -8,10 +10,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,5 +47,17 @@ public class Post extends BaseEntity {
         this.title = title;
         this.content = content;
         this.description = description;
+    }
+    public void updatePost(String title, String content, String description, Long requesterId) {
+        validateOwner(requesterId);
+        this.title = title;
+        this.content = content;
+        this.description = description;
+    }
+
+    public void validateOwner(Long userId) {
+        if (!this.user.getId().equals(userId)) {
+            throw new GeneralException(ErrorCode.POST_FORBIDDEN);
+        }
     }
 }

--- a/src/main/java/com/example/leets_project/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/leets_project/domain/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.example.leets_project.domain.post.repository;
+
+import com.example.leets_project.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/example/leets_project/domain/post/service/PostService.java
+++ b/src/main/java/com/example/leets_project/domain/post/service/PostService.java
@@ -1,0 +1,111 @@
+package com.example.leets_project.domain.post.service;
+
+import com.example.leets_project.common.exception.GeneralException;
+import com.example.leets_project.common.response.ErrorCode;
+import com.example.leets_project.domain.post.entity.Post;
+import com.example.leets_project.domain.post.repository.PostRepository;
+import com.example.leets_project.domain.post.web.dto.*;
+import com.example.leets_project.domain.user.User;
+import com.example.leets_project.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    private static final int MIN_PAGE = 0;
+    private static final int MAX_PAGE = 10;
+
+    // 1. 게시글 생성
+    @Transactional
+    public PostCreateResponse createPost(Long currentUserId, PostCreateRequest request) {
+        // 사용자 존재 확인
+        User user = findUserOrThrow(currentUserId);
+
+        Post post = Post.builder()
+                .user(user)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .description(request.getDescription())
+                .build();
+
+        Post savedPost = postRepository.save(post);
+
+        return PostCreateResponse.from(savedPost);
+    }
+
+    // 2. 게시글 목록 조회 (페이징)
+    public Page<PostListResponse> getPosts(int page, int size) {
+
+        validatePageRange(page);
+        PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        return postRepository.findAll(pageable)
+                .map(PostListResponse::from);
+    }
+
+    // 3. 게시글 상세 조회
+    public PostDetailResponse getPostDetail(Long postId) {
+
+        Post post = findPostOrThrow(postId);
+
+        return PostDetailResponse.from(post);
+    }
+
+    // 4. 게시글 수정
+    @Transactional
+    public PostUpdateResponse updatePost(Long postId, Long currentUserId, PostUpdateRequest request) {
+
+        Post post = findPostOrThrow(postId);
+
+        post.updatePost(
+                request.getTitle(),
+                request.getContent(),
+                request.getDescription(),
+                currentUserId
+        );
+
+        return PostUpdateResponse.from(post);
+    }
+
+    // 5. 게시글 삭제
+    @Transactional
+    public PostDeleteResponse deletePost(Long postId, Long currentUserId) {
+
+        Post post = findPostOrThrow(postId);
+
+        post.validateOwner(currentUserId);
+
+        postRepository.delete(post);
+
+        return PostDeleteResponse.of(postId);
+    }
+
+    // 공통 검증 로직
+    // 게시글 조회
+    private Post findPostOrThrow(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.POST_NOT_FOUND));
+    }
+
+    // 사용자 조회
+    private User findUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private void validatePageRange(int page) {
+        if (page < MIN_PAGE || page > MAX_PAGE) {
+            throw new GeneralException(ErrorCode.POST_INVALID);
+        }
+    }
+}

--- a/src/main/java/com/example/leets_project/domain/post/web/controller/PostController.java
+++ b/src/main/java/com/example/leets_project/domain/post/web/controller/PostController.java
@@ -1,0 +1,79 @@
+package com.example.leets_project.domain.post.web.controller;
+
+import com.example.leets_project.common.response.GlobalResponse;
+import com.example.leets_project.common.response.SuccessCode;
+import com.example.leets_project.domain.post.service.PostService;
+import com.example.leets_project.domain.post.web.dto.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name ="POST API", description = "게시글 생성,조회,수정,삭제 관련 API ")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/posts")
+public class PostController {
+
+    private final PostService postService;
+
+    // 게시물 생성
+    @Operation(summary = "게시글 생성", description = "새로운 게시글을 등록합니다.")
+    @PostMapping
+    public ResponseEntity<GlobalResponse> createPost(@RequestHeader("X-USER-ID") Long currentUserId,
+                                                     @RequestBody @Valid PostCreateRequest request){
+
+    PostCreateResponse response = postService.createPost(currentUserId, request);
+
+    return GlobalResponse.onSuccess(SuccessCode.POST_CREATE, response);
+    }
+
+    // 2. 게시글 목록 조회
+    @Operation(summary = "게시글 목록 조회", description = "게시글 목록을 페이징으로 조회합니다.")
+    @GetMapping
+    public ResponseEntity<GlobalResponse> getPosts(@RequestParam(defaultValue = "0") int page,
+                                                   @RequestParam(defaultValue = "10") int size) {
+
+        Page<PostListResponse> postPage = postService.getPosts(page, size);
+        PostListWrapperResponse response = PostListWrapperResponse.of(postPage);
+
+        return GlobalResponse.onSuccess(SuccessCode.POST_LIST, response);
+    }
+
+    // 3. 게시글 상세 조회
+    @Operation(summary = "게시글 상세 조회", description = "특정 게시글의 상세 내용을 조회합니다.")
+    @GetMapping("/{postId}")
+    public ResponseEntity<GlobalResponse> getPostDetail(@PathVariable Long postId) {
+
+        PostDetailResponse response = postService.getPostDetail(postId);
+
+        return GlobalResponse.onSuccess(SuccessCode.POST_DETAIL, response);
+    }
+
+    // 4. 게시글 수정
+    @Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
+    @PutMapping("/{postId}")
+    public ResponseEntity<GlobalResponse> updatePost(@PathVariable Long postId,
+                                                     @RequestHeader("X-USER-ID") Long currentUserId,
+                                                     @RequestBody @Valid PostUpdateRequest request) {
+
+        PostUpdateResponse response = postService.updatePost(postId, currentUserId, request);
+
+        return GlobalResponse.onSuccess(SuccessCode.POST_UPDATE, response);
+    }
+
+    // 5. 게시글 삭제
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<GlobalResponse> deletePost(@PathVariable Long postId,
+                                                     @RequestHeader("X-USER-ID") Long currentUserId) {
+
+        PostDeleteResponse response = postService.deletePost(postId, currentUserId);
+
+        return GlobalResponse.onSuccess(SuccessCode.POST_DELETE, response);
+    }
+}

--- a/src/main/java/com/example/leets_project/domain/post/web/dto/PostCreateRequest.java
+++ b/src/main/java/com/example/leets_project/domain/post/web/dto/PostCreateRequest.java
@@ -1,0 +1,22 @@
+package com.example.leets_project.domain.post.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostCreateRequest {
+
+    private Long userId;
+
+    @NotBlank(message = "제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+
+    private String description;
+}

--- a/src/main/java/com/example/leets_project/domain/post/web/dto/PostCreateResponse.java
+++ b/src/main/java/com/example/leets_project/domain/post/web/dto/PostCreateResponse.java
@@ -1,0 +1,26 @@
+package com.example.leets_project.domain.post.web.dto;
+
+import com.example.leets_project.domain.post.entity.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PostCreateResponse {
+
+    private Long postId;
+    private String title;
+    private String authorNickname;
+    private LocalDateTime createdAt;
+
+    public static PostCreateResponse from(Post post) {
+        return PostCreateResponse.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .authorNickname(post.getUser().getNickname())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/leets_project/domain/post/web/dto/PostDeleteResponse.java
+++ b/src/main/java/com/example/leets_project/domain/post/web/dto/PostDeleteResponse.java
@@ -1,0 +1,17 @@
+package com.example.leets_project.domain.post.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PostDeleteResponse {
+
+    private Long postId;
+
+    public static PostDeleteResponse of(Long postId) {
+        return PostDeleteResponse.builder()
+                .postId(postId)
+                .build();
+    }
+}

--- a/src/main/java/com/example/leets_project/domain/post/web/dto/PostDetailResponse.java
+++ b/src/main/java/com/example/leets_project/domain/post/web/dto/PostDetailResponse.java
@@ -1,0 +1,35 @@
+package com.example.leets_project.domain.post.web.dto;
+
+import com.example.leets_project.domain.post.entity.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PostDetailResponse {
+    private Long postId;
+    private Long userId;
+
+    private String title;
+    private String content;
+    private String description;
+    private String authorNickname;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static PostDetailResponse from(Post post) {
+        return PostDetailResponse.builder()
+                .postId(post.getId())
+                .userId(post.getUser().getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .description(post.getDescription())
+                .authorNickname(post.getUser().getNickname())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/leets_project/domain/post/web/dto/PostListResponse.java
+++ b/src/main/java/com/example/leets_project/domain/post/web/dto/PostListResponse.java
@@ -1,0 +1,34 @@
+package com.example.leets_project.domain.post.web.dto;
+
+import com.example.leets_project.domain.post.entity.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PostListResponse {
+
+    private Long postId;
+    private Long userId;
+
+    private String title;
+    private String description;
+    private String authorNickname;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static PostListResponse from(Post post) {
+        return PostListResponse.builder()
+                .postId(post.getId())
+                .userId(post.getUser().getId())
+                .title(post.getTitle())
+                .description(post.getDescription())
+                .authorNickname(post.getUser().getNickname())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/leets_project/domain/post/web/dto/PostListWrapperResponse.java
+++ b/src/main/java/com/example/leets_project/domain/post/web/dto/PostListWrapperResponse.java
@@ -1,0 +1,20 @@
+package com.example.leets_project.domain.post.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PostListWrapperResponse {
+
+    private List<PostListResponse> posts;
+
+    public static PostListWrapperResponse of(Page<PostListResponse> page) {
+        return PostListWrapperResponse.builder()
+                .posts(page.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/example/leets_project/domain/post/web/dto/PostUpdateRequest.java
+++ b/src/main/java/com/example/leets_project/domain/post/web/dto/PostUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.example.leets_project.domain.post.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostUpdateRequest {
+
+    @NotBlank(message = "제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+
+    private String description;
+}

--- a/src/main/java/com/example/leets_project/domain/post/web/dto/PostUpdateResponse.java
+++ b/src/main/java/com/example/leets_project/domain/post/web/dto/PostUpdateResponse.java
@@ -1,0 +1,32 @@
+package com.example.leets_project.domain.post.web.dto;
+
+import com.example.leets_project.domain.post.entity.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PostUpdateResponse {
+
+    private Long postId;
+
+    private String title;
+    private String content;
+    private String description;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static PostUpdateResponse from(Post post) {
+        return PostUpdateResponse.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .description(post.getDescription())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/leets_project/domain/user/User.java
+++ b/src/main/java/com/example/leets_project/domain/user/User.java
@@ -2,17 +2,13 @@ package com.example.leets_project.domain.user;
 
 import com.example.leets_project.common.entity.BaseEntity;
 import com.example.leets_project.domain.comment.Comment;
-import com.example.leets_project.domain.post.Post;
+import com.example.leets_project.domain.post.entity.Post;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-import org.springframework.data.domain.Auditable;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/example/leets_project/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/leets_project/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.example.leets_project.domain.user.repository;
+
+import com.example.leets_project.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User,Long> {
+
+    // 이메일 중복 확인
+    boolean existsByEmail(String email);
+
+    // 닉네임 중복 확인
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/example/leets_project/domain/user/service/UserService.java
+++ b/src/main/java/com/example/leets_project/domain/user/service/UserService.java
@@ -1,0 +1,41 @@
+package com.example.leets_project.domain.user.service;
+
+import com.example.leets_project.common.exception.GeneralException;
+import com.example.leets_project.common.response.ErrorCode;
+import com.example.leets_project.domain.user.User;
+import com.example.leets_project.domain.user.repository.UserRepository;
+import com.example.leets_project.domain.user.web.dto.UserCreateRequest;
+import com.example.leets_project.domain.user.web.dto.UserCreateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public UserCreateResponse createUser(UserCreateRequest request) {
+        // 1. 이메일 중복 검증
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new GeneralException(ErrorCode.USER_EMAIL_ALREADY_EXISTS);
+        }
+        // 2. 닉네임 중복 검증
+        if (userRepository.existsByNickname(request.getNickname())) {
+            throw new GeneralException(ErrorCode.USER_NICKNAME_ALREADY_EXISTS);
+        }
+
+        User user = User.builder()
+                .name(request.getName())
+                .email(request.getEmail())
+                .nickname(request.getNickname())
+                .build();
+
+        User savedUser = userRepository.save(user);
+
+        return UserCreateResponse.from(savedUser);
+    }
+}

--- a/src/main/java/com/example/leets_project/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/example/leets_project/domain/user/web/controller/UserController.java
@@ -1,0 +1,34 @@
+package com.example.leets_project.domain.user.web.controller;
+
+import com.example.leets_project.common.response.GlobalResponse;
+import com.example.leets_project.common.response.SuccessCode;
+import com.example.leets_project.domain.user.service.UserService;
+import com.example.leets_project.domain.user.web.dto.UserCreateRequest;
+import com.example.leets_project.domain.user.web.dto.UserCreateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name ="USER API", description = "유저 생성 및 관리 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "유저 등록", description = "새로운 유저를 등록합니다.")
+    @PostMapping
+    public ResponseEntity<GlobalResponse> createUser(@RequestBody @Valid UserCreateRequest request) {
+
+        UserCreateResponse response = userService.createUser(request);
+
+        return GlobalResponse.onSuccess(SuccessCode.USER_CREATE, response);
+    }
+}

--- a/src/main/java/com/example/leets_project/domain/user/web/dto/UserCreateRequest.java
+++ b/src/main/java/com/example/leets_project/domain/user/web/dto/UserCreateRequest.java
@@ -1,0 +1,23 @@
+package com.example.leets_project.domain.user.web.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserCreateRequest {
+
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
+    private String name;
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    private String nickname;
+}

--- a/src/main/java/com/example/leets_project/domain/user/web/dto/UserCreateResponse.java
+++ b/src/main/java/com/example/leets_project/domain/user/web/dto/UserCreateResponse.java
@@ -1,0 +1,24 @@
+package com.example.leets_project.domain.user.web.dto;
+
+import com.example.leets_project.domain.user.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserCreateResponse {
+
+    private Long id;
+    private String name;
+    private String email;
+    private String nickname;
+
+    public static UserCreateResponse from(User user) {
+        return UserCreateResponse.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .build();
+    }
+}


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

- [x] 게시글 CRUD(생성,조회,수정,삭제) 구현
- [x] api 명세서에 따른 공통 응답 구현
- [x] 전역 예외 처리 및 에러 코드 구현
- [x] 요청에 대한 처리를 성공한 경우 / 실패한 경우에 대한 결과 메시지


## 2. 핵심 변경 사항

1. 게시글 CRUD 관련 Controller, Service, Dto 작성
2. API 명세서에 따른 공통 응답 구조 및 전역 예외 처리 작성
3. Swagger Test 위한 사용자 등록 로직 작성
4. 페이징 적용


## 3. 실행 및 검증 결과

- 실행 결과: 
* 게시글 등록 성공
<img width="832" height="758" alt="image" src="https://github.com/user-attachments/assets/d863748b-08d9-4e09-a053-75ec5d409a9e" />

* 게시글 등록 실패
<img width="740" height="851" alt="image" src="https://github.com/user-attachments/assets/83d3d2b4-a8d3-4759-8c72-7e892ac3fe77" />

* 게시글 조회(단건)
<img width="823" height="867" alt="image" src="https://github.com/user-attachments/assets/d335e6b7-bf49-4436-bdc7-4da07a644179" />

* 게시글 조회(목록)
<img width="935" height="866" alt="image" src="https://github.com/user-attachments/assets/42c9d4b8-643d-4462-937a-74c2a7821162" />

* 게시글 수정
<img width="704" height="802" alt="image" src="https://github.com/user-attachments/assets/ecc5dd93-cf79-4911-965d-9cb6ad50c596" />

* 게시글 삭제
<img width="681" height="609" alt="image" src="https://github.com/user-attachments/assets/bec85b9f-1d1a-4497-beb9-b15109148ea6" />

* 에러 로그
<img width="1750" height="79" alt="image" src="https://github.com/user-attachments/assets/61ffce94-61b3-459c-b5e4-4a9e0209dab8" />



## 4. 완료 사항

1. 게시글 생성, 수정, 삭제, 조회 구현
2. 에러 코드 적용
3. 공통 응답 적용
4. 사용자 등록 로직 작성(Swagger Test)
5. 페이징 적용

## 5. 추가 사항

- 관련 이슈: `closed #111 `


## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [x] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다