### PR TITLE
[5주차] 김다인/[feat] Swagger 문서화

### DIFF
--- a/kimdain/build.gradle
+++ b/kimdain/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 }
 
 tasks.named('test') {

--- a/kimdain/src/main/resources/application.properties
+++ b/kimdain/src/main/resources/application.properties
@@ -5,3 +5,8 @@ spring.profiles.include=local
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+# Swagger ??
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.display-request-duration=true


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용
 - [] 기존에 구현 중인 서버 프로젝트에 Swagger를 추가한다.
 - [] 실행 후 Swagger UI 페이지에 접속할 수 있어야 한다.
 - [] 현재 프로젝트에 구현되어 있는 API가 Swagger 문서에 표시되어야 한다.
 - [] 문서를 보고 각 API의 요청 방식과 URL, 요청값, 응답값을 확인할 수 있어야 한다.

## 2. 핵심 변경 사항
기존 프로젝트에 Swagger 의존성 및 설정을 추가하여 API를 문서화

## 3. 실행 및 검증 결과
<img width="2251" height="1338" alt="스크린샷(5)" src="https://github.com/user-attachments/assets/30c2369a-6909-4148-8208-368cfdcb6d7e" />

<img width="1248" height="1314" alt="스크린샷(6)" src="https://github.com/user-attachments/assets/48c4c489-e3c5-450a-8aa5-12489304b4dd" />

<img width="1229" height="828" alt="스크린샷(7)" src="https://github.com/user-attachments/assets/a4d85827-3437-486c-807f-331fd86f8583" />

## 4. 완료 사항
Swagger 문서화

## 5. 추가 사항
- 관련 이슈: closed #178


## 제출 체크리스트
- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고