### PR TITLE
[4주차] 변승현 /[feat] 추가 API 구현

### DIFF
--- a/src/main/java/com/example/demo/controller/CommentController.java
+++ b/src/main/java/com/example/demo/controller/CommentController.java
@@ -1,0 +1,47 @@
+package com.example.demo.controller;
+
+import com.example.demo.domain.comment.dto.CommentAdoptRequest;
+import com.example.demo.domain.comment.dto.CommentCreateRequest;
+import com.example.demo.domain.comment.dto.CommentCreateResponse;
+import com.example.demo.domain.comment.dto.CommentStatusResponse;
+import com.example.demo.domain.comment.service.CommentService;
+import com.example.demo.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/api/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<CommentCreateResponse>> createComment(
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentCreateRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(
+                        "COMMENT_CREATE_SUCCESS",
+                        "댓글 생성 성공",
+                        commentService.createComment(postId, request)
+                ));
+    }
+
+    @PostMapping("/api/comments/{commentId}/adoption")
+    public ResponseEntity<ApiResponse<CommentStatusResponse>> adoptComment(
+            @PathVariable Long commentId,
+            @Valid @RequestBody CommentAdoptRequest request
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "COMMENT_ADOPT_SUCCESS",
+                        "댓글 채택 성공",
+                        commentService.adoptComment(commentId, request.userId())
+                )
+        );
+    }
+}

--- a/src/main/java/com/example/demo/controller/ReportController.java
+++ b/src/main/java/com/example/demo/controller/ReportController.java
@@ -1,0 +1,60 @@
+package com.example.demo.controller;
+
+import com.example.demo.domain.report.dto.ReportCreateRequest;
+import com.example.demo.domain.report.dto.ReportCreateResponse;
+import com.example.demo.domain.report.dto.ReportResolveRequest;
+import com.example.demo.domain.report.dto.ReportResolveResponse;
+import com.example.demo.domain.report.service.ReportService;
+import com.example.demo.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @PostMapping("/api/posts/{postId}/reports")
+    public ResponseEntity<ApiResponse<ReportCreateResponse>> reportPost(
+            @PathVariable Long postId,
+            @Valid @RequestBody ReportCreateRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(
+                        "POST_REPORT_SUCCESS",
+                        "게시글 신고 접수 성공",
+                        reportService.reportPost(postId, request)
+                ));
+    }
+
+    @PostMapping("/api/comments/{commentId}/reports")
+    public ResponseEntity<ApiResponse<ReportCreateResponse>> reportComment(
+            @PathVariable Long commentId,
+            @Valid @RequestBody ReportCreateRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(
+                        "COMMENT_REPORT_SUCCESS",
+                        "댓글 신고 접수 성공",
+                        reportService.reportComment(commentId, request)
+                ));
+    }
+
+    @PatchMapping("/api/reports/{reportId}/resolve")
+    public ResponseEntity<ApiResponse<ReportResolveResponse>> resolveReport(
+            @PathVariable Long reportId,
+            @Valid @RequestBody ReportResolveRequest request
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "REPORT_RESOLVE_SUCCESS",
+                        "신고 처리 완료",
+                        reportService.resolveReport(reportId, request)
+                )
+        );
+    }
+}

--- a/src/main/java/com/example/demo/domain/comment/dto/CommentAdoptRequest.java
+++ b/src/main/java/com/example/demo/domain/comment/dto/CommentAdoptRequest.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.comment.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CommentAdoptRequest(
+        @NotNull(message = "userId는 필수입니다.")
+        Long userId
+) {
+}

--- a/src/main/java/com/example/demo/domain/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/com/example/demo/domain/comment/dto/CommentCreateRequest.java
@@ -1,0 +1,13 @@
+package com.example.demo.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CommentCreateRequest(
+        @NotNull(message = "userId는 필수입니다.")
+        Long userId,
+
+        @NotBlank(message = "content는 필수입니다.")
+        String content
+) {
+}

--- a/src/main/java/com/example/demo/domain/comment/dto/CommentCreateResponse.java
+++ b/src/main/java/com/example/demo/domain/comment/dto/CommentCreateResponse.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.comment.dto;
+
+import com.example.demo.domain.comment.entity.CommentStatus;
+
+public record CommentCreateResponse(
+        Long commentId,
+        CommentStatus status
+) {
+}

--- a/src/main/java/com/example/demo/domain/comment/dto/CommentStatusResponse.java
+++ b/src/main/java/com/example/demo/domain/comment/dto/CommentStatusResponse.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.comment.dto;
+
+import com.example.demo.domain.comment.entity.CommentStatus;
+
+public record CommentStatusResponse(
+        Long commentId,
+        CommentStatus status
+) {
+}

--- a/src/main/java/com/example/demo/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/demo/domain/comment/entity/Comment.java
@@ -32,5 +32,26 @@ public class Comment extends BaseEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private CommentStatus status;
 
+    private Comment(User user, Post post, String content) {
+        this.user = user;
+        this.post = post;
+        this.content = content;
+        this.status = CommentStatus.ACTIVE;
+    }
+
+    public static Comment of(User user, Post post, String content) {
+        return new Comment(user, post, content);
+    }
+
+    public void hide() {
+        this.status = CommentStatus.HIDDEN;
+    }
+
+    public void adopt() {
+        this.status = CommentStatus.ADOPTED;
+    }
 }

--- a/src/main/java/com/example/demo/domain/comment/entity/CommentStatus.java
+++ b/src/main/java/com/example/demo/domain/comment/entity/CommentStatus.java
@@ -1,0 +1,7 @@
+package com.example.demo.domain.comment.entity;
+
+public enum CommentStatus {
+    ACTIVE,
+    HIDDEN,
+    ADOPTED
+}

--- a/src/main/java/com/example/demo/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/demo/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.comment.repository;
+
+import com.example.demo.domain.comment.entity.Comment;
+import com.example.demo.domain.comment.entity.CommentStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    boolean existsByPostIdAndStatus(Long postId, CommentStatus status);
+}

--- a/src/main/java/com/example/demo/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/demo/domain/comment/service/CommentService.java
@@ -1,0 +1,78 @@
+package com.example.demo.domain.comment.service;
+
+import com.example.demo.domain.comment.dto.CommentCreateRequest;
+import com.example.demo.domain.comment.dto.CommentCreateResponse;
+import com.example.demo.domain.comment.dto.CommentStatusResponse;
+import com.example.demo.domain.comment.entity.Comment;
+import com.example.demo.domain.comment.entity.CommentStatus;
+import com.example.demo.domain.comment.repository.CommentRepository;
+import com.example.demo.domain.post.entity.Post;
+import com.example.demo.domain.post.entity.PostStatus;
+import com.example.demo.domain.post.repository.PostRepository;
+import com.example.demo.domain.user.entity.User;
+import com.example.demo.domain.user.repository.UserRepository;
+import com.example.demo.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public CommentCreateResponse createComment(Long postId, CommentCreateRequest request) {
+        Post post = findPost(postId);
+        User user = findUser(request.userId());
+
+        if (post.getStatus() == PostStatus.HIDDEN) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "POST_HIDDEN", "숨김 처리된 게시글에는 댓글을 작성할 수 없습니다.");
+        }
+
+        Comment comment = commentRepository.save(Comment.of(user, post, request.content()));
+        return new CommentCreateResponse(comment.getId(), comment.getStatus());
+    }
+
+    @Transactional
+    public CommentStatusResponse adoptComment(Long commentId, Long userId) {
+        Comment comment = findComment(commentId);
+        Post post = comment.getPost();
+
+        if (!post.getUser().getId().equals(userId)) {
+            throw new CustomException(HttpStatus.FORBIDDEN, "FORBIDDEN", "댓글 채택 권한이 없습니다.");
+        }
+        if (post.getStatus() == PostStatus.HIDDEN) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "POST_HIDDEN", "숨김 처리된 게시글에서는 댓글을 채택할 수 없습니다.");
+        }
+        if (comment.getStatus() == CommentStatus.HIDDEN) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "COMMENT_HIDDEN", "숨김 처리된 댓글은 채택할 수 없습니다.");
+        }
+        if (commentRepository.existsByPostIdAndStatus(post.getId(), CommentStatus.ADOPTED)) {
+            throw new CustomException(HttpStatus.CONFLICT, "COMMENT_ALREADY_ADOPTED", "이미 채택된 댓글이 있습니다.");
+        }
+
+        comment.adopt();
+        return new CommentStatusResponse(comment.getId(), comment.getStatus());
+    }
+
+    public Comment findComment(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "COMMENT_NOT_FOUND", "해당 댓글을 찾을 수 없습니다."));
+    }
+
+    private Post findPost(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "POST_NOT_FOUND", "해당 게시글을 찾을 수 없습니다."));
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "해당 사용자를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/example/demo/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/example/demo/domain/post/dto/PostDetailResponse.java
@@ -1,5 +1,7 @@
 package com.example.demo.domain.post.dto;
 
+import com.example.demo.domain.post.entity.PostStatus;
+
 import java.time.LocalDateTime;
 
 public record PostDetailResponse(
@@ -7,6 +9,7 @@ public record PostDetailResponse(
         String title,
         String content,
         String imageUrl,
+        PostStatus status,
         Long authorId,
         String author,
         LocalDateTime createdAt,

--- a/src/main/java/com/example/demo/domain/post/dto/PostListItemResponse.java
+++ b/src/main/java/com/example/demo/domain/post/dto/PostListItemResponse.java
@@ -1,5 +1,7 @@
 package com.example.demo.domain.post.dto;
 
+import com.example.demo.domain.post.entity.PostStatus;
+
 import java.time.LocalDateTime;
 
 public record PostListItemResponse(
@@ -7,6 +9,7 @@ public record PostListItemResponse(
         String title,
         String content,
         String thumbnailImageUrl,
+        PostStatus status,
         String author,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/example/demo/domain/post/entity/Post.java
+++ b/src/main/java/com/example/demo/domain/post/entity/Post.java
@@ -38,6 +38,10 @@ public class Post extends BaseEntity {
     @Column(name = "image_url")
     private String imageUrl;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PostStatus status;
+
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
@@ -46,6 +50,7 @@ public class Post extends BaseEntity {
         this.title = title;
         this.content = content;
         this.imageUrl = imageUrl;
+        this.status = PostStatus.ACTIVE;
     }
 
     public static Post of(User user, String title, String content, String imageUrl) {
@@ -60,5 +65,9 @@ public class Post extends BaseEntity {
             this.content = content;
         }
         this.imageUrl = imageUrl;
+    }
+
+    public void hide() {
+        this.status = PostStatus.HIDDEN;
     }
 }

--- a/src/main/java/com/example/demo/domain/post/entity/PostStatus.java
+++ b/src/main/java/com/example/demo/domain/post/entity/PostStatus.java
@@ -1,0 +1,6 @@
+package com.example.demo.domain.post.entity;
+
+public enum PostStatus {
+    ACTIVE,
+    HIDDEN
+}

--- a/src/main/java/com/example/demo/domain/post/service/PostService.java
+++ b/src/main/java/com/example/demo/domain/post/service/PostService.java
@@ -31,6 +31,7 @@ public class PostService {
                                 post.getTitle(),
                                 post.getContent(),
                                 post.getImageUrl(),
+                                post.getStatus(),
                                 post.getUser().getName(),
                                 post.getCreatedAt()
                         ))
@@ -53,6 +54,7 @@ public class PostService {
                 post.getTitle(),
                 post.getContent(),
                 post.getImageUrl(),
+                post.getStatus(),
                 post.getUser().getId(),
                 post.getUser().getName(),
                 post.getCreatedAt(),

--- a/src/main/java/com/example/demo/domain/report/dto/ReportCreateRequest.java
+++ b/src/main/java/com/example/demo/domain/report/dto/ReportCreateRequest.java
@@ -1,0 +1,13 @@
+package com.example.demo.domain.report.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ReportCreateRequest(
+        @NotNull(message = "reporterId는 필수입니다.")
+        Long reporterId,
+
+        @NotBlank(message = "reason은 필수입니다.")
+        String reason
+) {
+}

--- a/src/main/java/com/example/demo/domain/report/dto/ReportCreateResponse.java
+++ b/src/main/java/com/example/demo/domain/report/dto/ReportCreateResponse.java
@@ -1,0 +1,11 @@
+package com.example.demo.domain.report.dto;
+
+import com.example.demo.domain.report.entity.ReportStatus;
+import com.example.demo.domain.report.entity.ReportTargetType;
+
+public record ReportCreateResponse(
+        Long reportId,
+        ReportTargetType targetType,
+        ReportStatus status
+) {
+}

--- a/src/main/java/com/example/demo/domain/report/dto/ReportResolveRequest.java
+++ b/src/main/java/com/example/demo/domain/report/dto/ReportResolveRequest.java
@@ -1,0 +1,13 @@
+package com.example.demo.domain.report.dto;
+
+import com.example.demo.domain.report.entity.ReportResolutionType;
+import jakarta.validation.constraints.NotNull;
+
+public record ReportResolveRequest(
+        @NotNull(message = "resolverId는 필수입니다.")
+        Long resolverId,
+
+        @NotNull(message = "resolutionType은 필수입니다.")
+        ReportResolutionType resolutionType
+) {
+}

--- a/src/main/java/com/example/demo/domain/report/dto/ReportResolveResponse.java
+++ b/src/main/java/com/example/demo/domain/report/dto/ReportResolveResponse.java
@@ -1,0 +1,11 @@
+package com.example.demo.domain.report.dto;
+
+import com.example.demo.domain.report.entity.ReportResolutionType;
+import com.example.demo.domain.report.entity.ReportStatus;
+
+public record ReportResolveResponse(
+        Long reportId,
+        ReportStatus status,
+        ReportResolutionType resolutionType
+) {
+}

--- a/src/main/java/com/example/demo/domain/report/entity/Report.java
+++ b/src/main/java/com/example/demo/domain/report/entity/Report.java
@@ -1,0 +1,74 @@
+package com.example.demo.domain.report.entity;
+
+import com.example.demo.domain.comment.entity.Comment;
+import com.example.demo.domain.post.entity.Post;
+import com.example.demo.domain.user.entity.User;
+import com.example.demo.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Report extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resolver_id")
+    private User resolver;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ReportTargetType targetType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ReportStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private ReportResolutionType resolutionType;
+
+    @Column(nullable = false, length = 255)
+    private String reason;
+
+    private Report(User reporter, Post post, Comment comment, ReportTargetType targetType, String reason) {
+        this.reporter = reporter;
+        this.post = post;
+        this.comment = comment;
+        this.targetType = targetType;
+        this.reason = reason;
+        this.status = ReportStatus.PENDING;
+    }
+
+    public static Report forPost(User reporter, Post post, String reason) {
+        return new Report(reporter, post, null, ReportTargetType.POST, reason);
+    }
+
+    public static Report forComment(User reporter, Comment comment, String reason) {
+        return new Report(reporter, null, comment, ReportTargetType.COMMENT, reason);
+    }
+
+    public void resolve(User resolver, ReportResolutionType resolutionType) {
+        this.resolver = resolver;
+        this.resolutionType = resolutionType;
+        this.status = ReportStatus.RESOLVED;
+    }
+}

--- a/src/main/java/com/example/demo/domain/report/entity/ReportResolutionType.java
+++ b/src/main/java/com/example/demo/domain/report/entity/ReportResolutionType.java
@@ -1,0 +1,7 @@
+package com.example.demo.domain.report.entity;
+
+public enum ReportResolutionType {
+    HIDE_POST,
+    HIDE_COMMENT,
+    REJECT
+}

--- a/src/main/java/com/example/demo/domain/report/entity/ReportStatus.java
+++ b/src/main/java/com/example/demo/domain/report/entity/ReportStatus.java
@@ -1,0 +1,6 @@
+package com.example.demo.domain.report.entity;
+
+public enum ReportStatus {
+    PENDING,
+    RESOLVED
+}

--- a/src/main/java/com/example/demo/domain/report/entity/ReportTargetType.java
+++ b/src/main/java/com/example/demo/domain/report/entity/ReportTargetType.java
@@ -1,0 +1,6 @@
+package com.example.demo.domain.report.entity;
+
+public enum ReportTargetType {
+    POST,
+    COMMENT
+}

--- a/src/main/java/com/example/demo/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/demo/domain/report/repository/ReportRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.domain.report.repository;
+
+import com.example.demo.domain.report.entity.Report;
+import com.example.demo.domain.report.entity.ReportStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+    boolean existsByReporterIdAndPostIdAndStatus(Long reporterId, Long postId, ReportStatus status);
+
+    boolean existsByReporterIdAndCommentIdAndStatus(Long reporterId, Long commentId, ReportStatus status);
+}

--- a/src/main/java/com/example/demo/domain/report/service/ReportService.java
+++ b/src/main/java/com/example/demo/domain/report/service/ReportService.java
@@ -1,0 +1,122 @@
+package com.example.demo.domain.report.service;
+
+import com.example.demo.domain.comment.entity.Comment;
+import com.example.demo.domain.comment.entity.CommentStatus;
+import com.example.demo.domain.comment.service.CommentService;
+import com.example.demo.domain.post.entity.Post;
+import com.example.demo.domain.post.entity.PostStatus;
+import com.example.demo.domain.post.repository.PostRepository;
+import com.example.demo.domain.report.dto.ReportCreateRequest;
+import com.example.demo.domain.report.dto.ReportCreateResponse;
+import com.example.demo.domain.report.dto.ReportResolveRequest;
+import com.example.demo.domain.report.dto.ReportResolveResponse;
+import com.example.demo.domain.report.entity.Report;
+import com.example.demo.domain.report.entity.ReportResolutionType;
+import com.example.demo.domain.report.entity.ReportStatus;
+import com.example.demo.domain.report.repository.ReportRepository;
+import com.example.demo.domain.user.entity.User;
+import com.example.demo.domain.user.repository.UserRepository;
+import com.example.demo.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final CommentService commentService;
+
+    @Transactional
+    public ReportCreateResponse reportPost(Long postId, ReportCreateRequest request) {
+        Post post = findPost(postId);
+        User reporter = findUser(request.reporterId());
+
+        if (post.getUser().getId().equals(reporter.getId())) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "SELF_REPORT_NOT_ALLOWED", "본인 게시글은 신고할 수 없습니다.");
+        }
+        if (reportRepository.existsByReporterIdAndPostIdAndStatus(reporter.getId(), postId, ReportStatus.PENDING)) {
+            throw new CustomException(HttpStatus.CONFLICT, "DUPLICATE_REPORT", "이미 처리 대기 중인 게시글 신고가 있습니다.");
+        }
+
+        Report report = reportRepository.save(Report.forPost(reporter, post, request.reason()));
+        return new ReportCreateResponse(report.getId(), report.getTargetType(), report.getStatus());
+    }
+
+    @Transactional
+    public ReportCreateResponse reportComment(Long commentId, ReportCreateRequest request) {
+        Comment comment = commentService.findComment(commentId);
+        User reporter = findUser(request.reporterId());
+
+        if (comment.getUser().getId().equals(reporter.getId())) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "SELF_REPORT_NOT_ALLOWED", "본인 댓글은 신고할 수 없습니다.");
+        }
+        if (reportRepository.existsByReporterIdAndCommentIdAndStatus(reporter.getId(), commentId, ReportStatus.PENDING)) {
+            throw new CustomException(HttpStatus.CONFLICT, "DUPLICATE_REPORT", "이미 처리 대기 중인 댓글 신고가 있습니다.");
+        }
+
+        Report report = reportRepository.save(Report.forComment(reporter, comment, request.reason()));
+        return new ReportCreateResponse(report.getId(), report.getTargetType(), report.getStatus());
+    }
+
+    @Transactional
+    public ReportResolveResponse resolveReport(Long reportId, ReportResolveRequest request) {
+        Report report = findReport(reportId);
+        User resolver = findUser(request.resolverId());
+
+        if (report.getStatus() == ReportStatus.RESOLVED) {
+            throw new CustomException(HttpStatus.CONFLICT, "REPORT_ALREADY_RESOLVED", "이미 처리 완료된 신고입니다.");
+        }
+
+        applyResolution(report, request.resolutionType());
+        report.resolve(resolver, request.resolutionType());
+
+        return new ReportResolveResponse(report.getId(), report.getStatus(), report.getResolutionType());
+    }
+
+    private void applyResolution(Report report, ReportResolutionType resolutionType) {
+        switch (resolutionType) {
+            case HIDE_POST -> {
+                if (report.getPost() == null) {
+                    throw new CustomException(HttpStatus.BAD_REQUEST, "INVALID_RESOLUTION", "댓글 신고에는 게시글 숨김 처리를 할 수 없습니다.");
+                }
+                if (report.getPost().getStatus() == PostStatus.HIDDEN) {
+                    throw new CustomException(HttpStatus.CONFLICT, "POST_ALREADY_HIDDEN", "이미 숨김 처리된 게시글입니다.");
+                }
+                report.getPost().hide();
+            }
+            case HIDE_COMMENT -> {
+                if (report.getComment() == null) {
+                    throw new CustomException(HttpStatus.BAD_REQUEST, "INVALID_RESOLUTION", "게시글 신고에는 댓글 숨김 처리를 할 수 없습니다.");
+                }
+                if (report.getComment().getStatus() == CommentStatus.HIDDEN) {
+                    throw new CustomException(HttpStatus.CONFLICT, "COMMENT_ALREADY_HIDDEN", "이미 숨김 처리된 댓글입니다.");
+                }
+                report.getComment().hide();
+            }
+            case REJECT -> {
+                // Intentionally left blank. Reject only changes the report state.
+            }
+        }
+    }
+
+    private Report findReport(Long reportId) {
+        return reportRepository.findById(reportId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "REPORT_NOT_FOUND", "해당 신고를 찾을 수 없습니다."));
+    }
+
+    private Post findPost(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "POST_NOT_FOUND", "해당 게시글을 찾을 수 없습니다."));
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "해당 사용자를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/example/demo/domain/user/entity/User.java
+++ b/src/main/java/com/example/demo/domain/user/entity/User.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "user")
+@Table(name = "users")
 public class User extends BaseEntity {
 
     // 유저 아이디
@@ -31,4 +31,12 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user")
     private List<Comment> comments = new ArrayList<>();
+
+    private User(String name) {
+        this.name = name;
+    }
+
+    public static User of(String name) {
+        return new User(name);
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,5 +4,5 @@ spring.datasource.url=jdbc:mysql://localhost:3306/leets_db
 spring.datasource.username=root
 spring.datasource.password=
 
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

- [x] 게시물 / 댓글 / 신고 도메인 활용
- [x] 단순 CRUD를 넘는 기능 직접 설계 및 API 구현
- [x] 상태(State) 변화를 고려한 설계
- [x] 동일 요청에 대한 중복 처리 방지 로직 구현
- [x] 직접 설계한 API 3개 이상 구현

구현한 기능
- 게시글 신고 API
- 댓글 신고 API
- 신고 처리 완료 API
- 댓글 채택 API
- 댓글 작성 API

## 2. 핵심 변경 사항

- `Post`, `Comment`, `Report` 도메인에 상태값을 추가했습니다.
  - 게시글: `ACTIVE`, `HIDDEN`
  - 댓글: `ACTIVE`, `HIDDEN`, `ADOPTED`
  - 신고: `PENDING`, `RESOLVED`
- 신고 도메인을 새로 추가하고, 게시글/댓글 대상 신고 및 처리 로직을 구현했습니다.
- 동일 사용자가 같은 게시글/댓글을 중복 신고하지 못하도록 중복 방지 로직을 추가했습니다.
- 게시글 작성자가 댓글을 채택할 수 있도록 구현했고, 한 게시글에는 1개의 채택 댓글만 허용하도록 제한했습니다.
- 신고 처리 결과에 따라 게시글/댓글 상태가 실제로 변경되도록 서비스 로직을 구성했습니다.

## 3. 실행 및 검증 결과

- 실행 결과:
  - 애플리케이션 실행 후 게시글/댓글/신고 API가 정상 동작하는 것을 확인했습니다.
- 주요 검증 내용:
  - 게시글 신고 등록 가능
  - 댓글 신고 등록 가능
  - 동일 사용자의 동일 대상 중복 신고 차단 가능
  - 신고 처리 시 `PENDING -> RESOLVED` 상태 변경 확인
  - 댓글 신고 처리 시 댓글 `HIDDEN` 상태 변경 확인
  - 게시글 신고 처리 시 게시글 `HIDDEN` 상태 변경 확인
  - 댓글 채택 시 `ADOPTED` 상태 변경 확인
  - 이미 채택된 댓글이 있는 경우 추가 채택 차단 확인

|댓글 신고 처리 완료|
|--|
|<img width="444" height="403" alt="스크린샷 2026-04-28 15 41 30" src="https://github.com/user-attachments/assets/8834d314-69ba-4555-a2f7-5cff914db73d" />|

|댓글 추가 완료|
|--|
|<img width="384" height="415" alt="스크린샷 2026-04-28 15 41 36" src="https://github.com/user-attachments/assets/6c0dbfdf-9915-4a03-970e-e453ff4c0b03" />|

|이미 채택된 댓글이 있는 경우 추가 채택 차단 확인|
|--|
|<img width="483" height="370" alt="스크린샷 2026-04-28 15 41 43" src="https://github.com/user-attachments/assets/8a534b48-37ae-47f3-8ec2-362cb9fb7526" />|

|본인 게시물 신고 불가 화면|
|--|
|<img width="475" height="381" alt="스크린샷 2026-04-28 15 42 07" src="https://github.com/user-attachments/assets/428fb98b-f0ca-47f1-ade9-045cb71a4a18" />|



## 4. 완료 사항
게시물 / 댓글 / 신고 도메인 상태 기반 구조 설계
게시글 신고, 댓글 신고, 신고 처리, 댓글 채택 API 구현
중복 신고 방지 및 상태 전이 로직 반영


## 5. 추가 사항

- 관련 이슈: `closed #135 `


## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고
