### PR TITLE
[5주차] 강지훈/[feat] Swagger 문서화

### DIFF
--- a/jihoonkang/src/main/java/com/example/blog/controller/HealthController.java
+++ b/jihoonkang/src/main/java/com/example/blog/controller/HealthController.java
@@ -1,13 +1,30 @@
 package com.example.blog.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "헬스체크", description = "서버 가용성 확인")
 @RestController
 public class HealthController {
 
-  @GetMapping("/api/v1/health")
-  public String health() {
-    return "ok";
-  }
+    @Operation(summary = "헬스체크", description = "서버가 정상 동작 중인지 확인합니다. 인증 불필요.")
+    @SecurityRequirements
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "서버 정상",
+            content = @Content(mediaType = "text/plain", schema = @Schema(type = "string", example = "ok"))
+        )
+    })
+    @GetMapping("/api/v1/health")
+    public String health() {
+        return "ok";
+    }
 }

--- a/jihoonkang/src/main/java/com/example/blog/domain/comment/controller/CommentController.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/comment/controller/CommentController.java
@@ -8,6 +8,19 @@ import com.example.blog.domain.report.dto.ReportCommentRequest;
 import com.example.blog.domain.report.dto.ReportResponse;
 import com.example.blog.domain.report.service.ReportService;
 import com.example.blog.global.response.ApiResponse;
+import com.example.blog.global.response.ErrorApiResponse;
+import com.example.blog.global.swagger.CommonErrorResponses;
+import com.example.blog.global.swagger.ConflictAlreadyReported;
+import com.example.blog.global.swagger.ForbiddenResponse;
+import com.example.blog.global.swagger.NotFoundCommentResponse;
+import com.example.blog.global.swagger.NotFoundPostResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,6 +28,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "댓글", description = "댓글 CRUD, 채택, 신고")
 @RestController
 @RequiredArgsConstructor
 public class CommentController {
@@ -22,53 +36,115 @@ public class CommentController {
     private final CommentService commentService;
     private final ReportService reportService;
 
+    @Operation(summary = "댓글 작성", description = "게시글에 댓글을 작성합니다. parentCommentId를 지정하면 대댓글이 됩니다.")
+    @CommonErrorResponses
+    @NotFoundPostResponse
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "댓글 작성 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "유효하지 않은 부모 댓글 (C002)",
+            content = @Content(
+                schema = @Schema(implementation = ErrorApiResponse.class),
+                examples = @ExampleObject(value = "{\"status\":\"error\",\"message\":\"유효하지 않은 부모 댓글입니다.\",\"data\":null}")
+            )
+        )
+    })
     @PostMapping("/api/v1/posts/{postId}/comments")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<CommentResponse> create(
         @RequestHeader("X-User-Id") Long userId,
-        @PathVariable Long postId,
+        @Parameter(description = "게시글 ID", example = "1") @PathVariable Long postId,
         @RequestBody @Valid CommentCreateRequest request
     ) {
         return ApiResponse.success(commentService.create(userId, postId, request));
     }
 
+    @Operation(summary = "게시글의 댓글 목록 조회")
+    @CommonErrorResponses
+    @NotFoundPostResponse
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
     @GetMapping("/api/v1/posts/{postId}/comments")
-    public ApiResponse<List<CommentResponse>> findByPostId(@PathVariable Long postId) {
+    public ApiResponse<List<CommentResponse>> findByPostId(
+        @Parameter(description = "게시글 ID", example = "1") @PathVariable Long postId
+    ) {
         return ApiResponse.success(commentService.findByPostId(postId));
     }
 
+    @Operation(summary = "댓글 수정")
+    @CommonErrorResponses
+    @ForbiddenResponse
+    @NotFoundCommentResponse
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공")
+    })
     @PatchMapping("/api/v1/comments/{commentId}")
     public ApiResponse<CommentResponse> update(
         @RequestHeader("X-User-Id") Long userId,
-        @PathVariable Long commentId,
+        @Parameter(description = "댓글 ID", example = "1") @PathVariable Long commentId,
         @RequestBody @Valid CommentUpdateRequest request
     ) {
         return ApiResponse.success(commentService.update(userId, commentId, request));
     }
 
+    @Operation(summary = "댓글 삭제")
+    @CommonErrorResponses
+    @ForbiddenResponse
+    @NotFoundCommentResponse
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "삭제 성공", content = @Content)
+    })
     @DeleteMapping("/api/v1/comments/{commentId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(
         @RequestHeader("X-User-Id") Long userId,
-        @PathVariable Long commentId
+        @Parameter(description = "댓글 ID", example = "1") @PathVariable Long commentId
     ) {
         commentService.delete(userId, commentId);
     }
 
+    @Operation(summary = "댓글 채택", description = "게시글 작성자가 댓글을 채택합니다. 게시글당 하나의 댓글만 채택 가능합니다.")
+    @CommonErrorResponses
+    @ForbiddenResponse
+    @NotFoundPostResponse
+    @NotFoundCommentResponse
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "채택 성공")
+    })
     @PostMapping("/api/v1/posts/{postId}/comments/{commentId}/accept")
     public ApiResponse<CommentResponse> accept(
         @RequestHeader("X-User-Id") Long userId,
-        @PathVariable Long postId,
-        @PathVariable Long commentId
+        @Parameter(description = "게시글 ID", example = "1") @PathVariable Long postId,
+        @Parameter(description = "채택할 댓글 ID", example = "1") @PathVariable Long commentId
     ) {
         return ApiResponse.success(commentService.acceptComment(userId, postId, commentId));
     }
 
+    @Operation(summary = "댓글 신고", description = "댓글을 신고합니다. 자신의 댓글 신고 불가(R003), 중복 신고 불가(R002).")
+    @CommonErrorResponses
+    @ConflictAlreadyReported
+    @NotFoundCommentResponse
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "신고 접수 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "잘못된 신고 대상(R001) 또는 자신의 댓글 신고(R003)",
+            content = @Content(
+                schema = @Schema(implementation = ErrorApiResponse.class),
+                examples = {
+                    @ExampleObject(name = "R001", value = "{\"status\":\"error\",\"message\":\"유효하지 않은 신고 대상입니다.\",\"data\":null}"),
+                    @ExampleObject(name = "R003", value = "{\"status\":\"error\",\"message\":\"자신의 게시물/댓글은 신고할 수 없습니다.\",\"data\":null}")
+                }
+            )
+        )
+    })
     @PostMapping("/api/v1/comments/{commentId}/reports")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<ReportResponse> reportComment(
         @RequestHeader("X-User-Id") Long reporterId,
-        @PathVariable Long commentId,
+        @Parameter(description = "댓글 ID", example = "1") @PathVariable Long commentId,
         @RequestBody @Valid ReportCommentRequest request
     ) {
         return ApiResponse.success(reportService.reportComment(reporterId, commentId, request));

--- a/jihoonkang/src/main/java/com/example/blog/domain/comment/dto/CommentCreateRequest.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/comment/dto/CommentCreateRequest.java
@@ -1,12 +1,16 @@
 package com.example.blog.domain.comment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "댓글 작성 요청")
 public record CommentCreateRequest(
 
+    @Schema(description = "댓글 내용", example = "좋은 글이네요!", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "댓글 내용은 필수입니다.")
     String content,
 
+    @Schema(description = "부모 댓글 ID (대댓글 작성 시 지정)", nullable = true, example = "1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     Long parentCommentId
 
 ) {}

--- a/jihoonkang/src/main/java/com/example/blog/domain/comment/dto/CommentResponse.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/comment/dto/CommentResponse.java
@@ -1,20 +1,22 @@
 package com.example.blog.domain.comment.dto;
 
 import com.example.blog.domain.comment.entity.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "댓글 응답")
 public record CommentResponse(
-    Long commentId,
-    Long postId,
-    Long userId,
-    String username,
-    String content,
-    boolean accepted,
-    Long parentCommentId,
-    List<CommentResponse> replies,
-    LocalDateTime createdAt
+    @Schema(description = "댓글 ID", example = "1") Long commentId,
+    @Schema(description = "게시글 ID", example = "1") Long postId,
+    @Schema(description = "작성자 ID", example = "1") Long userId,
+    @Schema(description = "작성자 이름", example = "지훈") String username,
+    @Schema(description = "댓글 내용", example = "좋은 글이네요!") String content,
+    @Schema(description = "채택 여부", example = "false") boolean accepted,
+    @Schema(description = "부모 댓글 ID (최상위 댓글이면 null)", nullable = true, example = "null") Long parentCommentId,
+    @Schema(description = "대댓글 목록", nullable = true) List<CommentResponse> replies,
+    @Schema(description = "생성 시각", example = "2026-05-04T10:30:00") LocalDateTime createdAt
 ) {
 
     public static CommentResponse from(Comment comment) {

--- a/jihoonkang/src/main/java/com/example/blog/domain/comment/dto/CommentUpdateRequest.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/comment/dto/CommentUpdateRequest.java
@@ -1,9 +1,12 @@
 package com.example.blog.domain.comment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "댓글 수정 요청")
 public record CommentUpdateRequest(
 
+    @Schema(description = "수정할 댓글 내용", example = "수정된 댓글 내용입니다.", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "댓글 내용은 필수입니다.")
     String content
 

--- a/jihoonkang/src/main/java/com/example/blog/domain/post/controller/PostController.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/post/controller/PostController.java
@@ -9,11 +9,26 @@ import com.example.blog.domain.report.dto.ReportPostRequest;
 import com.example.blog.domain.report.dto.ReportResponse;
 import com.example.blog.domain.report.service.ReportService;
 import com.example.blog.global.response.ApiResponse;
+import com.example.blog.global.response.ErrorApiResponse;
+import com.example.blog.global.swagger.CommonErrorResponses;
+import com.example.blog.global.swagger.ConflictAlreadyHidden;
+import com.example.blog.global.swagger.ConflictAlreadyReported;
+import com.example.blog.global.swagger.ForbiddenResponse;
+import com.example.blog.global.swagger.NotFoundPostResponse;
+import com.example.blog.global.swagger.NotFoundUserResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "게시글", description = "게시글 CRUD, 숨김, 신고")
 @RestController
 @RequestMapping("/api/v1/posts")
 @RequiredArgsConstructor
@@ -22,6 +37,12 @@ public class PostController {
     private final PostService postService;
     private final ReportService reportService;
 
+    @Operation(summary = "게시글 작성")
+    @CommonErrorResponses
+    @NotFoundUserResponse
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "작성 성공")
+    })
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<PostResponse> create(
@@ -31,6 +52,19 @@ public class PostController {
         return ApiResponse.success(postService.create(userId, request));
     }
 
+    @Operation(
+        summary = "게시글 목록 조회",
+        parameters = {
+            @Parameter(name = "status", description = "필터링할 상태. 미지정 시 전체 조회", example = "PUBLISHED",
+                schema = @Schema(allowableValues = {"PUBLISHED", "HIDDEN"})),
+            @Parameter(name = "page", description = "페이지 번호 (0부터 시작)", example = "0"),
+            @Parameter(name = "size", description = "페이지 크기", example = "10")
+        }
+    )
+    @CommonErrorResponses
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
     @GetMapping
     public ApiResponse<PostListResponse> findAll(
         @RequestParam(required = false) String status,
@@ -40,42 +74,90 @@ public class PostController {
         return ApiResponse.success(postService.findAll(status, page, size));
     }
 
+    @Operation(summary = "게시글 단건 조회")
+    @CommonErrorResponses
+    @NotFoundPostResponse
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
     @GetMapping("/{postId}")
-    public ApiResponse<PostResponse> findById(@PathVariable Long postId) {
+    public ApiResponse<PostResponse> findById(
+        @Parameter(description = "게시글 ID", example = "1") @PathVariable Long postId
+    ) {
         return ApiResponse.success(postService.findById(postId));
     }
 
+    @Operation(summary = "게시글 수정")
+    @CommonErrorResponses
+    @ForbiddenResponse
+    @NotFoundPostResponse
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공")
+    })
     @PatchMapping("/{postId}")
     public ApiResponse<PostResponse> update(
         @RequestHeader("X-User-Id") Long userId,
-        @PathVariable Long postId,
+        @Parameter(description = "게시글 ID", example = "1") @PathVariable Long postId,
         @RequestBody @Valid PostUpdateRequest request
     ) {
         return ApiResponse.success(postService.update(userId, postId, request));
     }
 
+    @Operation(summary = "게시글 삭제")
+    @CommonErrorResponses
+    @ForbiddenResponse
+    @NotFoundPostResponse
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "삭제 성공", content = @Content)
+    })
     @DeleteMapping("/{postId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(
         @RequestHeader("X-User-Id") Long userId,
-        @PathVariable Long postId
+        @Parameter(description = "게시글 ID", example = "1") @PathVariable Long postId
     ) {
         postService.delete(userId, postId);
     }
 
+    @Operation(summary = "게시글 숨김", description = "PUBLISHED 상태의 게시글을 HIDDEN으로 전환합니다. 이미 숨김 처리된 경우 409.")
+    @CommonErrorResponses
+    @ForbiddenResponse
+    @NotFoundPostResponse
+    @ConflictAlreadyHidden
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "숨김 성공")
+    })
     @PostMapping("/{postId}/hide")
     public ApiResponse<PostResponse> hide(
         @RequestHeader("X-User-Id") Long userId,
-        @PathVariable Long postId
+        @Parameter(description = "게시글 ID", example = "1") @PathVariable Long postId
     ) {
         return ApiResponse.success(postService.hidePost(userId, postId));
     }
 
+    @Operation(summary = "게시글 신고", description = "게시글을 신고합니다. 자신의 게시글 신고 불가(R003), 중복 신고 불가(R002).")
+    @CommonErrorResponses
+    @ConflictAlreadyReported
+    @NotFoundPostResponse
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "신고 접수 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "잘못된 신고 대상(R001) 또는 자신의 게시글 신고(R003)",
+            content = @Content(
+                schema = @Schema(implementation = ErrorApiResponse.class),
+                examples = {
+                    @ExampleObject(name = "R001", value = "{\"status\":\"error\",\"message\":\"유효하지 않은 신고 대상입니다.\",\"data\":null}"),
+                    @ExampleObject(name = "R003", value = "{\"status\":\"error\",\"message\":\"자신의 게시물/댓글은 신고할 수 없습니다.\",\"data\":null}")
+                }
+            )
+        )
+    })
     @PostMapping("/{postId}/reports")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<ReportResponse> reportPost(
         @RequestHeader("X-User-Id") Long reporterId,
-        @PathVariable Long postId,
+        @Parameter(description = "게시글 ID", example = "1") @PathVariable Long postId,
         @RequestBody @Valid ReportPostRequest request
     ) {
         return ApiResponse.success(reportService.reportPost(reporterId, postId, request));

--- a/jihoonkang/src/main/java/com/example/blog/domain/post/dto/PostCreateRequest.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/post/dto/PostCreateRequest.java
@@ -1,16 +1,21 @@
 package com.example.blog.domain.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "게시글 작성 요청")
 public record PostCreateRequest(
 
+    @Schema(description = "제목", example = "Spring Boot로 블로그 만들기", requiredMode = Schema.RequiredMode.REQUIRED, maxLength = 200)
     @NotBlank(message = "제목은 필수입니다.")
     @Size(max = 200, message = "제목은 200자 이하여야 합니다.")
     String title,
 
+    @Schema(description = "본문", example = "오늘은 Spring Boot 3.x와 springdoc으로 Swagger를 적용해보았습니다.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     String content,
 
+    @Schema(description = "게시 상태 (미지정 시 PUBLISHED)", example = "PUBLISHED", requiredMode = Schema.RequiredMode.NOT_REQUIRED, allowableValues = {"PUBLISHED", "HIDDEN"})
     String status
 
 ) {}

--- a/jihoonkang/src/main/java/com/example/blog/domain/post/dto/PostListResponse.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/post/dto/PostListResponse.java
@@ -1,10 +1,13 @@
 package com.example.blog.domain.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "게시글 목록 응답 (페이지네이션)")
 public record PostListResponse(
-    List<PostResponse> items,
-    int page,
-    int size,
-    long totalElements
+    @Schema(description = "게시글 목록") List<PostResponse> items,
+    @Schema(description = "현재 페이지 (0부터 시작)", example = "0") int page,
+    @Schema(description = "페이지 크기", example = "10") int size,
+    @Schema(description = "전체 게시글 수", example = "42") long totalElements
 ) {}

--- a/jihoonkang/src/main/java/com/example/blog/domain/post/dto/PostResponse.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/post/dto/PostResponse.java
@@ -1,18 +1,20 @@
 package com.example.blog.domain.post.dto;
 
 import com.example.blog.domain.post.entity.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "게시글 응답")
 public record PostResponse(
-    Long postId,
-    Long userId,
-    String username,
-    String title,
-    String content,
-    String status,
-    LocalDateTime createdAt,
-    LocalDateTime updatedAt
+    @Schema(description = "게시글 ID", example = "1") Long postId,
+    @Schema(description = "작성자 ID", example = "1") Long userId,
+    @Schema(description = "작성자 이름", example = "지훈") String username,
+    @Schema(description = "제목", example = "Spring Boot로 블로그 만들기") String title,
+    @Schema(description = "본문", example = "오늘은 Swagger를 적용해보았습니다.") String content,
+    @Schema(description = "게시 상태", example = "PUBLISHED", allowableValues = {"PUBLISHED", "HIDDEN"}) String status,
+    @Schema(description = "생성 시각", example = "2026-05-04T10:30:00") LocalDateTime createdAt,
+    @Schema(description = "수정 시각", example = "2026-05-04T10:30:00") LocalDateTime updatedAt
 ) {
 
     public static PostResponse from(Post post) {

--- a/jihoonkang/src/main/java/com/example/blog/domain/post/dto/PostUpdateRequest.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/post/dto/PostUpdateRequest.java
@@ -1,14 +1,19 @@
 package com.example.blog.domain.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "게시글 수정 요청 (변경할 필드만 포함)")
 public record PostUpdateRequest(
 
+    @Schema(description = "수정할 제목", example = "수정된 제목", requiredMode = Schema.RequiredMode.NOT_REQUIRED, maxLength = 200)
     @Size(max = 200, message = "제목은 200자 이하여야 합니다.")
     String title,
 
+    @Schema(description = "수정할 본문", example = "수정된 본문 내용", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     String content,
 
+    @Schema(description = "수정할 게시 상태", example = "HIDDEN", requiredMode = Schema.RequiredMode.NOT_REQUIRED, allowableValues = {"PUBLISHED", "HIDDEN"})
     String status
 
 ) {}

--- a/jihoonkang/src/main/java/com/example/blog/domain/report/controller/ReportController.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/report/controller/ReportController.java
@@ -3,11 +3,22 @@ package com.example.blog.domain.report.controller;
 import com.example.blog.domain.report.dto.ReportResponse;
 import com.example.blog.domain.report.service.ReportService;
 import com.example.blog.global.response.ApiResponse;
+import com.example.blog.global.response.ErrorApiResponse;
+import com.example.blog.global.swagger.CommonErrorResponses;
+import com.example.blog.global.swagger.ConflictReportResolved;
+import com.example.blog.global.swagger.ForbiddenResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "신고 관리", description = "신고 처리 (관리자 전용)")
 @RestController
 @RequestMapping("/api/v1/reports")
 @RequiredArgsConstructor
@@ -15,14 +26,31 @@ public class ReportController {
 
     private final ReportService reportService;
 
+    @Operation(summary = "신고 처리", description = "PENDING 상태의 신고를 RESOLVED로 처리합니다. 관리자 전용.")
+    @CommonErrorResponses
+    @ForbiddenResponse
+    @ConflictReportResolved
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "처리 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "신고를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorApiResponse.class))
+        )
+    })
     @PostMapping("/{reportId}/resolve")
     public ApiResponse<ReportResponse> resolve(
         @RequestHeader("X-User-Id") Long handlerId,
-        @PathVariable Long reportId
+        @Parameter(description = "신고 ID", example = "1") @PathVariable Long reportId
     ) {
         return ApiResponse.success(reportService.resolveReport(handlerId, reportId));
     }
 
+    @Operation(summary = "신고 목록 조회", description = "전체 신고 목록을 조회합니다. 관리자 전용.")
+    @CommonErrorResponses
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
     @GetMapping
     public ApiResponse<List<ReportResponse>> findAll() {
         return ApiResponse.success(reportService.findAll());

--- a/jihoonkang/src/main/java/com/example/blog/domain/report/dto/ReportCommentRequest.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/report/dto/ReportCommentRequest.java
@@ -1,8 +1,11 @@
 package com.example.blog.domain.report.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "댓글 신고 요청")
 public record ReportCommentRequest(
+    @Schema(description = "신고 사유", example = "욕설이 포함된 댓글입니다.", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "신고 사유는 필수입니다.")
     String reason
 ) {}

--- a/jihoonkang/src/main/java/com/example/blog/domain/report/dto/ReportPostRequest.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/report/dto/ReportPostRequest.java
@@ -1,8 +1,11 @@
 package com.example.blog.domain.report.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "게시글 신고 요청")
 public record ReportPostRequest(
+    @Schema(description = "신고 사유", example = "부적절한 광고 게시글입니다.", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "신고 사유는 필수입니다.")
     String reason
 ) {}

--- a/jihoonkang/src/main/java/com/example/blog/domain/report/dto/ReportResponse.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/report/dto/ReportResponse.java
@@ -2,19 +2,21 @@ package com.example.blog.domain.report.dto;
 
 import com.example.blog.domain.report.entity.Report;
 import com.example.blog.domain.report.entity.ReportStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "신고 응답")
 public record ReportResponse(
-    Long reportId,
-    Long reporterId,
-    String reporterUsername,
-    String targetType,
-    Long targetId,
-    String reason,
-    ReportStatus status,
-    LocalDateTime resolvedAt,
-    LocalDateTime createdAt
+    @Schema(description = "신고 ID", example = "1") Long reportId,
+    @Schema(description = "신고자 ID", example = "2") Long reporterId,
+    @Schema(description = "신고자 이름", example = "홍길동") String reporterUsername,
+    @Schema(description = "신고 대상 타입", example = "POST", allowableValues = {"POST", "COMMENT"}) String targetType,
+    @Schema(description = "신고 대상 ID", example = "1") Long targetId,
+    @Schema(description = "신고 사유", example = "부적절한 광고 게시글입니다.") String reason,
+    @Schema(description = "신고 처리 상태", example = "PENDING", allowableValues = {"PENDING", "RESOLVED"}) ReportStatus status,
+    @Schema(description = "처리 완료 시각 (PENDING이면 null)", nullable = true, example = "2026-05-04T11:00:00") LocalDateTime resolvedAt,
+    @Schema(description = "신고 접수 시각", example = "2026-05-04T10:30:00") LocalDateTime createdAt
 ) {
 
     public static ReportResponse from(Report report) {

--- a/jihoonkang/src/main/java/com/example/blog/domain/user/controller/UserController.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/user/controller/UserController.java
@@ -5,11 +5,22 @@ import com.example.blog.domain.user.dto.UserResponse;
 import com.example.blog.domain.user.dto.UserUpdateRequest;
 import com.example.blog.domain.user.service.UserService;
 import com.example.blog.global.response.ApiResponse;
+import com.example.blog.global.response.ErrorApiResponse;
+import com.example.blog.global.swagger.CommonErrorResponses;
+import com.example.blog.global.swagger.NotFoundUserResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "사용자", description = "사용자 가입/조회/수정/탈퇴")
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -17,28 +28,63 @@ public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "사용자 가입", description = "이메일/비밀번호/이름으로 신규 가입합니다.")
+    @CommonErrorResponses
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "가입 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "409",
+            description = "이메일 중복 (U002)",
+            content = @Content(
+                schema = @Schema(implementation = ErrorApiResponse.class),
+                examples = @ExampleObject(value = "{\"status\":\"error\",\"message\":\"이미 사용 중인 이메일입니다.\",\"data\":null}")
+            )
+        )
+    })
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<UserResponse> create(@RequestBody @Valid UserCreateRequest request) {
         return ApiResponse.success(userService.create(request));
     }
 
+    @Operation(summary = "사용자 단건 조회")
+    @CommonErrorResponses
+    @NotFoundUserResponse
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
     @GetMapping("/{userId}")
-    public ApiResponse<UserResponse> findById(@PathVariable Long userId) {
+    public ApiResponse<UserResponse> findById(
+        @Parameter(description = "사용자 ID", example = "1") @PathVariable Long userId
+    ) {
         return ApiResponse.success(userService.findById(userId));
     }
 
+    @Operation(summary = "사용자 정보 수정")
+    @CommonErrorResponses
+    @NotFoundUserResponse
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공")
+    })
     @PatchMapping("/{userId}")
     public ApiResponse<UserResponse> update(
-        @PathVariable Long userId,
+        @Parameter(description = "사용자 ID", example = "1") @PathVariable Long userId,
         @RequestBody @Valid UserUpdateRequest request
     ) {
         return ApiResponse.success(userService.update(userId, request));
     }
 
+    @Operation(summary = "사용자 탈퇴")
+    @CommonErrorResponses
+    @NotFoundUserResponse
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "탈퇴 성공", content = @Content)
+    })
     @DeleteMapping("/{userId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable Long userId) {
+    public void delete(
+        @Parameter(description = "사용자 ID", example = "1") @PathVariable Long userId
+    ) {
         userService.delete(userId);
     }
 }

--- a/jihoonkang/src/main/java/com/example/blog/domain/user/dto/UserCreateRequest.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/user/dto/UserCreateRequest.java
@@ -1,24 +1,30 @@
 package com.example.blog.domain.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "사용자 가입 요청")
 public record UserCreateRequest(
 
+    @Schema(description = "사용자 표시 이름", example = "지훈", requiredMode = Schema.RequiredMode.REQUIRED, maxLength = 50)
     @NotBlank(message = "이름은 필수입니다.")
     @Size(max = 50, message = "이름은 50자 이하여야 합니다.")
     String username,
 
+    @Schema(description = "이메일", example = "jihoon@example.com", requiredMode = Schema.RequiredMode.REQUIRED, format = "email", maxLength = 100)
     @NotBlank(message = "이메일은 필수입니다.")
     @Email(message = "이메일 형식이 올바르지 않습니다.")
     @Size(max = 100, message = "이메일은 100자 이하여야 합니다.")
     String email,
 
+    @Schema(description = "비밀번호 (평문)", example = "P@ssw0rd!", requiredMode = Schema.RequiredMode.REQUIRED, maxLength = 200, accessMode = Schema.AccessMode.WRITE_ONLY)
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Size(max = 200, message = "비밀번호는 200자 이하여야 합니다.")
     String password,
 
+    @Schema(description = "프로필 이미지 URL (선택)", example = "https://cdn.example.com/u/1.png", requiredMode = Schema.RequiredMode.NOT_REQUIRED, maxLength = 200)
     @Size(max = 200, message = "프로필 URL은 200자 이하여야 합니다.")
     String profileUrl
 

--- a/jihoonkang/src/main/java/com/example/blog/domain/user/dto/UserResponse.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/user/dto/UserResponse.java
@@ -1,16 +1,18 @@
 package com.example.blog.domain.user.dto;
 
 import com.example.blog.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "사용자 응답")
 public record UserResponse(
-    Long userId,
-    String username,
-    String email,
-    String profileUrl,
-    LocalDateTime createdAt,
-    LocalDateTime updatedAt
+    @Schema(description = "사용자 ID", example = "1") Long userId,
+    @Schema(description = "표시 이름", example = "지훈") String username,
+    @Schema(description = "이메일", example = "jihoon@example.com") String email,
+    @Schema(description = "프로필 이미지 URL", nullable = true, example = "https://cdn.example.com/u/1.png") String profileUrl,
+    @Schema(description = "생성 시각", example = "2026-05-04T10:30:00") LocalDateTime createdAt,
+    @Schema(description = "수정 시각", example = "2026-05-04T10:30:00") LocalDateTime updatedAt
 ) {
 
     public static UserResponse from(User user) {

--- a/jihoonkang/src/main/java/com/example/blog/domain/user/dto/UserUpdateRequest.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/user/dto/UserUpdateRequest.java
@@ -1,12 +1,16 @@
 package com.example.blog.domain.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "사용자 정보 수정 요청 (변경할 필드만 포함)")
 public record UserUpdateRequest(
 
+    @Schema(description = "수정할 이름", example = "지훈변경", requiredMode = Schema.RequiredMode.NOT_REQUIRED, maxLength = 50)
     @Size(max = 50, message = "이름은 50자 이하여야 합니다.")
     String username,
 
+    @Schema(description = "수정할 프로필 이미지 URL", example = "https://cdn.example.com/u/2.png", requiredMode = Schema.RequiredMode.NOT_REQUIRED, maxLength = 200)
     @Size(max = 200, message = "프로필 URL은 200자 이하여야 합니다.")
     String profileUrl
 

--- a/jihoonkang/src/main/java/com/example/blog/global/config/SwaggerConfig.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/config/SwaggerConfig.java
@@ -1,0 +1,56 @@
+package com.example.blog.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    static final String SECURITY_SCHEME_NAME = "X-User-Id";
+
+    @Bean
+    public OpenAPI blogOpenAPI() {
+        return new OpenAPI()
+            .info(apiInfo())
+            .servers(List.of(
+                new Server().url("http://localhost:8080").description("Local 개발 서버")
+            ))
+            .components(new Components()
+                .addSecuritySchemes(SECURITY_SCHEME_NAME, apiKeySecurityScheme()))
+            .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME));
+    }
+
+    private Info apiInfo() {
+        return new Info()
+            .title("Leets 7기 BE 블로그 API")
+            .description("""
+                블로그 도메인 REST API 명세서.
+                - 인증: X-User-Id 헤더로 사용자 식별 (우상단 Authorize 버튼에서 입력)
+                - 응답 형식: ApiResponse<T> 래퍼 (status / message / data)
+                - 에러 코드: U001/U002, P001/P002, C001/C002, A001, R001~R004
+                """)
+            .version("v1.0.0")
+            .contact(new Contact()
+                .name("jihoonkang")
+                .email("ivory.ma9ic@gmail.com"))
+            .license(new License().name("MIT").url("https://opensource.org/licenses/MIT"));
+    }
+
+    private SecurityScheme apiKeySecurityScheme() {
+        return new SecurityScheme()
+            .type(SecurityScheme.Type.APIKEY)
+            .in(SecurityScheme.In.HEADER)
+            .name(SECURITY_SCHEME_NAME)
+            .description("사용자 식별 헤더. 숫자 userId를 입력하세요 (예: 1)");
+    }
+}

--- a/jihoonkang/src/main/java/com/example/blog/global/response/ApiResponse.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/response/ApiResponse.java
@@ -1,14 +1,21 @@
 package com.example.blog.global.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Schema(description = "공통 응답 래퍼")
 public class ApiResponse<T> {
 
+    @Schema(description = "처리 상태", example = "success", allowableValues = {"success", "error"})
     private String status;
+
+    @Schema(description = "응답 메시지", example = "요청이 성공적으로 처리되었습니다.")
     private String message;
+
+    @Schema(description = "응답 데이터 (status=error 시 null)")
     private T data;
 
     public static <T> ApiResponse<T> success(T data) {

--- a/jihoonkang/src/main/java/com/example/blog/global/response/ErrorApiResponse.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/response/ErrorApiResponse.java
@@ -1,0 +1,19 @@
+package com.example.blog.global.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    description = "에러 응답 래퍼 (status=error, data=null)",
+    example = "{\"status\":\"error\",\"message\":\"오류 메시지\",\"data\":null}"
+)
+public class ErrorApiResponse {
+
+    @Schema(description = "처리 상태", example = "error")
+    private String status;
+
+    @Schema(description = "오류 메시지", example = "사용자를 찾을 수 없습니다.")
+    private String message;
+
+    @Schema(description = "응답 데이터 (항상 null)", nullable = true, example = "null")
+    private Object data;
+}

--- a/jihoonkang/src/main/java/com/example/blog/global/swagger/CommonErrorResponses.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/swagger/CommonErrorResponses.java
@@ -1,0 +1,29 @@
+package com.example.blog.global.swagger;
+
+import com.example.blog.global.response.ErrorApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "400",
+        description = "유효성 검증 실패 또는 잘못된 요청",
+        content = @Content(schema = @Schema(implementation = ErrorApiResponse.class))
+    ),
+    @ApiResponse(
+        responseCode = "500",
+        description = "서버 내부 오류",
+        content = @Content(schema = @Schema(implementation = ErrorApiResponse.class))
+    )
+})
+public @interface CommonErrorResponses {
+}

--- a/jihoonkang/src/main/java/com/example/blog/global/swagger/ConflictAlreadyHidden.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/swagger/ConflictAlreadyHidden.java
@@ -1,0 +1,25 @@
+package com.example.blog.global.swagger;
+
+import com.example.blog.global.response.ErrorApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "409",
+    description = "이미 숨김 처리된 게시글 (P002)",
+    content = @Content(
+        schema = @Schema(implementation = ErrorApiResponse.class),
+        examples = @ExampleObject(value = "{\"status\":\"error\",\"message\":\"이미 숨김 처리된 게시물입니다.\",\"data\":null}")
+    )
+)
+public @interface ConflictAlreadyHidden {
+}

--- a/jihoonkang/src/main/java/com/example/blog/global/swagger/ConflictAlreadyReported.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/swagger/ConflictAlreadyReported.java
@@ -1,0 +1,25 @@
+package com.example.blog.global.swagger;
+
+import com.example.blog.global.response.ErrorApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "409",
+    description = "이미 신고한 대상 (R002)",
+    content = @Content(
+        schema = @Schema(implementation = ErrorApiResponse.class),
+        examples = @ExampleObject(value = "{\"status\":\"error\",\"message\":\"이미 신고한 대상입니다.\",\"data\":null}")
+    )
+)
+public @interface ConflictAlreadyReported {
+}

--- a/jihoonkang/src/main/java/com/example/blog/global/swagger/ConflictReportResolved.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/swagger/ConflictReportResolved.java
@@ -1,0 +1,25 @@
+package com.example.blog.global.swagger;
+
+import com.example.blog.global.response.ErrorApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "409",
+    description = "이미 처리된 신고 (R004)",
+    content = @Content(
+        schema = @Schema(implementation = ErrorApiResponse.class),
+        examples = @ExampleObject(value = "{\"status\":\"error\",\"message\":\"이미 처리된 신고입니다.\",\"data\":null}")
+    )
+)
+public @interface ConflictReportResolved {
+}

--- a/jihoonkang/src/main/java/com/example/blog/global/swagger/ForbiddenResponse.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/swagger/ForbiddenResponse.java
@@ -1,0 +1,25 @@
+package com.example.blog.global.swagger;
+
+import com.example.blog.global.response.ErrorApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "403",
+    description = "접근 권한 없음 (A001)",
+    content = @Content(
+        schema = @Schema(implementation = ErrorApiResponse.class),
+        examples = @ExampleObject(value = "{\"status\":\"error\",\"message\":\"접근 권한이 없습니다.\",\"data\":null}")
+    )
+)
+public @interface ForbiddenResponse {
+}

--- a/jihoonkang/src/main/java/com/example/blog/global/swagger/NotFoundCommentResponse.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/swagger/NotFoundCommentResponse.java
@@ -1,0 +1,25 @@
+package com.example.blog.global.swagger;
+
+import com.example.blog.global.response.ErrorApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "404",
+    description = "댓글을 찾을 수 없음 (C001)",
+    content = @Content(
+        schema = @Schema(implementation = ErrorApiResponse.class),
+        examples = @ExampleObject(value = "{\"status\":\"error\",\"message\":\"댓글을 찾을 수 없습니다.\",\"data\":null}")
+    )
+)
+public @interface NotFoundCommentResponse {
+}

--- a/jihoonkang/src/main/java/com/example/blog/global/swagger/NotFoundPostResponse.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/swagger/NotFoundPostResponse.java
@@ -1,0 +1,25 @@
+package com.example.blog.global.swagger;
+
+import com.example.blog.global.response.ErrorApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "404",
+    description = "게시글을 찾을 수 없음 (P001)",
+    content = @Content(
+        schema = @Schema(implementation = ErrorApiResponse.class),
+        examples = @ExampleObject(value = "{\"status\":\"error\",\"message\":\"게시글을 찾을 수 없습니다.\",\"data\":null}")
+    )
+)
+public @interface NotFoundPostResponse {
+}

--- a/jihoonkang/src/main/java/com/example/blog/global/swagger/NotFoundUserResponse.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/swagger/NotFoundUserResponse.java
@@ -1,0 +1,25 @@
+package com.example.blog.global.swagger;
+
+import com.example.blog.global.response.ErrorApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "404",
+    description = "사용자를 찾을 수 없음 (U001)",
+    content = @Content(
+        schema = @Schema(implementation = ErrorApiResponse.class),
+        examples = @ExampleObject(value = "{\"status\":\"error\",\"message\":\"사용자를 찾을 수 없습니다.\",\"data\":null}")
+    )
+)
+public @interface NotFoundUserResponse {
+}

--- a/jihoonkang/src/main/resources/application.properties
+++ b/jihoonkang/src/main/resources/application.properties
@@ -13,3 +13,12 @@ spring.h2.console.enabled=true
 spring.jackson.property-naming-strategy=SNAKE_CASE
 
 springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.tags-sorter=alpha
+springdoc.swagger-ui.operations-sorter=method
+springdoc.swagger-ui.try-it-out-enabled=true
+springdoc.default-produces-media-type=application/json
+springdoc.default-consumes-media-type=application/json
+springdoc.packages-to-scan=com.example.blog
+springdoc.swagger-ui.default-models-expand-depth=2
+springdoc.swagger-ui.default-model-expand-depth=2


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

- [x] `SwaggerConfig` Bean — `Info`, `Server`, X-User-Id ApiKey `SecurityScheme`, 글로벌 `SecurityRequirement` 정의
- [x] `application.properties` springdoc 설정 9종 추가 (tags-sorter, operations-sorter, try-it-out-enabled, packages-to-scan, default-model-expand-depth 등)
- [x] `ApiResponse<T>` 필드에 `@Schema` 부여 및 `ErrorApiResponse` 슈가 클래스 도입
- [x] 에러 응답 메타애노테이션 8종 도입 (`CommonErrorResponses`, `ForbiddenResponse`, `NotFoundXxxResponse`, `ConflictXxx`)
- [x] 컨트롤러 5종에 `@Tag` / `@Operation` / `@ApiResponses` / `@Parameter` 적용
- [x] DTO 11종에 `@Schema(description, example, requiredMode, allowableValues, accessMode)` 적용
- [x] `http://localhost:8080/swagger-ui.html` 에서 26개 엔드포인트 Try it out 검증 완료


## 2. 핵심 변경 사항

**신규 생성**
- `global/config/SwaggerConfig.java` — OpenAPI Bean, X-User-Id ApiKey SecurityScheme
- `global/response/ErrorApiResponse.java` — 에러 응답 스키마 고정용 독립 POJO
- `global/swagger/CommonErrorResponses.java` 외 7종 — 에러 응답 메타애노테이션

**수정**
- `application.properties` — springdoc 설정 9종 추가
- `global/response/ApiResponse.java` — 클래스/필드 `@Schema` 부여
- `HealthController`, `UserController`, `PostController`, `CommentController`, `ReportController` — `@Tag` / `@Operation` / `@ApiResponses` 적용
- `UserCreateRequest` 외 10개 DTO record — `@Schema` 적용

**설계 결정 사유**
- SecurityScheme을 Bearer가 아닌 APIKEY/HEADER로 채택 → 실제 인증이 단순 헤더 기반이므로 거짓 모델링 회피
- 글로벌 `SecurityRequirement` 적용 → 각 메서드에 `@Parameter(in=HEADER)` 중복 불필요, 인증 불필요 엔드포인트만 `@SecurityRequirements({})` 예외 처리
- 메타애노테이션으로 에러 응답 중복 제거 → 컨트롤러 메서드당 4~5줄 `@ApiResponses` 블록을 1~2줄로 압축


## 3. 실행 및 검증 결과

```
./gradlew bootRun
```

- `GET /api/v1/health` 응답: `ok` (200, 자물쇠 없음 확인)
- `POST /api/v1/users` 응답: 201 + `{"status":"success","message":"...","data":{"user_id":1,"username":"...","email":"...","created_at":"2026-05-04T10:30:00"}}`
- `GET /api/v1/users/9999` 응답: 404 + `{"status":"error","message":"사용자를 찾을 수 없습니다.","data":null}`
- `/v3/api-docs` JSON: `info.title = "Leets 7기 BE 블로그 API"`, `components.securitySchemes."X-User-Id"` 존재 확인
- Swagger UI: 5개 Tag(게시글/댓글/사용자/신고 관리/헬스체크) 알파벳 정렬, Authorize 버튼 정상 동작


## 4. 완료 사항

1. SwaggerConfig Bean 및 application.properties springdoc 설정
2. ApiResponse @Schema 정비 및 ErrorApiResponse 도입
3. 에러 응답 메타애노테이션 8종 (global/swagger 패키지)
4. 컨트롤러 5종 @Tag/@Operation/@ApiResponses 적용
5. DTO 11종 @Schema 적용
6. 컴파일 에러 2건 수정 — Lombok @AllArgsConstructor 상속 충돌, ApiResponse 이름 충돌(FQCN으로 해결)


## 5. 추가 사항

- 관련 이슈: `closed #176`
- `ErrorApiResponse extends ApiResponse<Void>` 시도 시 Lombok `@AllArgsConstructor`가 부모 생성자를 상속받지 못해 컴파일 에러 발생 → 독립 POJO로 변경
- springdoc 2.7은 Jackson SNAKE_CASE 전략을 자동 인식하므로 `@Schema(name=...)` 강제 매핑 없이 snake_case 필드 노출 가능


## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `강지훈/main` 브랜치다
- [x] compare가 `강지훈/5주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [ ] 본인을 Assignee로 지정했다
- [ ] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고

<!--
BE: rootTiket, soyesenna
FE: One-HyeWon, woneeee
-->