### PR TITLE
[4주차] 이예서/[feat] 추가 API 구현

### DIFF
--- a/leeyeseo/src/main/java/com/example/blog/domain/post/controller/PostController.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/post/controller/PostController.java
@@ -56,4 +56,13 @@ public class PostController {
         postService.deletePost(userId, postId);
         return ApiResponse.onSuccess();
     }
+
+    // PATCH /posts/{postId}/hide - 게시글 숨김
+    @PatchMapping("/{postId}/hide")
+    public ApiResponse<Void> hidePost(
+            @RequestHeader("X-USER-ID") Long userId,
+            @PathVariable Long postId) {
+        postService.hidePost(userId, postId);
+        return ApiResponse.onSuccess();
+    }
 }

--- a/leeyeseo/src/main/java/com/example/blog/domain/post/entity/Post.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/post/entity/Post.java
@@ -1,6 +1,7 @@
 package com.example.blog.domain.post.entity;
 
 import com.example.blog.domain.user.entity.User;
+import com.example.blog.exception.AlreadyHiddenException;
 import com.example.blog.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -34,9 +35,22 @@ public class Post extends BaseEntity {
     @Comment("게시글 이미지 URL")
     private String imageUrl;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    @Builder.Default
+    @Comment("게시글 상태 (ACTIVE/HIDDEN)")
+    private PostStatus status = PostStatus.ACTIVE;
+
     public void update(String title, String content, String imageUrl) {
         this.title = title;
         this.content = content;
         this.imageUrl = imageUrl;
+    }
+
+    public void hide() {
+        if (this.status == PostStatus.HIDDEN) {
+            throw new AlreadyHiddenException();
+        }
+        this.status = PostStatus.HIDDEN;
     }
 }

--- a/leeyeseo/src/main/java/com/example/blog/domain/post/entity/PostStatus.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/post/entity/PostStatus.java
@@ -1,0 +1,6 @@
+package com.example.blog.domain.post.entity;
+
+public enum PostStatus {
+    ACTIVE,
+    HIDDEN
+}

--- a/leeyeseo/src/main/java/com/example/blog/domain/post/repository/PostRepository.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/post/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package com.example.blog.domain.post.repository;
 
 import com.example.blog.domain.post.entity.Post;
+import com.example.blog.domain.post.entity.PostStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,8 +9,7 @@ import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    // soft delete: deletedAt이 null인 것만 조회
-    List<Post> findAllByDeletedAtIsNull();
+    List<Post> findAllByDeletedAtIsNullAndStatus(PostStatus status);
 
     Optional<Post> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/leeyeseo/src/main/java/com/example/blog/domain/post/service/PostService.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/post/service/PostService.java
@@ -2,6 +2,7 @@ package com.example.blog.domain.post.service;
 
 import com.example.blog.domain.post.converter.PostConverter;
 import com.example.blog.domain.post.entity.Post;
+import com.example.blog.domain.post.entity.PostStatus;
 import com.example.blog.domain.post.repository.PostRepository;
 import com.example.blog.domain.user.entity.User;
 import com.example.blog.domain.user.repository.UserRepository;
@@ -26,10 +27,10 @@ public class PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
 
-    // 게시글 목록 조회
+    // 게시글 목록 조회 (ACTIVE만)
     @Transactional(readOnly = true)
     public List<PostSummaryResponse> getPosts() {
-        return postRepository.findAllByDeletedAtIsNull()
+        return postRepository.findAllByDeletedAtIsNullAndStatus(PostStatus.ACTIVE)
                 .stream()
                 .map(PostConverter::toSummaryResponse)
                 .collect(Collectors.toList());
@@ -59,7 +60,6 @@ public class PostService {
         Post post = postRepository.findByIdAndDeletedAtIsNull(postId)
                 .orElseThrow(() -> new PostNotFoundException(postId));
 
-        // 작성자 권한 확인
         if (!post.getUser().getId().equals(userId)) {
             throw new PostForbiddenException();
         }
@@ -68,17 +68,29 @@ public class PostService {
         return PostConverter.toDetailResponse(post);
     }
 
-    // 게시글 삭제 (soft delete)
+    // 게시글 삭제
     @Transactional
     public void deletePost(Long userId, Long postId) {
         Post post = postRepository.findByIdAndDeletedAtIsNull(postId)
                 .orElseThrow(() -> new PostNotFoundException(postId));
 
-        // 작성자 권한 확인
         if (!post.getUser().getId().equals(userId)) {
             throw new PostForbiddenException();
         }
 
         post.delete();
+    }
+
+    // 게시글 숨김
+    @Transactional
+    public void hidePost(Long userId, Long postId) {
+        Post post = postRepository.findByIdAndDeletedAtIsNull(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        if (!post.getUser().getId().equals(userId)) {
+            throw new PostForbiddenException();
+        }
+
+        post.hide();
     }
 }

--- a/leeyeseo/src/main/java/com/example/blog/domain/post/service/PostService.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/post/service/PostService.java
@@ -68,7 +68,7 @@ public class PostService {
         return PostConverter.toDetailResponse(post);
     }
 
-    // 게시글 삭제
+    // 게시글 삭제 (soft delete)
     @Transactional
     public void deletePost(Long userId, Long postId) {
         Post post = postRepository.findByIdAndDeletedAtIsNull(postId)

--- a/leeyeseo/src/main/java/com/example/blog/domain/report/controller/ReportController.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/report/controller/ReportController.java
@@ -1,0 +1,32 @@
+package com.example.blog.domain.report.controller;
+
+import com.example.blog.domain.report.service.ReportService;
+import com.example.blog.dto.report.ReportCreateRequest;
+import com.example.blog.dto.report.ReportResponse;
+import com.example.blog.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    // POST /posts/{postId}/reports - 게시물 신고
+    @PostMapping("/posts/{postId}/reports")
+    public ApiResponse<ReportResponse> createReport(
+            @RequestHeader("X-USER-ID") Long userId,
+            @PathVariable Long postId,
+            @Valid @RequestBody ReportCreateRequest request) {
+        return ApiResponse.onSuccess(reportService.createReport(userId, postId, request));
+    }
+
+    // PATCH /reports/{reportId}/resolve - 신고 처리 완료
+    @PatchMapping("/reports/{reportId}/resolve")
+    public ApiResponse<ReportResponse> resolveReport(
+            @PathVariable Long reportId) {
+        return ApiResponse.onSuccess(reportService.resolveReport(reportId));
+    }
+}

--- a/leeyeseo/src/main/java/com/example/blog/domain/report/converter/ReportConverter.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/report/converter/ReportConverter.java
@@ -1,0 +1,29 @@
+package com.example.blog.domain.report.converter;
+
+import com.example.blog.domain.post.entity.Post;
+import com.example.blog.domain.report.entity.Report;
+import com.example.blog.domain.user.entity.User;
+import com.example.blog.dto.report.ReportCreateRequest;
+import com.example.blog.dto.report.ReportResponse;
+
+public class ReportConverter {
+
+    public static Report toEntity(ReportCreateRequest request, User user, Post post) {
+        return Report.builder()
+                .user(user)
+                .post(post)
+                .reason(request.getReason())
+                .build();
+    }
+
+    public static ReportResponse toResponse(Report report) {
+        return ReportResponse.builder()
+                .id(report.getId())
+                .postId(report.getPost().getId())
+                .reporterId(report.getUser().getId())
+                .reason(report.getReason())
+                .status(report.getStatus())
+                .createdAt(report.getCreatedAt())
+                .build();
+    }
+}

--- a/leeyeseo/src/main/java/com/example/blog/domain/report/entity/Report.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/report/entity/Report.java
@@ -1,0 +1,55 @@
+package com.example.blog.domain.report.entity;
+
+import com.example.blog.domain.post.entity.Post;
+import com.example.blog.domain.user.entity.User;
+import com.example.blog.exception.AlreadyResolvedException;
+import com.example.blog.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Table(
+        name = "report",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_report_user_post",
+                columnNames = {"user_id", "post_id"}
+        )
+)
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Report extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @Comment("신고한 사용자")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    @Comment("신고된 게시글")
+    private Post post;
+
+    @Column(name = "reason", nullable = false, length = 500)
+    @Comment("신고 사유")
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    @Builder.Default
+    @Comment("신고 상태 (PENDING/RESOLVED)")
+    private ReportStatus status = ReportStatus.PENDING;
+
+    public void resolve() {
+        if (this.status == ReportStatus.RESOLVED) {
+            throw new AlreadyResolvedException();
+        }
+        this.status = ReportStatus.RESOLVED;
+    }
+}

--- a/leeyeseo/src/main/java/com/example/blog/domain/report/entity/ReportStatus.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/report/entity/ReportStatus.java
@@ -1,0 +1,6 @@
+package com.example.blog.domain.report.entity;
+
+public enum ReportStatus {
+    PENDING,
+    RESOLVED
+}

--- a/leeyeseo/src/main/java/com/example/blog/domain/report/repository/ReportRepository.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/report/repository/ReportRepository.java
@@ -1,0 +1,13 @@
+package com.example.blog.domain.report.repository;
+
+import com.example.blog.domain.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    boolean existsByUserIdAndPostId(Long userId, Long postId);
+
+    Optional<Report> findByIdAndDeletedAtIsNull(Long id);
+}

--- a/leeyeseo/src/main/java/com/example/blog/domain/report/service/ReportService.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/report/service/ReportService.java
@@ -1,0 +1,53 @@
+package com.example.blog.domain.report.service;
+
+import com.example.blog.domain.post.entity.Post;
+import com.example.blog.domain.post.repository.PostRepository;
+import com.example.blog.domain.report.converter.ReportConverter;
+import com.example.blog.domain.report.entity.Report;
+import com.example.blog.domain.report.repository.ReportRepository;
+import com.example.blog.domain.user.entity.User;
+import com.example.blog.domain.user.repository.UserRepository;
+import com.example.blog.dto.report.ReportCreateRequest;
+import com.example.blog.dto.report.ReportResponse;
+import com.example.blog.exception.DuplicateReportException;
+import com.example.blog.exception.PostNotFoundException;
+import com.example.blog.exception.ReportNotFoundException;
+import com.example.blog.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ReportResponse createReport(Long userId, Long postId, ReportCreateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        Post post = postRepository.findByIdAndDeletedAtIsNull(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        if (reportRepository.existsByUserIdAndPostId(userId, postId)) {
+            throw new DuplicateReportException();
+        }
+
+        Report report = ReportConverter.toEntity(request, user, post);
+        reportRepository.save(report);
+        return ReportConverter.toResponse(report);
+    }
+
+    @Transactional
+    public ReportResponse resolveReport(Long reportId) {
+        Report report = reportRepository.findByIdAndDeletedAtIsNull(reportId)
+                .orElseThrow(() -> new ReportNotFoundException(reportId));
+
+        report.resolve();
+        return ReportConverter.toResponse(report);
+    }
+}

--- a/leeyeseo/src/main/java/com/example/blog/dto/report/ReportCreateRequest.java
+++ b/leeyeseo/src/main/java/com/example/blog/dto/report/ReportCreateRequest.java
@@ -1,0 +1,15 @@
+package com.example.blog.dto.report;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReportCreateRequest {
+
+    @NotBlank(message = "신고 사유는 필수입니다.")
+    @Size(max = 500, message = "신고 사유는 최대 500자까지 입력 가능합니다.")
+    private String reason;
+}

--- a/leeyeseo/src/main/java/com/example/blog/dto/report/ReportResponse.java
+++ b/leeyeseo/src/main/java/com/example/blog/dto/report/ReportResponse.java
@@ -1,0 +1,23 @@
+package com.example.blog.dto.report;
+
+import com.example.blog.domain.report.entity.ReportStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReportResponse {
+
+    private Long id;
+    private Long postId;
+    private Long reporterId;
+    private String reason;
+    private ReportStatus status;
+    private LocalDateTime createdAt;
+}

--- a/leeyeseo/src/main/java/com/example/blog/exception/AlreadyHiddenException.java
+++ b/leeyeseo/src/main/java/com/example/blog/exception/AlreadyHiddenException.java
@@ -1,0 +1,15 @@
+package com.example.blog.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AlreadyHiddenException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public AlreadyHiddenException() {
+        super(ErrorCode.ALREADY_HIDDEN.getMessage());
+        this.errorCode = ErrorCode.ALREADY_HIDDEN;
+    }
+
+}

--- a/leeyeseo/src/main/java/com/example/blog/exception/AlreadyResolvedException.java
+++ b/leeyeseo/src/main/java/com/example/blog/exception/AlreadyResolvedException.java
@@ -1,0 +1,15 @@
+package com.example.blog.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AlreadyResolvedException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public AlreadyResolvedException() {
+        super(ErrorCode.ALREADY_RESOLVED.getMessage());
+        this.errorCode = ErrorCode.ALREADY_RESOLVED;
+    }
+
+}

--- a/leeyeseo/src/main/java/com/example/blog/exception/DuplicateReportException.java
+++ b/leeyeseo/src/main/java/com/example/blog/exception/DuplicateReportException.java
@@ -1,0 +1,15 @@
+package com.example.blog.exception;
+
+import lombok.Getter;
+
+@Getter
+public class DuplicateReportException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public DuplicateReportException() {
+        super(ErrorCode.DUPLICATE_REPORT.getMessage());
+        this.errorCode = ErrorCode.DUPLICATE_REPORT;
+    }
+
+}

--- a/leeyeseo/src/main/java/com/example/blog/exception/ErrorCode.java
+++ b/leeyeseo/src/main/java/com/example/blog/exception/ErrorCode.java
@@ -1,7 +1,9 @@
 package com.example.blog.exception;
 
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+@Getter
 public enum ErrorCode {
 
     // 400
@@ -9,6 +11,7 @@ public enum ErrorCode {
     MISSING_REQUIRED_VALUE(HttpStatus.BAD_REQUEST, "400_001", "필수 입력값이 누락되었습니다."),
     TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "400_002", "제목은 최대 255자까지 입력 가능합니다."),
     INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "400_004", "데이터 타입이 올바르지 않습니다."),
+    INVALID_STATE_TRANSITION(HttpStatus.BAD_REQUEST, "400_005", "유효하지 않은 상태 전이입니다."),
 
     // 403
     FORBIDDEN(HttpStatus.FORBIDDEN, "403_000", "접근 권한이 없습니다."),
@@ -18,6 +21,12 @@ public enum ErrorCode {
     NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, "404_000", "존재하지 않는 API 경로입니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "404_001", "요청하신 게시글을 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "404_002", "사용자를 찾을 수 없습니다."),
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "404_003", "요청하신 신고를 찾을 수 없습니다."),
+
+    // 409 (중복/충돌)
+    DUPLICATE_REPORT(HttpStatus.CONFLICT, "409_001", "이미 신고한 게시글입니다."),
+    ALREADY_RESOLVED(HttpStatus.CONFLICT, "409_002", "이미 처리 완료된 신고입니다."),
+    ALREADY_HIDDEN(HttpStatus.CONFLICT, "409_003", "이미 숨김 처리된 게시글입니다."),
 
     // 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500_000", "서버 내부 오류가 발생했습니다.");
@@ -32,15 +41,4 @@ public enum ErrorCode {
         this.message = message;
     }
 
-    public HttpStatus getStatus() {
-        return status;
-    }
-
-    public String getCode() {
-        return code;
-    }
-
-    public String getMessage() {
-        return message;
-    }
 }

--- a/leeyeseo/src/main/java/com/example/blog/exception/GlobalExceptionHandler.java
+++ b/leeyeseo/src/main/java/com/example/blog/exception/GlobalExceptionHandler.java
@@ -55,6 +55,50 @@ public class GlobalExceptionHandler {
                 ));
     }
 
+    // 신고 없음 404
+    @ExceptionHandler(ReportNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleReportNotFound(ReportNotFoundException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ApiResponse.onFailure(
+                        e.getErrorCode().getCode(),
+                        e.getMessage()
+                ));
+    }
+
+    // 중복 신고 409
+    @ExceptionHandler(DuplicateReportException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDuplicateReport(DuplicateReportException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ApiResponse.onFailure(
+                        e.getErrorCode().getCode(),
+                        e.getMessage()
+                ));
+    }
+
+    // 이미 처리된 신고 409
+    @ExceptionHandler(AlreadyResolvedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAlreadyResolved(AlreadyResolvedException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ApiResponse.onFailure(
+                        e.getErrorCode().getCode(),
+                        e.getMessage()
+                ));
+    }
+
+    // 이미 숨김 처리된 게시글 409
+    @ExceptionHandler(AlreadyHiddenException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAlreadyHidden(AlreadyHiddenException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ApiResponse.onFailure(
+                        e.getErrorCode().getCode(),
+                        e.getMessage()
+                ));
+    }
+
     // @Valid 검증 실패 400
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException e) {

--- a/leeyeseo/src/main/java/com/example/blog/exception/ReportNotFoundException.java
+++ b/leeyeseo/src/main/java/com/example/blog/exception/ReportNotFoundException.java
@@ -1,0 +1,15 @@
+package com.example.blog.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ReportNotFoundException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public ReportNotFoundException(Long reportId) {
+        super(ErrorCode.REPORT_NOT_FOUND.getMessage() + " id: " + reportId);
+        this.errorCode = ErrorCode.REPORT_NOT_FOUND;
+    }
+
+}


### PR DESCRIPTION
<!--
제목: [주차] {이름}/[타입] {작업 내용}
예시: [1주차] 조혜원/[feat] 초기 프로젝트 설정
-->

## 1. 과제 요구사항 중 구현한 내용

- 게시물 신고 (POST `/posts/{postId}/reports`)
- 신고 처리 완료 (PATCH `/reports/{reportId}/resolve`) — PENDING → RESOLVED
- 게시물 숨김 (PATCH `/posts/{postId}/hide`) — ACTIVE → HIDDEN
- 도메인 상태 변화 반영 + 중복 처리 방지 로직 포함

## 2. 핵심 변경 사항

- `PostStatus` (ACTIVE/HIDDEN) enum 및 Post 엔티티 상태 필드 추가
- `Report` 도메인 신규 생성 (entity, repository, service, controller, dto, converter)
- `(user_id, post_id)` 복합 유니크로 중복 신고 차단
- 신규 예외 4종 + `GlobalExceptionHandler` 핸들러 추가

## 3. 실행 및 검증 결과

<!-- 실행/검증 방법과 결과를 작성해주세요. 필요 시 요청/응답 예시를 포함해주세요. -->

Postman으로 9개 시나리오 모두 정상 동작 확인 완료
- 정상 케이스: 신고/처리/숨김
- 중복 처리 방지: 중복 신고/중복 처리/중복 숨김 → 409 Conflict
- 권한 검증: 작성자 아닌 사용자의 숨김 시도 → 403 Forbidden
- 목록 조회 시 HIDDEN 게시글 제외 확인

기본 헬스체크 정상 동작 확인
<img width="1265" height="645" alt="스크린샷 2026-03-31 오후 10 39 39" src="https://github.com/user-attachments/assets/5f2937e0-8616-4f51-b22b-f7b980fe4696" />

빈 배열 응답
<img width="958" height="619" alt="스크린샷 2026-04-07 오후 9 48 57" src="https://github.com/user-attachments/assets/f47060f9-828f-424e-afc1-a5424f243852" />

<img width="766" height="793" alt="스크린샷 2026-04-28 오후 11 33 12" src="https://github.com/user-attachments/assets/ed1684e2-0f06-4de1-be3e-2ddc5edbdbd0" />

<img width="764" height="771" alt="스크린샷 2026-04-28 오후 11 34 15" src="https://github.com/user-attachments/assets/5246ae74-4d67-4c62-a872-a969549444bd" />

<img width="768" height="671" alt="스크린샷 2026-04-28 오후 11 35 18" src="https://github.com/user-attachments/assets/6f075633-4675-433d-93a7-4b3a604dd038" />

중복 신고 차단
<img width="764" height="738" alt="스크린샷 2026-04-28 오후 11 36 22" src="https://github.com/user-attachments/assets/9a48f364-98d9-443a-8dee-70fc41ba34c2" />

신고 처리 완료
<img width="762" height="636" alt="스크린샷 2026-04-28 오후 11 36 45" src="https://github.com/user-attachments/assets/3ad913c4-7cdd-4347-b39a-b16d53f09925" />
중복 처리 차단

## 4. 완료 사항

- [x] 신규 API 3개 구현
- [x] 도메인 상태 enum 및 상태 전이 로직
- [x] 중복 처리 방지 (DB 유니크 제약 + 서비스 레벨 검증)
- [x] 예외 처리 통합
- [x] Postman 동작 테스트


## 5. 추가 사항

- 관련 이슈: `closed #이슈번호`
- 기존 `BaseEntity` / 소프트 딜리트 패턴 유지
- 3주차 `X-USER-ID` 헤더 인증 방식 동일 적용
- API 경로는 RESTful + 액션형 혼합 (자원 생성은 RESTful, 상태 전이는 `/hide`, `/resolve`)


## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고

<!--
BE: rootTiket, soyesenna
FE: One-HyeWon, woneeee
-->
