### PR TITLE
[5주차] 시재욱/[feat] Swagger 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/demo/comment/controller/CommentController.java
+++ b/src/main/java/com/example/demo/comment/controller/CommentController.java
@@ -7,6 +7,9 @@ import com.example.demo.comment.service.CommentService;
 import com.example.demo.global.exception.ApiResponse;
 import com.example.demo.global.exception.BaseCode;
 import com.example.demo.global.exception.ResponseUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Map;
 
+@Tag(name = "Comment", description = "댓글 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/comments")
@@ -21,7 +25,11 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    //댓글 생성
+    // 댓글 생성
+    @Operation(
+            summary = "댓글 생성 API",
+            description = "게시글에 댓글을 생성합니다."
+    )
     @PostMapping
     public ApiResponse<Map<String, Long>> create(
             @RequestBody @Valid CommentCreateRequest request) {
@@ -34,9 +42,14 @@ public class CommentController {
         );
     }
 
-    //특정 게시글 댓글 조회
+    // 특정 게시글 댓글 조회
+    @Operation(
+            summary = "특정 게시글 댓글 조회 API",
+            description = "postId에 해당하는 게시글의 댓글 목록을 조회합니다."
+    )
     @GetMapping("/post/{postId}")
     public ApiResponse<List<CommentResponse>> getComments(
+            @Parameter(description = "게시글 ID", example = "1")
             @PathVariable Long postId) {
 
         return ResponseUtil.success(
@@ -45,10 +58,16 @@ public class CommentController {
         );
     }
 
-    //댓글 수정
+    // 댓글 수정
+    @Operation(
+            summary = "댓글 수정 API",
+            description = "commentId에 해당하는 댓글 내용을 수정합니다."
+    )
     @PutMapping("/{commentId}")
     public ApiResponse<Void> update(
+            @Parameter(description = "댓글 ID", example = "1")
             @PathVariable Long commentId,
+
             @RequestBody @Valid CommentUpdateRequest request) {
 
         commentService.updateComment(commentId, request);
@@ -59,9 +78,14 @@ public class CommentController {
         );
     }
 
-    //댓글 삭제
+    // 댓글 삭제
+    @Operation(
+            summary = "댓글 삭제 API",
+            description = "commentId에 해당하는 댓글을 삭제합니다."
+    )
     @DeleteMapping("/{commentId}")
     public ApiResponse<Map<String, Long>> delete(
+            @Parameter(description = "댓글 ID", example = "1")
             @PathVariable Long commentId) {
 
         commentService.deleteComment(commentId);

--- a/src/main/java/com/example/demo/comment/controller/CommentController.java
+++ b/src/main/java/com/example/demo/comment/controller/CommentController.java
@@ -7,9 +7,13 @@ import com.example.demo.comment.service.CommentService;
 import com.example.demo.global.exception.ApiResponse;
 import com.example.demo.global.exception.BaseCode;
 import com.example.demo.global.exception.ResponseUtil;
+import com.example.demo.global.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -30,6 +34,22 @@ public class CommentController {
             summary = "댓글 생성 API",
             description = "게시글에 댓글을 생성합니다."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 생성 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "유효성 검증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "유저 또는 게시글을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     @PostMapping
     public ApiResponse<Map<String, Long>> create(
             @RequestBody @Valid CommentCreateRequest request) {
@@ -47,6 +67,17 @@ public class CommentController {
             summary = "특정 게시글 댓글 조회 API",
             description = "postId에 해당하는 게시글의 댓글 목록을 조회합니다."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 조회 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "게시글을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     @GetMapping("/post/{postId}")
     public ApiResponse<List<CommentResponse>> getComments(
             @Parameter(description = "게시글 ID", example = "1")
@@ -63,11 +94,26 @@ public class CommentController {
             summary = "댓글 수정 API",
             description = "commentId에 해당하는 댓글 내용을 수정합니다."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 수정 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "유효성 검증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "댓글을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     @PutMapping("/{commentId}")
     public ApiResponse<Void> update(
             @Parameter(description = "댓글 ID", example = "1")
             @PathVariable Long commentId,
-
             @RequestBody @Valid CommentUpdateRequest request) {
 
         commentService.updateComment(commentId, request);
@@ -83,6 +129,17 @@ public class CommentController {
             summary = "댓글 삭제 API",
             description = "commentId에 해당하는 댓글을 삭제합니다."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 삭제 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "댓글을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     @DeleteMapping("/{commentId}")
     public ApiResponse<Map<String, Long>> delete(
             @Parameter(description = "댓글 ID", example = "1")

--- a/src/main/java/com/example/demo/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/com/example/demo/comment/dto/CommentCreateRequest.java
@@ -1,18 +1,23 @@
 package com.example.demo.comment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 @Getter
+@Schema(description = "댓글 생성 요청 DTO")
 public class CommentCreateRequest {
 
+    @Schema(description = "유저 ID", example = "1")
     @NotNull(message = "유저 ID는 필수입니다.")
     private Long userId;
 
+    @Schema(description = "게시글 ID", example = "10")
     @NotNull(message = "게시글 ID는 필수입니다.")
     private Long postId;
 
+    @Schema(description = "댓글 내용", example = "좋은 글이네요!")
     @NotBlank(message = "댓글 내용은 비어 있을 수 없습니다.")
     private String content;
 }

--- a/src/main/java/com/example/demo/comment/dto/CommentResponse.java
+++ b/src/main/java/com/example/demo/comment/dto/CommentResponse.java
@@ -1,12 +1,20 @@
 package com.example.demo.comment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "댓글 응답 DTO")
 public class CommentResponse {
+
+    @Schema(description = "댓글 ID", example = "1")
     private Long id;
+
+    @Schema(description = "댓글 내용", example = "좋은 글이네요!")
     private String content;
+
+    @Schema(description = "작성자 유저 ID", example = "5")
     private Long userId;
 }

--- a/src/main/java/com/example/demo/comment/dto/CommentUpdateRequest.java
+++ b/src/main/java/com/example/demo/comment/dto/CommentUpdateRequest.java
@@ -1,11 +1,14 @@
 package com.example.demo.comment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import jakarta.validation.constraints.NotBlank;
 
 @Getter
+@Schema(description = "댓글 수정 요청 DTO")
 public class CommentUpdateRequest {
 
+    @Schema(description = "수정할 댓글 내용", example = "수정된 댓글입니다.")
     @NotBlank(message = "댓글 내용은 비어 있을 수 없습니다.")
     private String content;
 }

--- a/src/main/java/com/example/demo/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/demo/global/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.example.demo.global.config;
+
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Demo API")
+                        .description("게시글 / 댓글 / 신고 API 문서")
+                        .version("v1.0.0"));
+    }
+}

--- a/src/main/java/com/example/demo/global/exception/ErrorResponse.java
+++ b/src/main/java/com/example/demo/global/exception/ErrorResponse.java
@@ -1,0 +1,21 @@
+package com.example.demo.global.exception;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "공통 에러 응답 DTO")
+public class ErrorResponse {
+
+    @Schema(description = "요청 성공 여부", example = "false")
+    private boolean success;
+
+    @Schema(description = "응답 코드", example = "USER_NOT_FOUND")
+    private String code;
+
+    @Schema(description = "응답 메시지", example = "유저를 찾을 수 없습니다.")
+    private String message;
+
+    @Schema(description = "응답 데이터", example = "null")
+    private Object data;
+}

--- a/src/main/java/com/example/demo/media/controller/MediaController.java
+++ b/src/main/java/com/example/demo/media/controller/MediaController.java
@@ -2,9 +2,13 @@ package com.example.demo.media.controller;
 
 import com.example.demo.media.dto.MediaResponse;
 import com.example.demo.media.service.MediaService;
+import com.example.demo.global.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -21,6 +25,22 @@ public class MediaController {
             summary = "미디어 파일 업로드 API",
             description = "이미지 등의 미디어 파일을 업로드하고, 저장된 파일 정보를 반환합니다."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "파일 업로드 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 파일 요청 (파일 없음 / 형식 오류)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류 (파일 저장 실패)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     @PostMapping("/upload")
     public MediaResponse upload(
             @Parameter(description = "업로드할 파일", required = true)

--- a/src/main/java/com/example/demo/media/controller/MediaController.java
+++ b/src/main/java/com/example/demo/media/controller/MediaController.java
@@ -2,10 +2,14 @@ package com.example.demo.media.controller;
 
 import com.example.demo.media.dto.MediaResponse;
 import com.example.demo.media.service.MediaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+@Tag(name = "Media", description = "미디어 파일 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/media")
@@ -13,8 +17,15 @@ public class MediaController {
 
     private final MediaService mediaService;
 
+    @Operation(
+            summary = "미디어 파일 업로드 API",
+            description = "이미지 등의 미디어 파일을 업로드하고, 저장된 파일 정보를 반환합니다."
+    )
     @PostMapping("/upload")
-    public MediaResponse upload(@RequestParam("file") MultipartFile file) {
+    public MediaResponse upload(
+            @Parameter(description = "업로드할 파일", required = true)
+            @RequestParam("file") MultipartFile file) {
+
         return mediaService.upload(file);
     }
 }

--- a/src/main/java/com/example/demo/media/dto/MediaResponse.java
+++ b/src/main/java/com/example/demo/media/dto/MediaResponse.java
@@ -1,11 +1,17 @@
 package com.example.demo.media.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "미디어 업로드 응답 DTO")
 public class MediaResponse {
+
+    @Schema(description = "미디어 ID", example = "1")
     private Long id;
+
+    @Schema(description = "저장된 파일 접근 URL", example = "http://localhost:8080/images/example.jpg")
     private String url;
 }

--- a/src/main/java/com/example/demo/post/controller/PostController.java
+++ b/src/main/java/com/example/demo/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.example.demo.post.controller;
 
 import com.example.demo.global.exception.ApiResponse;
 import com.example.demo.global.exception.BaseCode;
+import com.example.demo.global.exception.ErrorResponse;
 import com.example.demo.global.exception.ResponseUtil;
 import com.example.demo.post.dto.PostCreateRequest;
 import com.example.demo.post.dto.PostDetailResponse;
@@ -9,6 +10,9 @@ import com.example.demo.post.dto.PostResponse;
 import com.example.demo.post.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +33,22 @@ public class PostController {
             summary = "게시글 생성 API",
             description = "사용자가 새로운 게시글을 생성합니다."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 생성 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "유효성 검증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "유저 또는 미디어를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     @PostMapping
     public ApiResponse<PostResponse> create(
             @RequestBody @Valid PostCreateRequest request) {
@@ -44,6 +64,22 @@ public class PostController {
             summary = "게시글 수정 API",
             description = "postId에 해당하는 게시글을 수정합니다."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 수정 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "유효성 검증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "게시글 또는 미디어를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     @PutMapping("/{postId}")
     public ApiResponse<PostResponse> update(
             @Parameter(description = "게시글 ID", example = "1")
@@ -62,6 +98,17 @@ public class PostController {
             summary = "게시글 삭제 API",
             description = "postId에 해당하는 게시글을 삭제합니다."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 삭제 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "게시글을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     @DeleteMapping("/{postId}")
     public ApiResponse<Map<String, Long>> delete(
             @Parameter(description = "게시글 ID", example = "1")
@@ -78,6 +125,17 @@ public class PostController {
             summary = "게시글 상세 조회 API",
             description = "postId에 해당하는 게시글 상세 정보를 조회합니다."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 상세 조회 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "게시글을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     @GetMapping("/{postId}")
     public ApiResponse<PostDetailResponse> getPost(
             @Parameter(description = "게시글 ID", example = "1")

--- a/src/main/java/com/example/demo/post/controller/PostController.java
+++ b/src/main/java/com/example/demo/post/controller/PostController.java
@@ -7,12 +7,16 @@ import com.example.demo.post.dto.PostCreateRequest;
 import com.example.demo.post.dto.PostDetailResponse;
 import com.example.demo.post.dto.PostResponse;
 import com.example.demo.post.service.PostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
+@Tag(name = "Post", description = "게시글 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/posts")
@@ -20,7 +24,11 @@ public class PostController {
 
     private final PostService postService;
 
-    //게시글 생성
+    // 게시글 생성
+    @Operation(
+            summary = "게시글 생성 API",
+            description = "사용자가 새로운 게시글을 생성합니다."
+    )
     @PostMapping
     public ApiResponse<PostResponse> create(
             @RequestBody @Valid PostCreateRequest request) {
@@ -31,10 +39,16 @@ public class PostController {
         );
     }
 
-    //게시글 수정
+    // 게시글 수정
+    @Operation(
+            summary = "게시글 수정 API",
+            description = "postId에 해당하는 게시글을 수정합니다."
+    )
     @PutMapping("/{postId}")
     public ApiResponse<PostResponse> update(
+            @Parameter(description = "게시글 ID", example = "1")
             @PathVariable Long postId,
+
             @RequestBody @Valid PostCreateRequest request) {
 
         return ResponseUtil.success(
@@ -43,9 +57,14 @@ public class PostController {
         );
     }
 
-    //게시글 삭제
+    // 게시글 삭제
+    @Operation(
+            summary = "게시글 삭제 API",
+            description = "postId에 해당하는 게시글을 삭제합니다."
+    )
     @DeleteMapping("/{postId}")
     public ApiResponse<Map<String, Long>> delete(
+            @Parameter(description = "게시글 ID", example = "1")
             @PathVariable Long postId) {
 
         return ResponseUtil.success(
@@ -54,9 +73,15 @@ public class PostController {
         );
     }
 
-    //게시글 조회
+    // 게시글 조회
+    @Operation(
+            summary = "게시글 상세 조회 API",
+            description = "postId에 해당하는 게시글 상세 정보를 조회합니다."
+    )
     @GetMapping("/{postId}")
-    public ApiResponse<PostDetailResponse> getPost(@PathVariable Long postId) {
+    public ApiResponse<PostDetailResponse> getPost(
+            @Parameter(description = "게시글 ID", example = "1")
+            @PathVariable Long postId) {
 
         return ResponseUtil.success(
                 BaseCode.SUCCESS,

--- a/src/main/java/com/example/demo/post/dto/PostBlockDto.java
+++ b/src/main/java/com/example/demo/post/dto/PostBlockDto.java
@@ -1,11 +1,28 @@
 package com.example.demo.post.dto;
 
 import com.example.demo.post.entity.BlockType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@Schema(description = "게시글 블록 DTO (텍스트 또는 이미지 블록)")
 public class PostBlockDto {
+
+    @Schema(
+            description = "블록 타입",
+            example = "TEXT"
+    )
     private BlockType blockType;
+
+    @Schema(
+            description = "텍스트 내용 (blockType이 TEXT일 때 사용)",
+            example = "오늘 자취방 리뷰 남깁니다."
+    )
     private String textContent;
+
+    @Schema(
+            description = "미디어 ID (blockType이 IMAGE일 때 사용)",
+            example = "3"
+    )
     private Long mediaId;
 }

--- a/src/main/java/com/example/demo/post/dto/PostBlockResponse.java
+++ b/src/main/java/com/example/demo/post/dto/PostBlockResponse.java
@@ -1,14 +1,30 @@
 package com.example.demo.post.dto;
 
 import com.example.demo.post.entity.BlockType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "게시글 블록 응답 DTO")
 public class PostBlockResponse {
 
+    @Schema(
+            description = "블록 타입 (TEXT: 텍스트, IMAGE: 이미지)",
+            example = "TEXT"
+    )
     private BlockType blockType;
+
+    @Schema(
+            description = "텍스트 내용 (blockType이 TEXT일 때 사용)",
+            example = "오늘 자취방 리뷰 남깁니다."
+    )
     private String textContent;
+
+    @Schema(
+            description = "이미지 URL (blockType이 IMAGE일 때 사용)",
+            example = "http://localhost:8080/images/sample.jpg"
+    )
     private String imageUrl;
 }

--- a/src/main/java/com/example/demo/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/example/demo/post/dto/PostCreateRequest.java
@@ -1,24 +1,32 @@
 package com.example.demo.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 import java.util.List;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-
 @Getter
+@Schema(description = "게시글 생성 요청 DTO")
 public class PostCreateRequest {
 
+    @Schema(description = "작성자 유저 ID", example = "1")
     @NotNull(message = "유저 ID는 필수입니다.")
     private Long userId;
 
+    @Schema(description = "게시글 제목", example = "학교 근처 자취방 후기")
     @NotBlank(message = "제목은 비어 있을 수 없습니다.")
     private String title;
 
+    @Schema(description = "게시글 설명", example = "학교 근처 원룸에 대한 리뷰입니다.")
     @NotBlank(message = "설명은 비어 있을 수 없습니다.")
     private String description;
 
+    @Schema(
+            description = "게시글 블록 목록 (TEXT 또는 IMAGE 블록으로 구성, 최소 1개 이상)",
+            required = true
+    )
     @NotEmpty(message = "블록은 최소 1개 이상이어야 합니다.")
     private List<PostBlockDto> blocks;
 }

--- a/src/main/java/com/example/demo/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/example/demo/post/dto/PostDetailResponse.java
@@ -1,5 +1,6 @@
 package com.example.demo.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,13 +9,26 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "게시글 상세 조회 응답 DTO")
 public class PostDetailResponse {
 
+    @Schema(description = "게시글 ID", example = "1")
     private Long postId;
+
+    @Schema(description = "게시글 제목", example = "학교 근처 자취방 후기")
     private String title;
+
+    @Schema(description = "게시글 설명", example = "학교 근처 원룸에 대한 상세 리뷰입니다.")
     private String description;
+
+    @Schema(description = "작성자 닉네임", example = "자취생")
     private String authorNickname;
+
+    @Schema(description = "게시글 생성 시간", example = "2026-05-05T12:00:00")
     private LocalDateTime createdAt;
 
+    @Schema(
+            description = "게시글 블록 목록 (TEXT: textContent 사용, IMAGE: imageUrl 사용)"
+    )
     private List<PostBlockResponse> blocks;
 }

--- a/src/main/java/com/example/demo/post/dto/PostResponse.java
+++ b/src/main/java/com/example/demo/post/dto/PostResponse.java
@@ -1,5 +1,6 @@
 package com.example.demo.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,13 +8,33 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@Schema(description = "게시글 응답 DTO (생성/수정 결과)")
 public class PostResponse {
 
+    @Schema(description = "게시글 ID", example = "1")
     private Long postId;
+
+    @Schema(description = "게시글 제목", example = "학교 근처 자취방 후기")
     private String title;
+
+    @Schema(
+            description = "게시글 본문 내용 (텍스트 블록들을 합친 내용 또는 요약)",
+            example = "오늘은 학교 근처 원룸 리뷰를 해보겠습니다."
+    )
     private String content;
+
+    @Schema(
+            description = "게시글 설명 (간단 요약)",
+            example = "학교 근처 원룸 리뷰입니다."
+    )
     private String description;
+
+    @Schema(description = "작성자 닉네임", example = "자취생")
     private String authorNickname;
+
+    @Schema(description = "게시글 생성 시간", example = "2026-05-05T12:00:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "게시글 수정 시간", example = "2026-05-05T13:00:00")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/example/demo/report/controller/ReportController.java
+++ b/src/main/java/com/example/demo/report/controller/ReportController.java
@@ -2,12 +2,16 @@ package com.example.demo.report.controller;
 
 import com.example.demo.global.exception.ApiResponse;
 import com.example.demo.global.exception.BaseCode;
+import com.example.demo.global.exception.ErrorResponse;
 import com.example.demo.global.exception.ResponseUtil;
 import com.example.demo.report.dto.ReportCreateRequest;
 import com.example.demo.report.dto.ReportResponse;
 import com.example.demo.report.service.ReportService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +29,22 @@ public class ReportController {
             summary = "게시글 신고 API",
             description = "postId에 해당하는 게시글을 신고합니다."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 신고 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 신고 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "게시글 또는 신고자를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     @PostMapping("/posts/{postId}/reports")
     public ResponseEntity<ApiResponse<ReportResponse>> reportPost(
             @Parameter(description = "신고할 게시글 ID", example = "1")
@@ -44,6 +64,22 @@ public class ReportController {
             summary = "댓글 신고 API",
             description = "commentId에 해당하는 댓글을 신고합니다."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 신고 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 신고 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "댓글 또는 신고자를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     @PostMapping("/comments/{commentId}/reports")
     public ResponseEntity<ApiResponse<ReportResponse>> reportComment(
             @Parameter(description = "신고할 댓글 ID", example = "1")
@@ -63,6 +99,17 @@ public class ReportController {
             summary = "신고 처리 완료 API",
             description = "reportId에 해당하는 신고 상태를 처리 완료로 변경합니다."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "신고 처리 완료 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "신고를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     @PatchMapping("/reports/{reportId}/resolve")
     public ResponseEntity<ApiResponse<ReportResponse>> resolveReport(
             @Parameter(description = "처리할 신고 ID", example = "1")

--- a/src/main/java/com/example/demo/report/controller/ReportController.java
+++ b/src/main/java/com/example/demo/report/controller/ReportController.java
@@ -6,10 +6,14 @@ import com.example.demo.global.exception.ResponseUtil;
 import com.example.demo.report.dto.ReportCreateRequest;
 import com.example.demo.report.dto.ReportResponse;
 import com.example.demo.report.service.ReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Report", description = "신고 관련 API")
 @RestController
 @RequiredArgsConstructor
 public class ReportController {
@@ -17,9 +21,15 @@ public class ReportController {
     private final ReportService reportService;
 
     // 게시글 신고
+    @Operation(
+            summary = "게시글 신고 API",
+            description = "postId에 해당하는 게시글을 신고합니다."
+    )
     @PostMapping("/posts/{postId}/reports")
     public ResponseEntity<ApiResponse<ReportResponse>> reportPost(
+            @Parameter(description = "신고할 게시글 ID", example = "1")
             @PathVariable Long postId,
+
             @RequestBody ReportCreateRequest request
     ) {
         ReportResponse response = reportService.reportPost(postId, request);
@@ -30,9 +40,15 @@ public class ReportController {
     }
 
     // 댓글 신고
+    @Operation(
+            summary = "댓글 신고 API",
+            description = "commentId에 해당하는 댓글을 신고합니다."
+    )
     @PostMapping("/comments/{commentId}/reports")
     public ResponseEntity<ApiResponse<ReportResponse>> reportComment(
+            @Parameter(description = "신고할 댓글 ID", example = "1")
             @PathVariable Long commentId,
+
             @RequestBody ReportCreateRequest request
     ) {
         ReportResponse response = reportService.reportComment(commentId, request);
@@ -43,8 +59,13 @@ public class ReportController {
     }
 
     // 신고 처리 완료
+    @Operation(
+            summary = "신고 처리 완료 API",
+            description = "reportId에 해당하는 신고 상태를 처리 완료로 변경합니다."
+    )
     @PatchMapping("/reports/{reportId}/resolve")
     public ResponseEntity<ApiResponse<ReportResponse>> resolveReport(
+            @Parameter(description = "처리할 신고 ID", example = "1")
             @PathVariable Long reportId
     ) {
         ReportResponse response = reportService.resolveReport(reportId);

--- a/src/main/java/com/example/demo/report/dto/ReportCreateRequest.java
+++ b/src/main/java/com/example/demo/report/dto/ReportCreateRequest.java
@@ -1,11 +1,18 @@
 package com.example.demo.report.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@Schema(description = "신고 생성 요청 DTO")
 public class ReportCreateRequest {
 
+    @Schema(description = "신고자 유저 ID", example = "5")
     private Long reporterId;
 
+    @Schema(
+            description = "신고 사유",
+            example = "욕설 및 비방 내용이 포함되어 있습니다."
+    )
     private String reason;
 }

--- a/src/main/java/com/example/demo/report/dto/ReportResponse.java
+++ b/src/main/java/com/example/demo/report/dto/ReportResponse.java
@@ -3,6 +3,7 @@ package com.example.demo.report.dto;
 import com.example.demo.report.entity.Report;
 import com.example.demo.report.entity.ReportStatus;
 import com.example.demo.report.entity.ReportTargetType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,15 +11,43 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@Schema(description = "신고 응답 DTO")
 public class ReportResponse {
 
+    @Schema(description = "신고 ID", example = "1")
     private Long reportId;
+
+    @Schema(description = "신고자 유저 ID", example = "5")
     private Long reporterId;
+
+    @Schema(
+            description = "신고 대상 타입 (POST: 게시글, COMMENT: 댓글)",
+            example = "POST"
+    )
     private ReportTargetType targetType;
+
+    @Schema(
+            description = "신고 대상 ID (게시글 ID 또는 댓글 ID)",
+            example = "10"
+    )
     private Long targetId;
+
+    @Schema(
+            description = "신고 사유",
+            example = "욕설 및 비방 내용이 포함되어 있습니다."
+    )
     private String reason;
+
+    @Schema(
+            description = "신고 상태 (PENDING: 처리 대기, RESOLVED: 처리 완료)",
+            example = "PENDING"
+    )
     private ReportStatus status;
+
+    @Schema(description = "신고 생성 시간", example = "2026-05-05T12:00:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "신고 처리 완료 시간", example = "2026-05-05T13:00:00")
     private LocalDateTime resolvedAt;
 
     public static ReportResponse from(Report report) {

--- a/src/main/java/com/example/demo/user/controller/UserController.java
+++ b/src/main/java/com/example/demo/user/controller/UserController.java
@@ -2,10 +2,14 @@ package com.example.demo.user.controller;
 
 import com.example.demo.global.exception.ApiResponse;
 import com.example.demo.global.exception.BaseCode;
+import com.example.demo.global.exception.ErrorResponse;
 import com.example.demo.global.exception.ResponseUtil;
 import com.example.demo.user.dto.UserCreateRequest;
 import com.example.demo.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -25,6 +29,22 @@ public class UserController {
             summary = "유저 생성 API",
             description = "새로운 유저를 생성합니다."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "유저 생성 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "유효성 검증 실패 (이름/이메일 오류)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "이미 존재하는 이메일",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     @PostMapping
     public ApiResponse<Map<String, Long>> create(
             @RequestBody @Valid UserCreateRequest request) {

--- a/src/main/java/com/example/demo/user/controller/UserController.java
+++ b/src/main/java/com/example/demo/user/controller/UserController.java
@@ -4,15 +4,16 @@ import com.example.demo.global.exception.ApiResponse;
 import com.example.demo.global.exception.BaseCode;
 import com.example.demo.global.exception.ResponseUtil;
 import com.example.demo.user.dto.UserCreateRequest;
-import com.example.demo.user.entity.User;
-import com.example.demo.user.repository.UserRepository;
 import com.example.demo.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 
 import java.util.Map;
 
+@Tag(name = "User", description = "유저 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
@@ -20,8 +21,14 @@ public class UserController {
 
     private final UserService userService;
 
+    @Operation(
+            summary = "유저 생성 API",
+            description = "새로운 유저를 생성합니다."
+    )
     @PostMapping
-    public ApiResponse<Map<String, Long>> create(@RequestBody @Valid UserCreateRequest request) {
+    public ApiResponse<Map<String, Long>> create(
+            @RequestBody @Valid UserCreateRequest request) {
+
         return ResponseUtil.success(
                 BaseCode.USER_CREATE_SUCCESS,
                 Map.of("userId", userService.createUser(request))

--- a/src/main/java/com/example/demo/user/dto/UserCreateRequest.java
+++ b/src/main/java/com/example/demo/user/dto/UserCreateRequest.java
@@ -1,15 +1,19 @@
 package com.example.demo.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 @Getter
+@Schema(description = "유저 생성 요청 DTO")
 public class UserCreateRequest {
 
+    @Schema(description = "유저 이름", example = "홍길동")
     @NotBlank(message = "이름은 필수입니다.")
     private String name;
 
+    @Schema(description = "이메일 주소", example = "test@example.com")
     @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
 }


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

- [x] 기존에 구현 중인 서버 프로젝트에 Swagger를 추가한다.
- [x] 실행 후 Swagger UI 페이지에 접속할 수 있어야 한다.
- [x] 현재 프로젝트에 구현되어 있는 API가 Swagger 문서에 표시되어야 한다.
- [x] 문서를 보고 각 API의 요청 방식과 URL, 요청값, 응답값을 확인할 수 있어야 한다.

## 2. 핵심 변경 사항
 
1. SwaggerConfig 클래스에서 API 문서 기본 정보 설정
2. Controller의 각 API마다 Operation, ApiResponses 애노테이션 추가 (API 설명, 성공/실패 응답)
3. DTO의 각 속성마다 Schema 애노테이션 추가 (설명, 예시)
4. global.exception.ErrorResponse 클래스 추가 (에러 발생 시 반환 되는 응답 구조 지정) -> Swagger의 ApiResponse 애노테이션에서 사용


## 3. 실행 및 검증 결과

<img width="1400" height="867" alt="전체 화면" src="https://github.com/user-attachments/assets/9b97737e-648c-464d-a28d-66eb0e2b204e" />


<img width="1203" height="897" alt="상세 내용" src="https://github.com/user-attachments/assets/7773ab0f-3870-4ede-b639-c757293ef3be" />



## 4. 완료 사항

Swagger 문서화 추가

## 5. 추가 사항

#186 

## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고

<!--
BE: rootTiket, soyesenna
FE: One-HyeWon, woneeee
-->
