### PR TITLE
[4주차] 김지훈 /[feat] 추가 API 구현

### DIFF
--- a/src/main/java/com/example/leets_7th/common/status/ErrorStatus.java
+++ b/src/main/java/com/example/leets_7th/common/status/ErrorStatus.java
@@ -27,8 +27,23 @@ public enum ErrorStatus implements BaseStatus {
 
 
     // Post
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND,"POST_404","게시글을 찾을 수 없습니다."),
-    POST_ALREADY_DELETED(HttpStatus.BAD_REQUEST,"POST_400","이미 삭제된 게시글입니다.");
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND,"POST_404","게시글이 존재하지 않습니다."),
+    POST_ALREADY_DELETED(HttpStatus.BAD_REQUEST,"POST_400","이미 삭제된 게시글입니다."),
+    FORBIDDEN_COMMENT_UPDATE(HttpStatus.FORBIDDEN,"POST_403","게시글을 수정할 권한이 없습니다."),
+    ALREADY_LIKED_POST(HttpStatus.CONFLICT, "POST_409", "이미 좋아요를 누른 게시글입니다."),
+    POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND,"POST_404","게시글에 좋아요 취소할 좋아요가 없습니다."),
+    ALREADY_REPORTED_POST(HttpStatus.CONFLICT, "POST_409", "이미 신고한 게시글입니다."),
+
+
+    // Comment
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND,"COMM_4041","게시글 또는 댓글이 존재하지 않습니다."),
+    ALREADY_LIKED_COMMENT(HttpStatus.BAD_REQUEST,"COMM_4001","이미 좋아요를 누른 댓글입니다."),
+    FORBIDDEN_COMMENT_DELETE(HttpStatus.FORBIDDEN,"COMM_4031","댓글을 삭제할 권한이 없습니다."),
+    COMMENT_LIKE_COUNT_INVALID(HttpStatus.BAD_REQUEST,"COMM_4002","좋아요 수는 0보다 작을 수 없습니다."),
+    COMMENT_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND,"COMM_4042","좋아요를 누르지 않은 댓글입니다."),
+    ALREADY_REPORTED_COMMENT(HttpStatus.BAD_REQUEST,"COMM_4003","이미 신고한 댓글입니다."),
+    DELETED_COMMENT(HttpStatus.NO_CONTENT,"COMM_2041","삭제된 댓글입니다."),
+    HIDDEN_COMMENT(HttpStatus.NO_CONTENT,"COMM_2042","신고로 인해 숨겨진 댓글입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/leets_7th/common/status/SuccessStatus.java
+++ b/src/main/java/com/example/leets_7th/common/status/SuccessStatus.java
@@ -13,12 +13,24 @@ public enum SuccessStatus implements BaseStatus {
     HEALTH_CHECK_SUCCESS_STATUS(HttpStatus.OK, "TEST_200", "OK"),
     STRING_REPEAT_SUCCESS(HttpStatus.CREATED, "TEST_201", "문자열을 성공적으로 출력했습니다."),
 
+
+    // Post
     GET_ALL_POST_SUCCESS(HttpStatus.OK, "POST_2001", "게시글 목록 조회에 성공했습니다."),
     GET_POST_DETAIL_SUCCESS(HttpStatus.OK, "POST_2002", "게시글 상세 조회에 성공했습니다."),
     CREATE_POST_SUCCESS(HttpStatus.CREATED, "POST_2011", "게시글 생성에 성공했습니다."),
     UPDATE_POST_SUCCESS(HttpStatus.CREATED, "POST_2003", "게시글 수정에 성공했습니다."),
-    DELETE_POST_SUCCESS(HttpStatus.OK, "POST_2004", "게시글 삭제에 성공했습니다.");
+    DELETE_POST_SUCCESS(HttpStatus.OK, "POST_2004", "게시글 삭제에 성공했습니다."),
+    LIKE_POST_SUCCESS(HttpStatus.OK,"POST_2005","게시글 좋아요에 성공했습니다."),
+    UNLIKE_POST_CANCEL_SUCCESS(HttpStatus.OK,"POST_2006","게시글 좋아요 취소에 성공했습니다."),
+    REPORT_POST_SUCCESS(HttpStatus.OK,"POST_2007","게시글 신고에 성공했습니다."),
 
+    // Comment
+    CREATE_COMMENT_SUCCESS(HttpStatus.CREATED,"COMM_2011","댓글 생성에 성공했습니다."),
+    UPDATE_COMMENT_SUCCESS(HttpStatus.CREATED, "COMM_2003", "댓글 수정에 성공했습니다."),
+    DELETE_COMMENT_SUCCESS(HttpStatus.OK, "COMM_2004", "댓글 삭제에 성공했습니다."),
+    REPORT_COMMENT_SUCCESS(HttpStatus.OK,"COMM_REPORT_2001","댓글 신고에 성공했습니다."),
+    LIKE_COMMENT_SUCCESS(HttpStatus.OK,"LIKE_2001","댓글 좋아요에 성공했습니다."),
+    UNLIKE_COMMENT_CANCEL_SUCCESS(HttpStatus.OK,"UNLIKE_2001","댓글 좋아요 취소에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/leets_7th/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/controller/CommentController.java
@@ -1,6 +1,90 @@
 package com.example.leets_7th.domain.comment.controller;
 
+import com.example.leets_7th.common.response.ApiResponse;
+import com.example.leets_7th.common.status.SuccessStatus;
 import com.example.leets_7th.domain.comment.controller.docs.CommentControllerDocs;
+import com.example.leets_7th.domain.comment.dto.request.CreateCommentRequest;
+import com.example.leets_7th.domain.comment.dto.request.ReportCommentRequest;
+import com.example.leets_7th.domain.comment.dto.request.UpdateCommentRequest;
+import com.example.leets_7th.domain.comment.service.CommentCommandService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
+@RequestMapping("/api/posts")
+@RestController
+@Validated
+@RequiredArgsConstructor
 public class CommentController implements CommentControllerDocs {
+
+    private final CommentCommandService commentCommandService;
+
+    @Override
+    @PostMapping("/{postId}/comments")
+    public ResponseEntity<ApiResponse<Void>> createComment(
+            @RequestParam Long userId,
+            @PathVariable Long postId,
+            @RequestBody @Valid CreateCommentRequest request
+    ) {
+        commentCommandService.createComment(userId, postId, request);
+        return ApiResponse.success(SuccessStatus.CREATE_COMMENT_SUCCESS);
+    }
+
+    @Override
+    @DeleteMapping("/{postId}/comments/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(
+            @RequestParam Long userId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId
+    ) {
+        commentCommandService.deleteComment(userId, postId, commentId);
+        return ApiResponse.success(SuccessStatus.DELETE_COMMENT_SUCCESS);
+    }
+
+    @Override
+    @PatchMapping("/{postId}/comments/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> updateComment(
+            @RequestParam Long userId,
+            @PathVariable Long postId, Long commentId,
+            @RequestBody @Valid UpdateCommentRequest request
+    ) {
+        commentCommandService.updateComment(userId, postId, commentId, request);
+        return ApiResponse.success(SuccessStatus.UPDATE_COMMENT_SUCCESS);
+    }
+
+    @Override
+    @PostMapping("/{postId}/comments/{commentId}/likes")
+    public ResponseEntity<ApiResponse<Void>> likeComment(
+            @RequestParam Long userId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId
+    ) {
+        commentCommandService.likeComment(userId, postId, commentId);
+        return ApiResponse.success(SuccessStatus.LIKE_COMMENT_SUCCESS);
+    }
+
+    @Override
+    @DeleteMapping("/{postId}/comments/{commentId}/likes")
+    public ResponseEntity<ApiResponse<Void>> unlikeComment(
+            @RequestParam Long userId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId
+    ) {
+        commentCommandService.unlikeComment(userId, postId, commentId);
+        return ApiResponse.success(SuccessStatus.UNLIKE_COMMENT_CANCEL_SUCCESS);
+    }
+
+    @Override
+    @PostMapping("/{postId}/comments/{commentId}/reports")
+    public ResponseEntity<ApiResponse<Void>> reportComment(
+            @RequestParam Long userId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @RequestBody @Valid ReportCommentRequest request
+    ) {
+        commentCommandService.reportComment(userId, postId, commentId, request);
+        return ApiResponse.success(SuccessStatus.REPORT_COMMENT_SUCCESS);
+    }
 }

--- a/src/main/java/com/example/leets_7th/domain/comment/controller/docs/CommentControllerDocs.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/controller/docs/CommentControllerDocs.java
@@ -1,7 +1,151 @@
 package com.example.leets_7th.domain.comment.controller.docs;
 
+import com.example.leets_7th.common.response.ApiResponse;
+import com.example.leets_7th.domain.comment.dto.request.CreateCommentRequest;
+import com.example.leets_7th.domain.comment.dto.request.ReportCommentRequest;
+import com.example.leets_7th.domain.comment.dto.request.UpdateCommentRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Comment", description = "댓글 API")
+@Tag(name = "Comment", description = "댓글 관련 API")
 public interface CommentControllerDocs {
+
+    @PostMapping("/{postId}/comments")
+    @Operation(summary = "댓글 작성", description = "특정 게시글에 댓글을 작성합니다.")
+    @Parameters({
+            @Parameter(name = "userId", description = "댓글 작성 사용자 ID", required = true, example = "1"),
+            @Parameter(name = "postId", description = "게시글 ID", required = true, example = "10")
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 작성 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    ResponseEntity<ApiResponse<Void>> createComment(
+            @RequestParam Long userId,
+            @PathVariable Long postId,
+            @RequestBody @Valid CreateCommentRequest request
+    );
+
+    @Operation(
+            summary = "댓글 삭제",
+            description = "특정 게시글의 댓글을 삭제합니다. 댓글 작성자만 삭제할 수 있습니다."
+    )
+    @Parameters({
+            @Parameter(name = "userId", description = "댓글 삭제 요청 사용자 ID", required = true, example = "1"),
+            @Parameter(name = "postId", description = "게시글 ID", required = true, example = "10"),
+            @Parameter(name = "commentId", description = "삭제할 댓글 ID", required = true, example = "100")
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 삭제 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "댓글 삭제 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글, 댓글 또는 사용자를 찾을 수 없음")
+    })
+    @DeleteMapping("/{postId}/comments/{commentId}")
+    ResponseEntity<ApiResponse<Void>> deleteComment(
+            @RequestParam Long userId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId
+    );
+
+    @PatchMapping("/{postId}/comments/{commentId}")
+    @Operation(summary = "댓글 수정", description = "특정 댓글을 수정합니다.")
+    @Parameters({
+            @Parameter(name = "userId", description = "댓글 수정 사용자 ID", required = true, example = "1"),
+            @Parameter(name = "postId", description = "게시글 ID", required = true, example = "10"),
+            @Parameter(name = "commentId", description = "댓글 ID", required = true, example = "100")
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 수정 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    ResponseEntity<ApiResponse<Void>> updateComment(
+            @RequestParam Long userId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @RequestBody @Valid UpdateCommentRequest request
+    );
+
+    @PostMapping("/{postId}/comments/{commentId}/likes")
+    @Operation(summary = "댓글 좋아요", description = "특정 댓글에 좋아요를 추가합니다.")
+    @Parameters({
+            @Parameter(name = "userId", description = "좋아요 사용자 ID", required = true, example = "1"),
+            @Parameter(name = "postId", description = "게시글 ID", required = true, example = "10"),
+            @Parameter(name = "commentId", description = "댓글 ID", required = true, example = "100")
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 좋아요 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    ResponseEntity<ApiResponse<Void>> likeComment(
+            @RequestParam Long userId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId
+    );
+
+    @DeleteMapping("/{postId}/comments/{commentId}/likes")
+    @Operation(summary = "댓글 좋아요 취소", description = "특정 댓글의 좋아요를 취소합니다.")
+    @Parameters({
+            @Parameter(name = "userId", description = "좋아요 취소 사용자 ID", required = true, example = "1"),
+            @Parameter(name = "postId", description = "게시글 ID", required = true, example = "10"),
+            @Parameter(name = "commentId", description = "댓글 ID", required = true, example = "100")
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 좋아요 취소 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            )
+    })
+    ResponseEntity<ApiResponse<Void>> unlikeComment(
+            @RequestParam Long userId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId
+    );
+
+    @Operation(
+            summary = "댓글 신고",
+            description = "특정 게시글의 댓글을 신고합니다. 한 사용자는 같은 댓글을 한 번만 신고할 수 있습니다."
+    )
+    @Parameters({
+            @Parameter(name = "userId", description = "신고하는 사용자 ID", required = true, example = "1"),
+            @Parameter(name = "postId", description = "게시글 ID", required = true, example = "10"),
+            @Parameter(name = "commentId", description = "신고할 댓글 ID", required = true, example = "100")
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 신고 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 신고한 댓글이거나 잘못된 요청값"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글, 댓글 또는 사용자를 찾을 수 없음")
+    })
+    @PostMapping("/{postId}/comments/{commentId}/reports")
+    ResponseEntity<ApiResponse<Void>> reportComment(
+            @RequestParam Long userId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @RequestBody @Valid ReportCommentRequest request
+    );
 }

--- a/src/main/java/com/example/leets_7th/domain/comment/dto/request/CreateCommentRequest.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/dto/request/CreateCommentRequest.java
@@ -1,0 +1,14 @@
+package com.example.leets_7th.domain.comment.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateCommentRequest(
+
+        @Schema(example = "내용")
+        @NotBlank(message = "내용은 공백일 수 없습니다")
+        String comment
+        //todo 댓글에도 이미지 추가
+        //todo 대댓글
+) {
+}

--- a/src/main/java/com/example/leets_7th/domain/comment/dto/request/ReportCommentRequest.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/dto/request/ReportCommentRequest.java
@@ -1,0 +1,15 @@
+package com.example.leets_7th.domain.comment.dto.request;
+
+import com.example.leets_7th.domain.comment.enums.ReportReason;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ReportCommentRequest(
+
+        @NotNull(message = "신고 사유는 필수입니다.")
+        ReportReason reason,
+
+        @Size(max = 500, message = "신고 내용은 500자 이하로 입력해주세요.")
+        String content
+) {
+}

--- a/src/main/java/com/example/leets_7th/domain/comment/dto/request/UpdateCommentRequest.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/dto/request/UpdateCommentRequest.java
@@ -1,0 +1,14 @@
+package com.example.leets_7th.domain.comment.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateCommentRequest(
+
+        @Schema(example = "내용")
+        @NotBlank(message = "내용은 공백일 수 없습니다")
+        String comment
+        //todo 댓글에도 이미지 추가
+        //todo 대댓글
+) {
+}

--- a/src/main/java/com/example/leets_7th/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/dto/response/CommentResponse.java
@@ -1,0 +1,23 @@
+package com.example.leets_7th.domain.comment.dto.response;
+
+import com.example.leets_7th.domain.comment.entity.Comment;
+
+import java.time.LocalDateTime;
+
+public record CommentResponse(
+        Long commentId,
+        String content,
+        String author,
+        Integer likeCount,
+        LocalDateTime createdAt
+) {
+    public static CommentResponse from(Comment comment) {
+        return new CommentResponse(
+                comment.getId(),
+                comment.getContent(),
+                comment.getUser().getName(),
+                comment.getLikeCount(),
+                comment.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/leets_7th/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/entity/Comment.java
@@ -1,6 +1,9 @@
 package com.example.leets_7th.domain.comment.entity;
 
 import com.example.leets_7th.common.base.BaseEntity;
+import com.example.leets_7th.common.exception.GeneralException;
+import com.example.leets_7th.common.status.ErrorStatus;
+import com.example.leets_7th.domain.comment.enums.CommentStatus;
 import com.example.leets_7th.domain.post.entity.Post;
 import com.example.leets_7th.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -19,6 +22,12 @@ public class Comment extends BaseEntity {
     @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     private String content;
 
+    @Column(nullable = false)
+    private Integer likeCount = 0;
+
+    @Column(nullable = false)
+    private Integer reportCount = 0;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -27,9 +36,37 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CommentStatus status = CommentStatus.ACTIVE;
+
+    @Builder
     public Comment(String content, User user, Post post) {
         this.content = content;
         this.user = user;
         this.post = post;
+    }
+
+    public void delete() {
+        this.status = CommentStatus.DELETED;
+    }
+
+    public void update(String content) {
+        this.content = content;
+    }
+
+    public void hideByReports() {
+        this.status = CommentStatus.HIDDEN;
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount <= 0) {
+            throw new GeneralException(ErrorStatus.COMMENT_LIKE_COUNT_INVALID);
+        }
+        this.likeCount--;
     }
 }

--- a/src/main/java/com/example/leets_7th/domain/comment/entity/CommentLike.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/entity/CommentLike.java
@@ -1,0 +1,44 @@
+package com.example.leets_7th.domain.comment.entity;
+
+import com.example.leets_7th.common.base.BaseEntity;
+import com.example.leets_7th.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "comment_like",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"comment_id", "user_id"})
+        }
+)
+public class CommentLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    private CommentLike(Comment comment, User user) {
+        this.comment = comment;
+        this.user = user;
+    }
+
+    public static CommentLike of(Comment comment, User user) {
+        return new CommentLike(comment, user);
+    }
+}
+

--- a/src/main/java/com/example/leets_7th/domain/comment/entity/CommentReport.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/entity/CommentReport.java
@@ -1,0 +1,58 @@
+package com.example.leets_7th.domain.comment.entity;
+
+import com.example.leets_7th.common.base.BaseEntity;
+import com.example.leets_7th.domain.comment.enums.ReportReason;
+import com.example.leets_7th.domain.comment.enums.ReportStatus;
+import com.example.leets_7th.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "comment_report",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"comment_id", "user_id"})
+        }
+)
+public class CommentReport extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportReason reason;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportStatus status = ReportStatus.PENDING;
+
+    private CommentReport(Comment comment, User user, ReportReason reason, String content) {
+        this.comment = comment;
+        this.user = user;
+        this.reason = reason;
+        this.content = content;
+        this.status = ReportStatus.PENDING;
+    }
+
+    public static CommentReport of(Comment comment, User user, ReportReason reason, String content) {
+        return new CommentReport(comment, user, reason, content);
+    }
+}
+

--- a/src/main/java/com/example/leets_7th/domain/comment/enums/CommentStatus.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/enums/CommentStatus.java
@@ -1,0 +1,7 @@
+package com.example.leets_7th.domain.comment.enums;
+
+public enum CommentStatus {
+    ACTIVE,
+    HIDDEN,
+    DELETED
+}

--- a/src/main/java/com/example/leets_7th/domain/comment/enums/ReportReason.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/enums/ReportReason.java
@@ -1,0 +1,10 @@
+package com.example.leets_7th.domain.comment.enums;
+
+public enum ReportReason {
+    SPAM,
+    ABUSE,
+    OBSCENE,
+    PERSONAL_INFO,
+    ILLEGAL_CONTENT,
+    ETC
+}

--- a/src/main/java/com/example/leets_7th/domain/comment/enums/ReportStatus.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/enums/ReportStatus.java
@@ -1,0 +1,7 @@
+package com.example.leets_7th.domain.comment.enums;
+
+public enum ReportStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED
+}

--- a/src/main/java/com/example/leets_7th/domain/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/repository/CommentLikeRepository.java
@@ -1,0 +1,13 @@
+package com.example.leets_7th.domain.comment.repository;
+
+import com.example.leets_7th.domain.comment.entity.CommentLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+
+    boolean existsByCommentIdAndUserId(Long commentId, Long userId);
+
+    Optional<CommentLike> findByCommentIdAndUserId(Long commentId, Long userId);
+}

--- a/src/main/java/com/example/leets_7th/domain/comment/repository/CommentReportRepository.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/repository/CommentReportRepository.java
@@ -1,0 +1,11 @@
+package com.example.leets_7th.domain.comment.repository;
+
+import com.example.leets_7th.domain.comment.entity.CommentReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentReportRepository extends JpaRepository<CommentReport , Long> {
+
+    boolean existsByCommentIdAndUserId(Long commentId, Long userId);
+
+    long countByCommentId(Long commentId);
+}

--- a/src/main/java/com/example/leets_7th/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package com.example.leets_7th.domain.comment.repository;
+
+import com.example.leets_7th.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    Optional<Comment> findByPostIdAndId(Long postId, Long commentId);
+}

--- a/src/main/java/com/example/leets_7th/domain/comment/service/CommentCommandService.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/service/CommentCommandService.java
@@ -1,0 +1,119 @@
+package com.example.leets_7th.domain.comment.service;
+
+import com.example.leets_7th.common.exception.GeneralException;
+import com.example.leets_7th.common.status.ErrorStatus;
+import com.example.leets_7th.domain.comment.dto.request.CreateCommentRequest;
+import com.example.leets_7th.domain.comment.dto.request.ReportCommentRequest;
+import com.example.leets_7th.domain.comment.dto.request.UpdateCommentRequest;
+import com.example.leets_7th.domain.comment.entity.Comment;
+import com.example.leets_7th.domain.comment.entity.CommentLike;
+import com.example.leets_7th.domain.comment.entity.CommentReport;
+import com.example.leets_7th.domain.comment.repository.CommentLikeRepository;
+import com.example.leets_7th.domain.comment.repository.CommentReportRepository;
+import com.example.leets_7th.domain.comment.repository.CommentRepository;
+import com.example.leets_7th.domain.comment.validator.CommentValidator;
+import com.example.leets_7th.domain.post.entity.Post;
+import com.example.leets_7th.domain.post.validator.PostValidator;
+import com.example.leets_7th.domain.user.entity.User;
+import com.example.leets_7th.domain.user.validator.UserValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentCommandService {
+
+    private final PostValidator postValidator;
+    private final UserValidator userValidator;
+    private final CommentValidator commentValidator;
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final CommentReportRepository commentReportRepository;
+
+    public void createComment(Long userId, Long postId, CreateCommentRequest request) {
+
+        User user = userValidator.validateUser(userId);
+        Post post = postValidator.validatePost(postId);
+
+        Comment comment = Comment.builder()
+                .user(user)
+                .post(post)
+                .content(request.comment())
+                .build();
+
+        commentRepository.save(comment);
+    }
+
+    public void deleteComment(Long userId, Long postId, Long commentId) {
+        User user = userValidator.validateUser(userId);
+        Comment comment = commentValidator.validateComment(postId, commentId);
+
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new GeneralException(ErrorStatus.FORBIDDEN_COMMENT_DELETE);
+        }
+
+        comment.delete();
+    }
+
+    public void updateComment(Long userId, Long postId, Long commentId, UpdateCommentRequest request) {
+
+        User user = userValidator.validateUser(userId);
+        postValidator.validatePost(postId);
+
+        Comment comment = commentValidator.validateComment(postId,commentId);
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new GeneralException(ErrorStatus.FORBIDDEN_COMMENT_UPDATE);
+        }
+        comment.update(request.comment());
+    }
+
+    public void likeComment(Long userId, Long postId, Long commentId) {
+        User user = userValidator.validateUser(userId);
+        Comment comment = commentValidator.validateComment(postId, commentId);
+
+        if (commentLikeRepository.existsByCommentIdAndUserId(commentId, userId)) {
+            throw new GeneralException(ErrorStatus.ALREADY_LIKED_COMMENT);
+        }
+
+        commentLikeRepository.save(CommentLike.of(comment, user));
+        comment.increaseLikeCount();
+    }
+
+    public void reportComment(Long userId, Long postId, Long commentId, ReportCommentRequest request) {
+        User user = userValidator.validateUser(userId);
+        Comment comment = commentValidator.validateComment(postId, commentId);
+
+        if (commentReportRepository.existsByCommentIdAndUserId(commentId, userId)) {
+            throw new GeneralException(ErrorStatus.ALREADY_REPORTED_COMMENT);
+        }
+
+        CommentReport commentReport = CommentReport.of(
+                comment,
+                user,
+                request.reason(),
+                request.content()
+        );
+
+        commentReportRepository.save(commentReport);
+
+        long reportCount = commentReportRepository.countByCommentId(commentId);
+
+        if (reportCount >= 10) {
+            comment.hideByReports();
+        }
+    }
+
+    public void unlikeComment(Long userId, Long postId, Long commentId) {
+        userValidator.validateUser(userId);
+        Comment comment = commentValidator.validateComment(postId, commentId);
+
+        CommentLike commentLike = commentLikeRepository.findByCommentIdAndUserId(commentId, userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_LIKE_NOT_FOUND));
+
+        commentLikeRepository.delete(commentLike);
+        comment.decreaseLikeCount();
+    }
+
+}

--- a/src/main/java/com/example/leets_7th/domain/comment/validator/CommentValidator.java
+++ b/src/main/java/com/example/leets_7th/domain/comment/validator/CommentValidator.java
@@ -1,0 +1,45 @@
+package com.example.leets_7th.domain.comment.validator;
+
+import com.example.leets_7th.common.exception.GeneralException;
+import com.example.leets_7th.common.status.ErrorStatus;
+import com.example.leets_7th.domain.comment.entity.Comment;
+import com.example.leets_7th.domain.comment.enums.CommentStatus;
+import com.example.leets_7th.domain.comment.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentValidator {
+
+    private final CommentRepository commentRepository;
+
+    public Comment validateComment(Long postId, Long commentId) {
+
+        Comment comment = commentRepository.findByPostIdAndId(postId, commentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+
+        if (comment.getStatus() == CommentStatus.DELETED) {
+            throw new GeneralException(ErrorStatus.DELETED_COMMENT);
+        }
+
+        if (comment.getStatus() == CommentStatus.HIDDEN) {
+            throw new GeneralException(ErrorStatus.HIDDEN_COMMENT);
+        }
+
+        return comment;
+    }
+
+    // 관리자 전용
+    public Comment validateCommentIncludingHidden(Long postId, Long commentId) {
+
+        Comment comment = commentRepository.findByPostIdAndId(postId, commentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+
+        if (comment.getStatus() == CommentStatus.DELETED) {
+            throw new GeneralException(ErrorStatus.DELETED_COMMENT);
+        }
+
+        return comment;
+    }
+}

--- a/src/main/java/com/example/leets_7th/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/leets_7th/domain/post/controller/PostController.java
@@ -5,6 +5,7 @@ import com.example.leets_7th.common.status.SuccessStatus;
 import com.example.leets_7th.domain.post.controller.docs.PostControllerDocs;
 import com.example.leets_7th.domain.post.dto.request.CreatePostRequest;
 import com.example.leets_7th.domain.post.dto.request.GetPostRequest;
+import com.example.leets_7th.domain.post.dto.request.ReportPostRequest;
 import com.example.leets_7th.domain.post.dto.request.UpdatePostRequest;
 import com.example.leets_7th.domain.post.dto.response.CreatePostResponse;
 import com.example.leets_7th.domain.post.dto.response.GetPostDetailResponse;
@@ -65,6 +66,37 @@ public class PostController implements PostControllerDocs {
     ) {
         UpdatePostResponse response = postCommandService.updatePost(userId, postId, request);
         return ApiResponse.success(SuccessStatus.UPDATE_POST_SUCCESS, response);
+    }
+
+    @Override
+    @PostMapping("/{postId}/likes")
+    public ResponseEntity<ApiResponse<Void>> likePost(
+            @RequestParam Long userId,
+            @PathVariable Long postId
+    ) {
+        postCommandService.likePost(userId, postId);
+        return ApiResponse.success(SuccessStatus.LIKE_POST_SUCCESS);
+    }
+
+    @Override
+    @DeleteMapping("/{postId}/likes")
+    public ResponseEntity<ApiResponse<Void>> unlikePost(
+            @RequestParam Long userId,
+            @PathVariable Long postId
+    ) {
+        postCommandService.unlikePost(userId, postId);
+        return ApiResponse.success(SuccessStatus.UNLIKE_POST_CANCEL_SUCCESS);
+    }
+
+    @Override
+    @PostMapping("/{postId}/reports")
+    public ResponseEntity<ApiResponse<Void>> reportPost(
+            @RequestParam Long userId,
+            @PathVariable Long postId,
+            @RequestBody @Valid ReportPostRequest request
+    ) {
+        postCommandService.reportPost(userId, postId, request);
+        return ApiResponse.success(SuccessStatus.REPORT_POST_SUCCESS);
     }
 
     @Override

--- a/src/main/java/com/example/leets_7th/domain/post/controller/docs/PostControllerDocs.java
+++ b/src/main/java/com/example/leets_7th/domain/post/controller/docs/PostControllerDocs.java
@@ -3,6 +3,7 @@ package com.example.leets_7th.domain.post.controller.docs;
 import com.example.leets_7th.common.response.ApiResponse;
 import com.example.leets_7th.domain.post.dto.request.CreatePostRequest;
 import com.example.leets_7th.domain.post.dto.request.GetPostRequest;
+import com.example.leets_7th.domain.post.dto.request.ReportPostRequest;
 import com.example.leets_7th.domain.post.dto.request.UpdatePostRequest;
 import com.example.leets_7th.domain.post.dto.response.CreatePostResponse;
 import com.example.leets_7th.domain.post.dto.response.GetPostDetailResponse;
@@ -43,6 +44,28 @@ public interface PostControllerDocs {
             @RequestParam Long userId,
             @PathVariable Long postId,
             @Valid @RequestBody UpdatePostRequest request
+    );
+
+    @Operation(summary = "게시글 좋아요", description = "특정 게시글에 좋아요를 누릅니다.")
+    @PostMapping("/{postId}/likes")
+    ResponseEntity<ApiResponse<Void>> likePost(
+            @RequestParam Long userId,
+            @PathVariable Long postId
+    );
+
+    @Operation(summary = "게시글 좋아요 취소", description = "특정 게시글의 좋아요를 취소합니다.")
+    @DeleteMapping("/{postId}/likes")
+    ResponseEntity<ApiResponse<Void>> unlikePost(
+            @RequestParam Long userId,
+            @PathVariable Long postId
+    );
+
+    @Operation(summary = "게시글 신고", description = "특정 게시글을 신고합니다.")
+    @PostMapping("/{postId}/reports")
+    ResponseEntity<ApiResponse<Void>> reportPost(
+            @RequestParam Long userId,
+            @PathVariable Long postId,
+            @RequestBody @Valid ReportPostRequest request
     );
 
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")

--- a/src/main/java/com/example/leets_7th/domain/post/dto/request/CreatePostRequest.java
+++ b/src/main/java/com/example/leets_7th/domain/post/dto/request/CreatePostRequest.java
@@ -1,5 +1,6 @@
 package com.example.leets_7th.domain.post.dto.request;
 
+import com.example.leets_7th.domain.post.enums.PostVisibility;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
@@ -13,7 +14,14 @@ public record CreatePostRequest(
         @NotBlank(message = "내용은 공백일 수 없습니다")
         String content,
 
-        Integer thumbnailIndex
+        Integer thumbnailIndex,
+
+        @Schema(
+                description = "공개 범위 설정",
+                allowableValues = {"PUBLIC", "FRIENDS", "PRIVATE"},
+                example = "PUBLIC"
+        )
+        PostVisibility postVisibility
 
 ) {
 }

--- a/src/main/java/com/example/leets_7th/domain/post/dto/request/ReportPostRequest.java
+++ b/src/main/java/com/example/leets_7th/domain/post/dto/request/ReportPostRequest.java
@@ -1,0 +1,15 @@
+package com.example.leets_7th.domain.post.dto.request;
+
+import com.example.leets_7th.domain.comment.enums.ReportReason;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ReportPostRequest(
+
+        @NotNull(message = "신고 사유는 필수입니다.")
+        ReportReason reason,
+
+        @Size(max = 500, message = "신고 내용은 500자 이하로 입력해주세요.")
+        String content
+) {
+}

--- a/src/main/java/com/example/leets_7th/domain/post/dto/request/UpdatePostRequest.java
+++ b/src/main/java/com/example/leets_7th/domain/post/dto/request/UpdatePostRequest.java
@@ -1,5 +1,6 @@
 package com.example.leets_7th.domain.post.dto.request;
 
+import com.example.leets_7th.domain.post.enums.PostVisibility;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
@@ -13,7 +14,14 @@ public record UpdatePostRequest(
         @NotBlank(message = "내용은 공백일 수 없습니다")
         String content,
 
-        Integer thumbnailIndex
+        Integer thumbnailIndex,
+
+        @Schema(
+                description = "공개 범위 설정",
+                allowableValues = {"PUBLIC", "FRIENDS", "PRIVATE"},
+                example = "PUBLIC"
+        )
+        PostVisibility postVisibility
 
 ) {
 }

--- a/src/main/java/com/example/leets_7th/domain/post/dto/response/CreatePostResponse.java
+++ b/src/main/java/com/example/leets_7th/domain/post/dto/response/CreatePostResponse.java
@@ -1,6 +1,9 @@
 package com.example.leets_7th.domain.post.dto.response;
 
+import com.example.leets_7th.domain.post.enums.PostVisibility;
+
 public record CreatePostResponse(
         Long postId,
-        String thumbnailUrl
+        String thumbnailUrl,
+        PostVisibility postVisibility
 ) {}

--- a/src/main/java/com/example/leets_7th/domain/post/dto/response/GetPostDetailResponse.java
+++ b/src/main/java/com/example/leets_7th/domain/post/dto/response/GetPostDetailResponse.java
@@ -1,7 +1,11 @@
 package com.example.leets_7th.domain.post.dto.response;
 
+import com.example.leets_7th.domain.comment.dto.response.CommentResponse;
+import com.example.leets_7th.domain.comment.enums.CommentStatus;
 import com.example.leets_7th.domain.post.entity.Image;
 import com.example.leets_7th.domain.post.entity.Post;
+import com.example.leets_7th.domain.post.enums.PostVisibility;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -11,7 +15,10 @@ public record GetPostDetailResponse(
         String content,
         String thumbnailImageUrl,
         String author,
+        Long likeCount,
+        PostVisibility postVisibility,
         List<String> imageUrls,
+        List<CommentResponse> comments,
         LocalDateTime createdAt
 ) {
     public static GetPostDetailResponse from(Post post) {
@@ -21,10 +28,17 @@ public record GetPostDetailResponse(
                 post.getContent(),
                 post.getThumbnailImageUrl(),
                 post.getUser().getName(),
+                post.getLikeCount(),
+                post.getPostVisibility(),
                 post.getImages().stream()
                         .map(Image::getImageUrl)
                         .toList(),
+                post.getComments().stream()
+                        .filter(comment -> comment.getStatus() == CommentStatus.ACTIVE)
+                        .map(CommentResponse::from)
+                        .toList(),
                 post.getCreatedAt()
+
         );
     }
 }

--- a/src/main/java/com/example/leets_7th/domain/post/dto/response/PostSummary.java
+++ b/src/main/java/com/example/leets_7th/domain/post/dto/response/PostSummary.java
@@ -1,6 +1,7 @@
 package com.example.leets_7th.domain.post.dto.response;
 
 import com.example.leets_7th.domain.post.entity.Post;
+import com.example.leets_7th.domain.post.enums.PostVisibility;
 
 import java.time.LocalDateTime;
 
@@ -9,6 +10,8 @@ public record PostSummary(
         String title,
         String thumbnailImageUrl,
         String author,
+        Long likeCount,
+        PostVisibility postVisibility,
         LocalDateTime createdAt
 ) {
     public static PostSummary from(Post post) {
@@ -17,6 +20,8 @@ public record PostSummary(
                 post.getTitle(),
                 post.getThumbnailImageUrl(),
                 post.getUser().getName(),
+                post.getLikeCount(),
+                post.getPostVisibility(),
                 post.getCreatedAt()
         );
     }

--- a/src/main/java/com/example/leets_7th/domain/post/dto/response/UpdatePostResponse.java
+++ b/src/main/java/com/example/leets_7th/domain/post/dto/response/UpdatePostResponse.java
@@ -1,8 +1,12 @@
 package com.example.leets_7th.domain.post.dto.response;
 
+import com.example.leets_7th.domain.post.enums.PostVisibility;
+
 import java.time.LocalDateTime;
 
 public record UpdatePostResponse(
         Long postId,
+        PostVisibility postVisibility,
         LocalDateTime updatedAt
+
 ) {}

--- a/src/main/java/com/example/leets_7th/domain/post/entity/Post.java
+++ b/src/main/java/com/example/leets_7th/domain/post/entity/Post.java
@@ -2,9 +2,14 @@ package com.example.leets_7th.domain.post.entity;
 
 import com.example.leets_7th.common.base.BaseEntity;
 import com.example.leets_7th.domain.comment.entity.Comment;
+import com.example.leets_7th.domain.post.enums.PostStatus;
+import com.example.leets_7th.domain.post.enums.PostVisibility;
 import com.example.leets_7th.domain.user.entity.User;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -26,6 +31,13 @@ public class Post extends BaseEntity {
     @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     private String content;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "post_visibility", nullable = false)
+    private PostVisibility postVisibility;
+
+    @Column(name = "like_count", nullable = false)
+    private Long likeCount;
+
     @Column(name = "thumbnail")
     private String thumbnailImageUrl;
 
@@ -39,15 +51,48 @@ public class Post extends BaseEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private PostStatus status;
+
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
     @Builder
-    public Post(User user, String title, String content, String thumbnailImageUrl) {
+    private Post(
+            User user,
+            String title,
+            String content,
+            String thumbnailImageUrl,
+            PostVisibility postVisibility,
+            Long likeCount,
+            PostStatus status
+    ) {
         this.user = user;
         this.title = title;
         this.content = content;
         this.thumbnailImageUrl = thumbnailImageUrl;
+        this.postVisibility = postVisibility;
+        this.likeCount = likeCount;
+        this.status = status;
+    }
+
+    public static Post create(
+            User user,
+            String title,
+            String content,
+            String thumbnailImageUrl,
+            PostVisibility postVisibility
+    ) {
+        return Post.builder()
+                .user(user)
+                .title(title)
+                .content(content)
+                .thumbnailImageUrl(thumbnailImageUrl)
+                .postVisibility(postVisibility != null ? postVisibility : PostVisibility.PUBLIC)
+                .likeCount(0L)
+                .status(PostStatus.ACTIVE)
+                .build();
     }
 
     public void update(String title, String content) {
@@ -55,7 +100,23 @@ public class Post extends BaseEntity {
         this.content = content;
     }
 
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
+    public void hide() {
+        this.status = PostStatus.HIDDEN;
+    }
+
     public void delete() {
+        this.status = PostStatus.DELETED;
         this.deletedAt = LocalDateTime.now();
     }
+
 }

--- a/src/main/java/com/example/leets_7th/domain/post/entity/PostLike.java
+++ b/src/main/java/com/example/leets_7th/domain/post/entity/PostLike.java
@@ -1,0 +1,42 @@
+package com.example.leets_7th.domain.post.entity;
+
+import com.example.leets_7th.common.base.BaseEntity;
+import com.example.leets_7th.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(
+        name = "post_like",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_post_like_user_post",
+                        columnNames = {"user_id", "post_id"}
+                )
+        }
+)
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class PostLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    public static PostLike of(User user, Post post) {
+        return PostLike.builder()
+                .user(user)
+                .post(post)
+                .build();
+    }
+}

--- a/src/main/java/com/example/leets_7th/domain/post/entity/PostReport.java
+++ b/src/main/java/com/example/leets_7th/domain/post/entity/PostReport.java
@@ -1,0 +1,52 @@
+package com.example.leets_7th.domain.post.entity;
+
+import com.example.leets_7th.common.base.BaseEntity;
+import com.example.leets_7th.domain.comment.enums.ReportReason;
+import com.example.leets_7th.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(
+        name = "post_report",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_post_report_user_post",
+                        columnNames = {"user_id", "post_id"}
+                )
+        }
+)
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class PostReport extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportReason reason;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    public static PostReport of(User user, Post post, ReportReason reason, String content) {
+        return PostReport.builder()
+                .user(user)
+                .post(post)
+                .reason(reason)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/com/example/leets_7th/domain/post/enums/PostStatus.java
+++ b/src/main/java/com/example/leets_7th/domain/post/enums/PostStatus.java
@@ -1,0 +1,7 @@
+package com.example.leets_7th.domain.post.enums;
+
+public enum PostStatus {
+    HIDDEN,
+    DELETED,
+    ACTIVE
+}

--- a/src/main/java/com/example/leets_7th/domain/post/enums/PostVisibility.java
+++ b/src/main/java/com/example/leets_7th/domain/post/enums/PostVisibility.java
@@ -1,0 +1,10 @@
+package com.example.leets_7th.domain.post.enums;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@JsonFormat(shape = JsonFormat.Shape.STRING)
+public enum PostVisibility {
+    PUBLIC,
+    FRIENDS,
+    PRIVATE
+}

--- a/src/main/java/com/example/leets_7th/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/example/leets_7th/domain/post/repository/PostLikeRepository.java
@@ -1,0 +1,17 @@
+package com.example.leets_7th.domain.post.repository;
+
+import com.example.leets_7th.domain.post.entity.Post;
+import com.example.leets_7th.domain.post.entity.PostLike;
+import com.example.leets_7th.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    // 중복 좋아요 체크
+    boolean existsByUserAndPost(User user, Post post);
+
+    // 좋아요 취소 시 조회
+    Optional<PostLike> findByUserAndPost(User user, Post post);
+}

--- a/src/main/java/com/example/leets_7th/domain/post/repository/PostReportRepository.java
+++ b/src/main/java/com/example/leets_7th/domain/post/repository/PostReportRepository.java
@@ -1,0 +1,14 @@
+package com.example.leets_7th.domain.post.repository;
+
+import com.example.leets_7th.domain.post.entity.Post;
+import com.example.leets_7th.domain.post.entity.PostReport;
+import com.example.leets_7th.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostReportRepository extends JpaRepository<PostReport, Long> {
+
+    // 중복 신고 방지
+    boolean existsByUserAndPost(User user, Post post);
+
+    int countByPost(Post post);
+}

--- a/src/main/java/com/example/leets_7th/domain/post/service/PostCommandService.java
+++ b/src/main/java/com/example/leets_7th/domain/post/service/PostCommandService.java
@@ -3,13 +3,19 @@ package com.example.leets_7th.domain.post.service;
 import com.example.leets_7th.common.exception.GeneralException;
 import com.example.leets_7th.common.status.ErrorStatus;
 import com.example.leets_7th.domain.post.dto.request.CreatePostRequest;
+import com.example.leets_7th.domain.post.dto.request.ReportPostRequest;
 import com.example.leets_7th.domain.post.dto.request.UpdatePostRequest;
 import com.example.leets_7th.domain.post.dto.response.CreatePostResponse;
 import com.example.leets_7th.domain.post.dto.response.UpdatePostResponse;
 import com.example.leets_7th.domain.post.entity.Post;
+import com.example.leets_7th.domain.post.entity.PostLike;
+import com.example.leets_7th.domain.post.entity.PostReport;
+import com.example.leets_7th.domain.post.repository.PostLikeRepository;
+import com.example.leets_7th.domain.post.repository.PostReportRepository;
 import com.example.leets_7th.domain.post.repository.PostRepository;
+import com.example.leets_7th.domain.post.validator.PostValidator;
 import com.example.leets_7th.domain.user.entity.User;
-import com.example.leets_7th.domain.user.repository.UserRepository;
+import com.example.leets_7th.domain.user.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,68 +27,112 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostCommandService {
 
     private final PostRepository postRepository;
-    private final UserRepository userRepository;
+    private final PostValidator postValidator;
+    private final UserValidator userValidator;
+    private final PostLikeRepository postLikeRepository;
+    private final PostReportRepository postReportRepository;
 
     public CreatePostResponse createPost(Long userId, CreatePostRequest request) {
 
-        User user = getUser(userId);
+        User user = userValidator.validateUser(userId);
 
-        Post post = Post.builder()
-                .user(user)
-                .title(request.title())
-                .content(request.content())
-                .thumbnailImageUrl(null)
-                .build();
+        Post post = Post.create(
+                user,
+                request.title(),
+                request.content(),
+                null,
+                request.postVisibility()
+        );
 
         postRepository.save(post);
 
-        return new CreatePostResponse(post.getId(), null);
+        return new CreatePostResponse(
+                post.getId(),
+                null,
+                post.getPostVisibility()
+        );
     }
 
     public UpdatePostResponse updatePost(Long userId, Long postId, UpdatePostRequest request) {
 
-        Post post = getPost(postId);
-
-        validateOwner(post, userId);
-        validateNotDeleted(post);
-
+        Post post = validatePostOwner(userId, postId);
         post.update(request.title(), request.content());
 
         return new UpdatePostResponse(
                 post.getId(),
+                post.getPostVisibility(),
                 post.getUpdatedAt()
         );
     }
 
     public void deletePost(Long userId, Long postId) {
 
-        Post post = getPost(postId);
-
-        validateOwner(post, userId);
-        validateNotDeleted(post);
-
+        Post post = validatePostOwner(userId, postId);
         post.delete();
     }
 
-    private User getUser(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    public void likePost(Long userId, Long postId) {
+
+        UserAndPost userAndPost = validateUserAndPost(userId, postId);
+
+        if (postLikeRepository.existsByUserAndPost(userAndPost.user(), userAndPost.post())) {
+            throw new GeneralException(ErrorStatus.ALREADY_LIKED_POST);
+        }
+
+        postLikeRepository.save(PostLike.of(userAndPost.user(), userAndPost.post()));
+        userAndPost.post().increaseLikeCount();
     }
 
-    private Post getPost(Long postId) {
-        return postRepository.findById(postId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+    public void unlikePost(Long userId, Long postId) {
+
+        UserAndPost userAndPost = validateUserAndPost(userId, postId);
+
+        PostLike postLike = postLikeRepository
+                .findByUserAndPost(userAndPost.user(), userAndPost.post())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_LIKE_NOT_FOUND));
+
+        postLikeRepository.delete(postLike);
+        userAndPost.post().decreaseLikeCount();
     }
 
-    private void validateOwner(Post post, Long userId) {
+    public void reportPost(Long userId, Long postId, ReportPostRequest request) {
+
+        UserAndPost userAndPost = validateUserAndPost(userId, postId);
+
+        if (postReportRepository.existsByUserAndPost(userAndPost.user(), userAndPost.post())) {
+            throw new GeneralException(ErrorStatus.ALREADY_REPORTED_POST);
+        }
+
+        PostReport report = PostReport.of(
+                userAndPost.user(),
+                userAndPost.post(),
+                request.reason(),
+                request.content()
+        );
+
+        postReportRepository.save(report);
+
+        if (postReportRepository.countByPost(userAndPost.post()) >= 10) {
+            userAndPost.post().hide();
+        }
+    }
+
+    private UserAndPost validateUserAndPost(Long userId, Long postId) {
+        User user = userValidator.validateUser(userId);
+        Post post = postValidator.validatePost(postId);
+        return new UserAndPost(user, post);
+    }
+
+    private Post validatePostOwner(Long userId, Long postId) {
+        Post post = postValidator.validatePost(postId);
+
         if (!post.getUser().getId().equals(userId)) {
             throw new GeneralException(ErrorStatus.FORBIDDEN);
         }
+
+        return post;
     }
 
-    private void validateNotDeleted(Post post) {
-        if (post.getDeletedAt() != null) {
-            throw new GeneralException(ErrorStatus.POST_ALREADY_DELETED);
-        }
+    private record UserAndPost(User user, Post post) {
     }
 }

--- a/src/main/java/com/example/leets_7th/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/example/leets_7th/domain/post/service/PostQueryService.java
@@ -8,6 +8,7 @@ import com.example.leets_7th.domain.post.entity.Post;
 import com.example.leets_7th.domain.post.repository.PostRepository;
 import com.example.leets_7th.domain.post.validator.PostValidator;
 import com.example.leets_7th.domain.user.entity.User;
+import com.example.leets_7th.domain.user.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -22,10 +23,11 @@ public class PostQueryService {
 
     private final PostRepository postRepository;
     private final PostValidator postValidator;
+    private final UserValidator userValidator;
 
     public GetPostResponse getAllPost(GetPostRequest request) {
 
-        User user = postValidator.validateUser(request.userId());
+        User user = userValidator.validateUser(request.userId());
 
         Page<Post> postPage = postRepository
                 .findAllByUserAndDeletedAtIsNull(user, request.toPageable());
@@ -45,7 +47,7 @@ public class PostQueryService {
 
     public GetPostDetailResponse getPostDetail(Long userId, Long postId) {
 
-        postValidator.validateUser(userId);
+        userValidator.validateUser(userId);
         Post post = postValidator.validatePost(postId);
 
         return GetPostDetailResponse.from(post);

--- a/src/main/java/com/example/leets_7th/domain/post/validator/PostValidator.java
+++ b/src/main/java/com/example/leets_7th/domain/post/validator/PostValidator.java
@@ -4,8 +4,6 @@ import com.example.leets_7th.common.exception.GeneralException;
 import com.example.leets_7th.common.status.ErrorStatus;
 import com.example.leets_7th.domain.post.entity.Post;
 import com.example.leets_7th.domain.post.repository.PostRepository;
-import com.example.leets_7th.domain.user.entity.User;
-import com.example.leets_7th.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/example/leets_7th/domain/post/validator/PostValidator.java
+++ b/src/main/java/com/example/leets_7th/domain/post/validator/PostValidator.java
@@ -13,13 +13,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PostValidator {
 
-    private final UserRepository userRepository;
     private final PostRepository postRepository;
-
-    public User validateUser(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-    }
 
     public Post validatePost(Long postId) {
         Post post = postRepository.findById(postId)

--- a/src/main/java/com/example/leets_7th/domain/user/validator/UserValidator.java
+++ b/src/main/java/com/example/leets_7th/domain/user/validator/UserValidator.java
@@ -1,0 +1,21 @@
+package com.example.leets_7th.domain.user.validator;
+
+import com.example.leets_7th.common.exception.GeneralException;
+import com.example.leets_7th.common.status.ErrorStatus;
+import com.example.leets_7th.domain.user.entity.User;
+import com.example.leets_7th.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+
+public class UserValidator {
+
+    private final UserRepository userRepository;
+
+    public User validateUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

<!-- README의 과제 요구사항 기준으로 이번 PR에서 구현한 범위를 작성해주세요. -->

- [x] 게시글 관련 기본 API 구현 (생성,조회,삭제,수정)
- [x] 댓글 관련 기본 API 구현 (생성,삭제,수정)
- [x] 게시글 좋아요,좋아요취소,신고 API 구현 
- [x] 댓글 좋아요,좋아요취소,신고 API 구현  


## 2. 핵심 변경 사항

기본 API는 각설하고 게시글 좋아요 , 좋아요 취소 기능 ( 게시글,  댓글)을 구현하였습니다. 요구사항에 따라 좋아요 상태에서 다시 좋아요를 누르는, 좋아요가 되어있지않은 상태에서 좋아요 취소하는 상황을 구현체에서 예외처리를 하였고 신고 기능 또한 추가하였습니다. 일정 신고 갯수가 누적되면 status를 변화하여 접수 , 삭제 or 숨김 상태로 전환되도록 구현하였고 soft delete 형식을 사용하기위해 추후에 scheduler를 도입하여 관리할 생각입니다. 

## 3. 실행 및 검증 결과

!! 기본적인 CRUD 캡쳐는 제외하고 올립니다.

- 게시글 좋아요 Request
<img width="826" height="537" alt="image" src="https://github.com/user-attachments/assets/0ea057ab-d478-489b-a9dc-a46e80460d7f" />

- Response
<img width="867" height="615" alt="image" src="https://github.com/user-attachments/assets/18f567c2-2547-466a-9434-f9b524709756" />

- 반복요청 예외
<img width="698" height="405" alt="image" src="https://github.com/user-attachments/assets/35b3defe-03a0-4789-826b-297e2b1cb633" />

- 게시글 좋아요 취소 Request
<img width="830" height="593" alt="image" src="https://github.com/user-attachments/assets/6df6dc41-b385-490a-8695-0f59f2939130" />

- Response
<img width="786" height="620" alt="image" src="https://github.com/user-attachments/assets/074afde6-5a88-417d-9652-3e31ab6f4a07" />


- 반복요청 예외
<img width="672" height="515" alt="image" src="https://github.com/user-attachments/assets/61c0b82e-612d-4bbc-b1d7-a21a5df952c9" />

- 게시글 신고 Request
<img width="911" height="756" alt="image" src="https://github.com/user-attachments/assets/840fcfa5-b9af-461c-bfa8-cd350b9a5f1c" />

- Response
<img width="713" height="501" alt="image" src="https://github.com/user-attachments/assets/780873c1-547f-4f74-959a-e096471ec011" />

- 반복요청 예외
<img width="598" height="372" alt="image" src="https://github.com/user-attachments/assets/62537636-a72f-4fdc-a4c3-de2aa8d859e2" />

- 게시글 신고 DB 
<img width="1745" height="512" alt="image" src="https://github.com/user-attachments/assets/0e0e7373-0218-4cb2-b673-e0a129f72a93" />

- 신고 10개를 넘어설 시
<img width="1518" height="402" alt="image" src="https://github.com/user-attachments/assets/0d7414a5-2525-44a2-93d7-40b3a8cb4647" />

게시글 Stauts가 HIDDEN 상태로 전환.

댓글 또한 이와 같습니다.


## 4. 완료 사항

게시글, 댓글 좋아요,신고 상태 변환에 대한 예외처리 및 기능 구현 성공


## 5. 추가 사항

- 관련 이슈: closed #130 
<!-- 리뷰 시 참고할 포인트나 남은 작업이 있다면 작성해주세요. -->


## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다
