### PR TITLE
[5주차] 변승현/[feat] Swagger 문서화

### DIFF
--- a/src/main/java/com/example/demo/controller/CommentController.java
+++ b/src/main/java/com/example/demo/controller/CommentController.java
@@ -6,20 +6,26 @@ import com.example.demo.domain.comment.dto.CommentCreateResponse;
 import com.example.demo.domain.comment.dto.CommentStatusResponse;
 import com.example.demo.domain.comment.service.CommentService;
 import com.example.demo.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Comment", description = "댓글 API")
 @RestController
 @RequiredArgsConstructor
 public class CommentController {
 
     private final CommentService commentService;
 
+    @Operation(summary = "댓글 생성", description = "특정 게시글에 댓글을 작성합니다.")
     @PostMapping("/api/posts/{postId}/comments")
     public ResponseEntity<ApiResponse<CommentCreateResponse>> createComment(
+            @Parameter(description = "댓글을 작성할 게시글 ID", example = "1")
             @PathVariable Long postId,
             @Valid @RequestBody CommentCreateRequest request
     ) {
@@ -31,8 +37,10 @@ public class CommentController {
                 ));
     }
 
+    @Operation(summary = "댓글 채택", description = "게시글 작성자가 댓글 하나를 채택합니다. 이미 채택된 댓글이 있으면 실패합니다.")
     @PostMapping("/api/comments/{commentId}/adoption")
     public ResponseEntity<ApiResponse<CommentStatusResponse>> adoptComment(
+            @Parameter(description = "채택할 댓글 ID", example = "1")
             @PathVariable Long commentId,
             @Valid @RequestBody CommentAdoptRequest request
     ) {

--- a/src/main/java/com/example/demo/controller/CommentController.java
+++ b/src/main/java/com/example/demo/controller/CommentController.java
@@ -1,0 +1,47 @@
+package com.example.demo.controller;
+
+import com.example.demo.domain.comment.dto.CommentAdoptRequest;
+import com.example.demo.domain.comment.dto.CommentCreateRequest;
+import com.example.demo.domain.comment.dto.CommentCreateResponse;
+import com.example.demo.domain.comment.dto.CommentStatusResponse;
+import com.example.demo.domain.comment.service.CommentService;
+import com.example.demo.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/api/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<CommentCreateResponse>> createComment(
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentCreateRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(
+                        "COMMENT_CREATE_SUCCESS",
+                        "댓글 생성 성공",
+                        commentService.createComment(postId, request)
+                ));
+    }
+
+    @PostMapping("/api/comments/{commentId}/adoption")
+    public ResponseEntity<ApiResponse<CommentStatusResponse>> adoptComment(
+            @PathVariable Long commentId,
+            @Valid @RequestBody CommentAdoptRequest request
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "COMMENT_ADOPT_SUCCESS",
+                        "댓글 채택 성공",
+                        commentService.adoptComment(commentId, request.userId())
+                )
+        );
+    }
+}

--- a/src/main/java/com/example/demo/controller/HealthController.java
+++ b/src/main/java/com/example/demo/controller/HealthController.java
@@ -1,13 +1,16 @@
 package com.example.demo.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Health", description = "서버 상태 확인 API")
 @RestController
 public class HealthController {
+    @Operation(summary = "헬스 체크", description = "서버가 정상적으로 실행 중인지 확인합니다.")
     @GetMapping("/health")
     public String health() {
         return "OK";
     }
 }
-

--- a/src/main/java/com/example/demo/controller/PostController.java
+++ b/src/main/java/com/example/demo/controller/PostController.java
@@ -3,12 +3,16 @@ package com.example.demo.controller;
 import com.example.demo.domain.post.dto.*;
 import com.example.demo.domain.post.service.PostService;
 import com.example.demo.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Post", description = "게시글 API")
 @RestController
 @RequestMapping("/api/posts")
 @RequiredArgsConstructor
@@ -16,6 +20,7 @@ public class PostController {
 
     private final PostService postService;
 
+    @Operation(summary = "게시글 목록 조회", description = "페이지 번호와 크기를 기준으로 게시글 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<PostListResponse>> getPosts(
             @Valid @ModelAttribute PostListRequest request
@@ -25,13 +30,18 @@ public class PostController {
         );
     }
 
+    @Operation(summary = "게시글 상세 조회", description = "게시글 ID로 상세 정보를 조회합니다.")
     @GetMapping("/{postId}")
-    public ResponseEntity<ApiResponse<PostDetailResponse>> getPost(@PathVariable Long postId) {
+    public ResponseEntity<ApiResponse<PostDetailResponse>> getPost(
+            @Parameter(description = "조회할 게시글 ID", example = "1")
+            @PathVariable Long postId
+    ) {
         return ResponseEntity.ok(
                 ApiResponse.success("POST_DETAIL_SUCCESS", "게시글 상세 조회 성공", postService.getPost(postId))
         );
     }
 
+    @Operation(summary = "게시글 생성", description = "새 게시글을 생성합니다.")
     @PostMapping
     public ResponseEntity<ApiResponse<PostCreateResponse>> createPost(
             @Valid @RequestBody PostCreateRequest request
@@ -44,8 +54,10 @@ public class PostController {
                 ));
     }
 
+    @Operation(summary = "게시글 수정", description = "게시글 작성자만 게시글을 수정할 수 있습니다.")
     @PatchMapping("/{postId}")
     public ResponseEntity<ApiResponse<Void>> updatePost(
+            @Parameter(description = "수정할 게시글 ID", example = "1")
             @PathVariable Long postId,
             @Valid @RequestBody PostUpdateRequest request
     ) {
@@ -55,8 +67,10 @@ public class PostController {
         );
     }
 
+    @Operation(summary = "게시글 삭제", description = "게시글 작성자만 게시글을 삭제할 수 있습니다.")
     @DeleteMapping("/{postId}")
     public ResponseEntity<ApiResponse<Void>> deletePost(
+            @Parameter(description = "삭제할 게시글 ID", example = "1")
             @PathVariable Long postId,
             @Valid @RequestBody PostDeleteRequest request
     ) {

--- a/src/main/java/com/example/demo/controller/ReportController.java
+++ b/src/main/java/com/example/demo/controller/ReportController.java
@@ -6,20 +6,26 @@ import com.example.demo.domain.report.dto.ReportResolveRequest;
 import com.example.demo.domain.report.dto.ReportResolveResponse;
 import com.example.demo.domain.report.service.ReportService;
 import com.example.demo.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Report", description = "신고 API")
 @RestController
 @RequiredArgsConstructor
 public class ReportController {
 
     private final ReportService reportService;
 
+    @Operation(summary = "게시글 신고", description = "특정 게시글을 신고합니다. 동일 사용자의 중복 신고는 제한됩니다.")
     @PostMapping("/api/posts/{postId}/reports")
     public ResponseEntity<ApiResponse<ReportCreateResponse>> reportPost(
+            @Parameter(description = "신고할 게시글 ID", example = "1")
             @PathVariable Long postId,
             @Valid @RequestBody ReportCreateRequest request
     ) {
@@ -31,8 +37,10 @@ public class ReportController {
                 ));
     }
 
+    @Operation(summary = "댓글 신고", description = "특정 댓글을 신고합니다. 동일 사용자의 중복 신고는 제한됩니다.")
     @PostMapping("/api/comments/{commentId}/reports")
     public ResponseEntity<ApiResponse<ReportCreateResponse>> reportComment(
+            @Parameter(description = "신고할 댓글 ID", example = "1")
             @PathVariable Long commentId,
             @Valid @RequestBody ReportCreateRequest request
     ) {
@@ -44,8 +52,10 @@ public class ReportController {
                 ));
     }
 
+    @Operation(summary = "신고 처리", description = "신고를 처리 완료 상태로 변경하고, 처리 방식에 따라 게시글 또는 댓글 상태를 변경합니다.")
     @PatchMapping("/api/reports/{reportId}/resolve")
     public ResponseEntity<ApiResponse<ReportResolveResponse>> resolveReport(
+            @Parameter(description = "처리할 신고 ID", example = "1")
             @PathVariable Long reportId,
             @Valid @RequestBody ReportResolveRequest request
     ) {

--- a/src/main/java/com/example/demo/controller/ReportController.java
+++ b/src/main/java/com/example/demo/controller/ReportController.java
@@ -1,0 +1,60 @@
+package com.example.demo.controller;
+
+import com.example.demo.domain.report.dto.ReportCreateRequest;
+import com.example.demo.domain.report.dto.ReportCreateResponse;
+import com.example.demo.domain.report.dto.ReportResolveRequest;
+import com.example.demo.domain.report.dto.ReportResolveResponse;
+import com.example.demo.domain.report.service.ReportService;
+import com.example.demo.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @PostMapping("/api/posts/{postId}/reports")
+    public ResponseEntity<ApiResponse<ReportCreateResponse>> reportPost(
+            @PathVariable Long postId,
+            @Valid @RequestBody ReportCreateRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(
+                        "POST_REPORT_SUCCESS",
+                        "게시글 신고 접수 성공",
+                        reportService.reportPost(postId, request)
+                ));
+    }
+
+    @PostMapping("/api/comments/{commentId}/reports")
+    public ResponseEntity<ApiResponse<ReportCreateResponse>> reportComment(
+            @PathVariable Long commentId,
+            @Valid @RequestBody ReportCreateRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(
+                        "COMMENT_REPORT_SUCCESS",
+                        "댓글 신고 접수 성공",
+                        reportService.reportComment(commentId, request)
+                ));
+    }
+
+    @PatchMapping("/api/reports/{reportId}/resolve")
+    public ResponseEntity<ApiResponse<ReportResolveResponse>> resolveReport(
+            @PathVariable Long reportId,
+            @Valid @RequestBody ReportResolveRequest request
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "REPORT_RESOLVE_SUCCESS",
+                        "신고 처리 완료",
+                        reportService.resolveReport(reportId, request)
+                )
+        );
+    }
+}

--- a/src/main/java/com/example/demo/controller/StringController.java
+++ b/src/main/java/com/example/demo/controller/StringController.java
@@ -3,8 +3,11 @@ package com.example.demo.controller;
 import com.example.demo.dto.RepeatRequest;
 import com.example.demo.dto.RepeatResponse;
 import com.example.demo.service.StringService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "String", description = "문자열 처리 API")
 @RestController
 @RequestMapping("/string")
 public class StringController {
@@ -15,6 +18,7 @@ public class StringController {
         this.stringService = stringService;
     }
 
+    @Operation(summary = "문자열 2회 반환", description = "입력받은 문자열을 2개의 필드로 반복 반환합니다.")
     @PostMapping("/repeat")
     public RepeatResponse repeat(@RequestBody RepeatRequest request) {
         return stringService.repeatTwice(request.value());

--- a/src/main/java/com/example/demo/domain/comment/dto/CommentAdoptRequest.java
+++ b/src/main/java/com/example/demo/domain/comment/dto/CommentAdoptRequest.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.comment.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CommentAdoptRequest(
+        @NotNull(message = "userId는 필수입니다.")
+        Long userId
+) {
+}

--- a/src/main/java/com/example/demo/domain/comment/dto/CommentAdoptRequest.java
+++ b/src/main/java/com/example/demo/domain/comment/dto/CommentAdoptRequest.java
@@ -1,8 +1,11 @@
 package com.example.demo.domain.comment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "댓글 채택 요청")
 public record CommentAdoptRequest(
+        @Schema(description = "채택을 요청한 게시글 작성자 ID", example = "1")
         @NotNull(message = "userId는 필수입니다.")
         Long userId
 ) {

--- a/src/main/java/com/example/demo/domain/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/com/example/demo/domain/comment/dto/CommentCreateRequest.java
@@ -1,0 +1,13 @@
+package com.example.demo.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CommentCreateRequest(
+        @NotNull(message = "userId는 필수입니다.")
+        Long userId,
+
+        @NotBlank(message = "content는 필수입니다.")
+        String content
+) {
+}

--- a/src/main/java/com/example/demo/domain/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/com/example/demo/domain/comment/dto/CommentCreateRequest.java
@@ -1,12 +1,16 @@
 package com.example.demo.domain.comment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "댓글 생성 요청")
 public record CommentCreateRequest(
+        @Schema(description = "댓글 작성자 ID", example = "2")
         @NotNull(message = "userId는 필수입니다.")
         Long userId,
 
+        @Schema(description = "댓글 내용", example = "좋은 글이네요!")
         @NotBlank(message = "content는 필수입니다.")
         String content
 ) {

--- a/src/main/java/com/example/demo/domain/comment/dto/CommentCreateResponse.java
+++ b/src/main/java/com/example/demo/domain/comment/dto/CommentCreateResponse.java
@@ -1,9 +1,13 @@
 package com.example.demo.domain.comment.dto;
 
 import com.example.demo.domain.comment.entity.CommentStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "댓글 생성 응답")
 public record CommentCreateResponse(
+        @Schema(description = "생성된 댓글 ID", example = "1")
         Long commentId,
+        @Schema(description = "댓글 상태", example = "ACTIVE")
         CommentStatus status
 ) {
 }

--- a/src/main/java/com/example/demo/domain/comment/dto/CommentCreateResponse.java
+++ b/src/main/java/com/example/demo/domain/comment/dto/CommentCreateResponse.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.comment.dto;
+
+import com.example.demo.domain.comment.entity.CommentStatus;
+
+public record CommentCreateResponse(
+        Long commentId,
+        CommentStatus status
+) {
+}

--- a/src/main/java/com/example/demo/domain/comment/dto/CommentStatusResponse.java
+++ b/src/main/java/com/example/demo/domain/comment/dto/CommentStatusResponse.java
@@ -1,9 +1,13 @@
 package com.example.demo.domain.comment.dto;
 
 import com.example.demo.domain.comment.entity.CommentStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "댓글 상태 응답")
 public record CommentStatusResponse(
+        @Schema(description = "댓글 ID", example = "1")
         Long commentId,
+        @Schema(description = "댓글 상태", example = "ADOPTED")
         CommentStatus status
 ) {
 }

--- a/src/main/java/com/example/demo/domain/comment/dto/CommentStatusResponse.java
+++ b/src/main/java/com/example/demo/domain/comment/dto/CommentStatusResponse.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.comment.dto;
+
+import com.example.demo.domain.comment.entity.CommentStatus;
+
+public record CommentStatusResponse(
+        Long commentId,
+        CommentStatus status
+) {
+}

--- a/src/main/java/com/example/demo/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/demo/domain/comment/entity/Comment.java
@@ -32,5 +32,26 @@ public class Comment extends BaseEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private CommentStatus status;
 
+    private Comment(User user, Post post, String content) {
+        this.user = user;
+        this.post = post;
+        this.content = content;
+        this.status = CommentStatus.ACTIVE;
+    }
+
+    public static Comment of(User user, Post post, String content) {
+        return new Comment(user, post, content);
+    }
+
+    public void hide() {
+        this.status = CommentStatus.HIDDEN;
+    }
+
+    public void adopt() {
+        this.status = CommentStatus.ADOPTED;
+    }
 }

--- a/src/main/java/com/example/demo/domain/comment/entity/CommentStatus.java
+++ b/src/main/java/com/example/demo/domain/comment/entity/CommentStatus.java
@@ -1,0 +1,7 @@
+package com.example.demo.domain.comment.entity;
+
+public enum CommentStatus {
+    ACTIVE,
+    HIDDEN,
+    ADOPTED
+}

--- a/src/main/java/com/example/demo/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/demo/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.comment.repository;
+
+import com.example.demo.domain.comment.entity.Comment;
+import com.example.demo.domain.comment.entity.CommentStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    boolean existsByPostIdAndStatus(Long postId, CommentStatus status);
+}

--- a/src/main/java/com/example/demo/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/demo/domain/comment/service/CommentService.java
@@ -1,0 +1,78 @@
+package com.example.demo.domain.comment.service;
+
+import com.example.demo.domain.comment.dto.CommentCreateRequest;
+import com.example.demo.domain.comment.dto.CommentCreateResponse;
+import com.example.demo.domain.comment.dto.CommentStatusResponse;
+import com.example.demo.domain.comment.entity.Comment;
+import com.example.demo.domain.comment.entity.CommentStatus;
+import com.example.demo.domain.comment.repository.CommentRepository;
+import com.example.demo.domain.post.entity.Post;
+import com.example.demo.domain.post.entity.PostStatus;
+import com.example.demo.domain.post.repository.PostRepository;
+import com.example.demo.domain.user.entity.User;
+import com.example.demo.domain.user.repository.UserRepository;
+import com.example.demo.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public CommentCreateResponse createComment(Long postId, CommentCreateRequest request) {
+        Post post = findPost(postId);
+        User user = findUser(request.userId());
+
+        if (post.getStatus() == PostStatus.HIDDEN) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "POST_HIDDEN", "숨김 처리된 게시글에는 댓글을 작성할 수 없습니다.");
+        }
+
+        Comment comment = commentRepository.save(Comment.of(user, post, request.content()));
+        return new CommentCreateResponse(comment.getId(), comment.getStatus());
+    }
+
+    @Transactional
+    public CommentStatusResponse adoptComment(Long commentId, Long userId) {
+        Comment comment = findComment(commentId);
+        Post post = comment.getPost();
+
+        if (!post.getUser().getId().equals(userId)) {
+            throw new CustomException(HttpStatus.FORBIDDEN, "FORBIDDEN", "댓글 채택 권한이 없습니다.");
+        }
+        if (post.getStatus() == PostStatus.HIDDEN) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "POST_HIDDEN", "숨김 처리된 게시글에서는 댓글을 채택할 수 없습니다.");
+        }
+        if (comment.getStatus() == CommentStatus.HIDDEN) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "COMMENT_HIDDEN", "숨김 처리된 댓글은 채택할 수 없습니다.");
+        }
+        if (commentRepository.existsByPostIdAndStatus(post.getId(), CommentStatus.ADOPTED)) {
+            throw new CustomException(HttpStatus.CONFLICT, "COMMENT_ALREADY_ADOPTED", "이미 채택된 댓글이 있습니다.");
+        }
+
+        comment.adopt();
+        return new CommentStatusResponse(comment.getId(), comment.getStatus());
+    }
+
+    public Comment findComment(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "COMMENT_NOT_FOUND", "해당 댓글을 찾을 수 없습니다."));
+    }
+
+    private Post findPost(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "POST_NOT_FOUND", "해당 게시글을 찾을 수 없습니다."));
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "해당 사용자를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/example/demo/domain/post/dto/PageInfoResponse.java
+++ b/src/main/java/com/example/demo/domain/post/dto/PageInfoResponse.java
@@ -1,10 +1,18 @@
 package com.example.demo.domain.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "페이지 정보")
 public record PageInfoResponse(
+        @Schema(description = "현재 페이지 번호", example = "0")
         int page,
+        @Schema(description = "페이지 크기", example = "10")
         int size,
+        @Schema(description = "전체 데이터 수", example = "25")
         long totalElements,
+        @Schema(description = "전체 페이지 수", example = "3")
         int totalPages,
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
         boolean hasNext
 ) {
 }

--- a/src/main/java/com/example/demo/domain/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/example/demo/domain/post/dto/PostCreateRequest.java
@@ -1,18 +1,24 @@
 package com.example.demo.domain.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "게시글 생성 요청")
 public record PostCreateRequest(
+        @Schema(description = "작성자 사용자 ID", example = "1")
         @NotNull(message = "userId는 필수입니다.")
         Long userId,
 
+        @Schema(description = "게시글 제목", example = "첫 번째 게시글")
         @NotBlank(message = "title은 필수입니다.")
         String title,
 
+        @Schema(description = "게시글 내용", example = "게시글 내용입니다.")
         @NotBlank(message = "content는 필수입니다.")
         String content,
 
+        @Schema(description = "대표 이미지 URL", example = "https://example.com/image.png")
         String imageUrl
 ) {
 }

--- a/src/main/java/com/example/demo/domain/post/dto/PostCreateResponse.java
+++ b/src/main/java/com/example/demo/domain/post/dto/PostCreateResponse.java
@@ -1,7 +1,12 @@
 package com.example.demo.domain.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "게시글 생성 응답")
 public record PostCreateResponse(
+        @Schema(description = "생성된 게시글 ID", example = "1")
         Long postId,
+        @Schema(description = "결과 메시지", example = "게시글이 생성되었습니다.")
         String message
 ) {
 }

--- a/src/main/java/com/example/demo/domain/post/dto/PostDeleteRequest.java
+++ b/src/main/java/com/example/demo/domain/post/dto/PostDeleteRequest.java
@@ -1,8 +1,11 @@
 package com.example.demo.domain.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "게시글 삭제 요청")
 public record PostDeleteRequest(
+        @Schema(description = "삭제를 요청한 사용자 ID", example = "1")
         @NotNull(message = "userId는 필수입니다.")
         Long userId
 ) {

--- a/src/main/java/com/example/demo/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/example/demo/domain/post/dto/PostDetailResponse.java
@@ -1,18 +1,29 @@
 package com.example.demo.domain.post.dto;
 
 import com.example.demo.domain.post.entity.PostStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "게시글 상세 응답")
 public record PostDetailResponse(
+        @Schema(description = "게시글 ID", example = "1")
         Long postId,
+        @Schema(description = "게시글 제목", example = "첫 번째 게시글")
         String title,
+        @Schema(description = "게시글 내용", example = "게시글 내용입니다.")
         String content,
+        @Schema(description = "게시글 이미지 URL", example = "https://example.com/image.png")
         String imageUrl,
+        @Schema(description = "게시글 상태", example = "ACTIVE")
         PostStatus status,
+        @Schema(description = "작성자 ID", example = "1")
         Long authorId,
+        @Schema(description = "작성자 이름", example = "tester")
         String author,
+        @Schema(description = "생성 시각", example = "2026-05-05T12:00:00")
         LocalDateTime createdAt,
+        @Schema(description = "수정 시각", example = "2026-05-05T12:30:00")
         LocalDateTime updatedAt
 ) {
 }

--- a/src/main/java/com/example/demo/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/example/demo/domain/post/dto/PostDetailResponse.java
@@ -1,5 +1,7 @@
 package com.example.demo.domain.post.dto;
 
+import com.example.demo.domain.post.entity.PostStatus;
+
 import java.time.LocalDateTime;
 
 public record PostDetailResponse(
@@ -7,6 +9,7 @@ public record PostDetailResponse(
         String title,
         String content,
         String imageUrl,
+        PostStatus status,
         Long authorId,
         String author,
         LocalDateTime createdAt,

--- a/src/main/java/com/example/demo/domain/post/dto/PostListItemResponse.java
+++ b/src/main/java/com/example/demo/domain/post/dto/PostListItemResponse.java
@@ -1,5 +1,7 @@
 package com.example.demo.domain.post.dto;
 
+import com.example.demo.domain.post.entity.PostStatus;
+
 import java.time.LocalDateTime;
 
 public record PostListItemResponse(
@@ -7,6 +9,7 @@ public record PostListItemResponse(
         String title,
         String content,
         String thumbnailImageUrl,
+        PostStatus status,
         String author,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/example/demo/domain/post/dto/PostListItemResponse.java
+++ b/src/main/java/com/example/demo/domain/post/dto/PostListItemResponse.java
@@ -1,16 +1,25 @@
 package com.example.demo.domain.post.dto;
 
 import com.example.demo.domain.post.entity.PostStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "게시글 목록 항목")
 public record PostListItemResponse(
+        @Schema(description = "게시글 ID", example = "1")
         Long postId,
+        @Schema(description = "게시글 제목", example = "첫 번째 게시글")
         String title,
+        @Schema(description = "게시글 내용", example = "게시글 내용입니다.")
         String content,
+        @Schema(description = "썸네일 이미지 URL", example = "https://example.com/thumb.png")
         String thumbnailImageUrl,
+        @Schema(description = "게시글 상태", example = "ACTIVE")
         PostStatus status,
+        @Schema(description = "작성자 이름", example = "tester")
         String author,
+        @Schema(description = "생성 시각", example = "2026-05-05T12:00:00")
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/example/demo/domain/post/dto/PostListRequest.java
+++ b/src/main/java/com/example/demo/domain/post/dto/PostListRequest.java
@@ -1,11 +1,15 @@
 package com.example.demo.domain.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 
+@Schema(description = "게시글 목록 조회 요청")
 public record PostListRequest(
+        @Schema(description = "페이지 번호", example = "0", defaultValue = "0")
         @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.")
         Integer page,
 
+        @Schema(description = "페이지 크기", example = "10", defaultValue = "10")
         @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
         Integer size
 ) {

--- a/src/main/java/com/example/demo/domain/post/dto/PostListResponse.java
+++ b/src/main/java/com/example/demo/domain/post/dto/PostListResponse.java
@@ -1,9 +1,14 @@
 package com.example.demo.domain.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "게시글 목록 응답")
 public record PostListResponse(
+        @Schema(description = "게시글 목록")
         List<PostListItemResponse> posts,
+        @Schema(description = "페이지 정보")
         PageInfoResponse pageInfo
 ) {
 }

--- a/src/main/java/com/example/demo/domain/post/dto/PostUpdateRequest.java
+++ b/src/main/java/com/example/demo/domain/post/dto/PostUpdateRequest.java
@@ -1,13 +1,19 @@
 package com.example.demo.domain.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "게시글 수정 요청")
 public record PostUpdateRequest(
+        @Schema(description = "수정을 요청한 사용자 ID", example = "1")
         @NotNull(message = "userId는 필수입니다.")
         Long userId,
 
+        @Schema(description = "수정할 제목", example = "수정된 제목")
         String title,
+        @Schema(description = "수정할 내용", example = "수정된 내용")
         String content,
+        @Schema(description = "수정할 이미지 URL", example = "https://example.com/updated-image.png")
         String imageUrl
 ) {
 }

--- a/src/main/java/com/example/demo/domain/post/entity/Post.java
+++ b/src/main/java/com/example/demo/domain/post/entity/Post.java
@@ -38,6 +38,10 @@ public class Post extends BaseEntity {
     @Column(name = "image_url")
     private String imageUrl;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PostStatus status;
+
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
@@ -46,6 +50,7 @@ public class Post extends BaseEntity {
         this.title = title;
         this.content = content;
         this.imageUrl = imageUrl;
+        this.status = PostStatus.ACTIVE;
     }
 
     public static Post of(User user, String title, String content, String imageUrl) {
@@ -60,5 +65,9 @@ public class Post extends BaseEntity {
             this.content = content;
         }
         this.imageUrl = imageUrl;
+    }
+
+    public void hide() {
+        this.status = PostStatus.HIDDEN;
     }
 }

--- a/src/main/java/com/example/demo/domain/post/entity/PostStatus.java
+++ b/src/main/java/com/example/demo/domain/post/entity/PostStatus.java
@@ -1,0 +1,6 @@
+package com.example.demo.domain.post.entity;
+
+public enum PostStatus {
+    ACTIVE,
+    HIDDEN
+}

--- a/src/main/java/com/example/demo/domain/post/service/PostService.java
+++ b/src/main/java/com/example/demo/domain/post/service/PostService.java
@@ -31,6 +31,7 @@ public class PostService {
                                 post.getTitle(),
                                 post.getContent(),
                                 post.getImageUrl(),
+                                post.getStatus(),
                                 post.getUser().getName(),
                                 post.getCreatedAt()
                         ))
@@ -53,6 +54,7 @@ public class PostService {
                 post.getTitle(),
                 post.getContent(),
                 post.getImageUrl(),
+                post.getStatus(),
                 post.getUser().getId(),
                 post.getUser().getName(),
                 post.getCreatedAt(),

--- a/src/main/java/com/example/demo/domain/report/dto/ReportCreateRequest.java
+++ b/src/main/java/com/example/demo/domain/report/dto/ReportCreateRequest.java
@@ -1,12 +1,16 @@
 package com.example.demo.domain.report.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "신고 생성 요청")
 public record ReportCreateRequest(
+        @Schema(description = "신고자 ID", example = "2")
         @NotNull(message = "reporterId는 필수입니다.")
         Long reporterId,
 
+        @Schema(description = "신고 사유", example = "스팸성 게시물입니다.")
         @NotBlank(message = "reason은 필수입니다.")
         String reason
 ) {

--- a/src/main/java/com/example/demo/domain/report/dto/ReportCreateRequest.java
+++ b/src/main/java/com/example/demo/domain/report/dto/ReportCreateRequest.java
@@ -1,0 +1,13 @@
+package com.example.demo.domain.report.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ReportCreateRequest(
+        @NotNull(message = "reporterId는 필수입니다.")
+        Long reporterId,
+
+        @NotBlank(message = "reason은 필수입니다.")
+        String reason
+) {
+}

--- a/src/main/java/com/example/demo/domain/report/dto/ReportCreateResponse.java
+++ b/src/main/java/com/example/demo/domain/report/dto/ReportCreateResponse.java
@@ -1,0 +1,11 @@
+package com.example.demo.domain.report.dto;
+
+import com.example.demo.domain.report.entity.ReportStatus;
+import com.example.demo.domain.report.entity.ReportTargetType;
+
+public record ReportCreateResponse(
+        Long reportId,
+        ReportTargetType targetType,
+        ReportStatus status
+) {
+}

--- a/src/main/java/com/example/demo/domain/report/dto/ReportCreateResponse.java
+++ b/src/main/java/com/example/demo/domain/report/dto/ReportCreateResponse.java
@@ -2,10 +2,15 @@ package com.example.demo.domain.report.dto;
 
 import com.example.demo.domain.report.entity.ReportStatus;
 import com.example.demo.domain.report.entity.ReportTargetType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "신고 생성 응답")
 public record ReportCreateResponse(
+        @Schema(description = "생성된 신고 ID", example = "1")
         Long reportId,
+        @Schema(description = "신고 대상 타입", example = "POST")
         ReportTargetType targetType,
+        @Schema(description = "신고 상태", example = "PENDING")
         ReportStatus status
 ) {
 }

--- a/src/main/java/com/example/demo/domain/report/dto/ReportResolveRequest.java
+++ b/src/main/java/com/example/demo/domain/report/dto/ReportResolveRequest.java
@@ -1,12 +1,16 @@
 package com.example.demo.domain.report.dto;
 
 import com.example.demo.domain.report.entity.ReportResolutionType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "신고 처리 요청")
 public record ReportResolveRequest(
+        @Schema(description = "신고 처리자 ID", example = "1")
         @NotNull(message = "resolverId는 필수입니다.")
         Long resolverId,
 
+        @Schema(description = "신고 처리 방식", example = "HIDE_COMMENT")
         @NotNull(message = "resolutionType은 필수입니다.")
         ReportResolutionType resolutionType
 ) {

--- a/src/main/java/com/example/demo/domain/report/dto/ReportResolveRequest.java
+++ b/src/main/java/com/example/demo/domain/report/dto/ReportResolveRequest.java
@@ -1,0 +1,13 @@
+package com.example.demo.domain.report.dto;
+
+import com.example.demo.domain.report.entity.ReportResolutionType;
+import jakarta.validation.constraints.NotNull;
+
+public record ReportResolveRequest(
+        @NotNull(message = "resolverId는 필수입니다.")
+        Long resolverId,
+
+        @NotNull(message = "resolutionType은 필수입니다.")
+        ReportResolutionType resolutionType
+) {
+}

--- a/src/main/java/com/example/demo/domain/report/dto/ReportResolveResponse.java
+++ b/src/main/java/com/example/demo/domain/report/dto/ReportResolveResponse.java
@@ -2,10 +2,15 @@ package com.example.demo.domain.report.dto;
 
 import com.example.demo.domain.report.entity.ReportResolutionType;
 import com.example.demo.domain.report.entity.ReportStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "신고 처리 응답")
 public record ReportResolveResponse(
+        @Schema(description = "신고 ID", example = "1")
         Long reportId,
+        @Schema(description = "신고 상태", example = "RESOLVED")
         ReportStatus status,
+        @Schema(description = "적용된 처리 방식", example = "HIDE_COMMENT")
         ReportResolutionType resolutionType
 ) {
 }

--- a/src/main/java/com/example/demo/domain/report/dto/ReportResolveResponse.java
+++ b/src/main/java/com/example/demo/domain/report/dto/ReportResolveResponse.java
@@ -1,0 +1,11 @@
+package com.example.demo.domain.report.dto;
+
+import com.example.demo.domain.report.entity.ReportResolutionType;
+import com.example.demo.domain.report.entity.ReportStatus;
+
+public record ReportResolveResponse(
+        Long reportId,
+        ReportStatus status,
+        ReportResolutionType resolutionType
+) {
+}

--- a/src/main/java/com/example/demo/domain/report/entity/Report.java
+++ b/src/main/java/com/example/demo/domain/report/entity/Report.java
@@ -1,0 +1,74 @@
+package com.example.demo.domain.report.entity;
+
+import com.example.demo.domain.comment.entity.Comment;
+import com.example.demo.domain.post.entity.Post;
+import com.example.demo.domain.user.entity.User;
+import com.example.demo.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Report extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resolver_id")
+    private User resolver;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ReportTargetType targetType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ReportStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private ReportResolutionType resolutionType;
+
+    @Column(nullable = false, length = 255)
+    private String reason;
+
+    private Report(User reporter, Post post, Comment comment, ReportTargetType targetType, String reason) {
+        this.reporter = reporter;
+        this.post = post;
+        this.comment = comment;
+        this.targetType = targetType;
+        this.reason = reason;
+        this.status = ReportStatus.PENDING;
+    }
+
+    public static Report forPost(User reporter, Post post, String reason) {
+        return new Report(reporter, post, null, ReportTargetType.POST, reason);
+    }
+
+    public static Report forComment(User reporter, Comment comment, String reason) {
+        return new Report(reporter, null, comment, ReportTargetType.COMMENT, reason);
+    }
+
+    public void resolve(User resolver, ReportResolutionType resolutionType) {
+        this.resolver = resolver;
+        this.resolutionType = resolutionType;
+        this.status = ReportStatus.RESOLVED;
+    }
+}

--- a/src/main/java/com/example/demo/domain/report/entity/ReportResolutionType.java
+++ b/src/main/java/com/example/demo/domain/report/entity/ReportResolutionType.java
@@ -1,0 +1,7 @@
+package com.example.demo.domain.report.entity;
+
+public enum ReportResolutionType {
+    HIDE_POST,
+    HIDE_COMMENT,
+    REJECT
+}

--- a/src/main/java/com/example/demo/domain/report/entity/ReportStatus.java
+++ b/src/main/java/com/example/demo/domain/report/entity/ReportStatus.java
@@ -1,0 +1,6 @@
+package com.example.demo.domain.report.entity;
+
+public enum ReportStatus {
+    PENDING,
+    RESOLVED
+}

--- a/src/main/java/com/example/demo/domain/report/entity/ReportTargetType.java
+++ b/src/main/java/com/example/demo/domain/report/entity/ReportTargetType.java
@@ -1,0 +1,6 @@
+package com.example.demo.domain.report.entity;
+
+public enum ReportTargetType {
+    POST,
+    COMMENT
+}

--- a/src/main/java/com/example/demo/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/demo/domain/report/repository/ReportRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.domain.report.repository;
+
+import com.example.demo.domain.report.entity.Report;
+import com.example.demo.domain.report.entity.ReportStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+    boolean existsByReporterIdAndPostIdAndStatus(Long reporterId, Long postId, ReportStatus status);
+
+    boolean existsByReporterIdAndCommentIdAndStatus(Long reporterId, Long commentId, ReportStatus status);
+}

--- a/src/main/java/com/example/demo/domain/report/service/ReportService.java
+++ b/src/main/java/com/example/demo/domain/report/service/ReportService.java
@@ -1,0 +1,122 @@
+package com.example.demo.domain.report.service;
+
+import com.example.demo.domain.comment.entity.Comment;
+import com.example.demo.domain.comment.entity.CommentStatus;
+import com.example.demo.domain.comment.service.CommentService;
+import com.example.demo.domain.post.entity.Post;
+import com.example.demo.domain.post.entity.PostStatus;
+import com.example.demo.domain.post.repository.PostRepository;
+import com.example.demo.domain.report.dto.ReportCreateRequest;
+import com.example.demo.domain.report.dto.ReportCreateResponse;
+import com.example.demo.domain.report.dto.ReportResolveRequest;
+import com.example.demo.domain.report.dto.ReportResolveResponse;
+import com.example.demo.domain.report.entity.Report;
+import com.example.demo.domain.report.entity.ReportResolutionType;
+import com.example.demo.domain.report.entity.ReportStatus;
+import com.example.demo.domain.report.repository.ReportRepository;
+import com.example.demo.domain.user.entity.User;
+import com.example.demo.domain.user.repository.UserRepository;
+import com.example.demo.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final CommentService commentService;
+
+    @Transactional
+    public ReportCreateResponse reportPost(Long postId, ReportCreateRequest request) {
+        Post post = findPost(postId);
+        User reporter = findUser(request.reporterId());
+
+        if (post.getUser().getId().equals(reporter.getId())) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "SELF_REPORT_NOT_ALLOWED", "본인 게시글은 신고할 수 없습니다.");
+        }
+        if (reportRepository.existsByReporterIdAndPostIdAndStatus(reporter.getId(), postId, ReportStatus.PENDING)) {
+            throw new CustomException(HttpStatus.CONFLICT, "DUPLICATE_REPORT", "이미 처리 대기 중인 게시글 신고가 있습니다.");
+        }
+
+        Report report = reportRepository.save(Report.forPost(reporter, post, request.reason()));
+        return new ReportCreateResponse(report.getId(), report.getTargetType(), report.getStatus());
+    }
+
+    @Transactional
+    public ReportCreateResponse reportComment(Long commentId, ReportCreateRequest request) {
+        Comment comment = commentService.findComment(commentId);
+        User reporter = findUser(request.reporterId());
+
+        if (comment.getUser().getId().equals(reporter.getId())) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "SELF_REPORT_NOT_ALLOWED", "본인 댓글은 신고할 수 없습니다.");
+        }
+        if (reportRepository.existsByReporterIdAndCommentIdAndStatus(reporter.getId(), commentId, ReportStatus.PENDING)) {
+            throw new CustomException(HttpStatus.CONFLICT, "DUPLICATE_REPORT", "이미 처리 대기 중인 댓글 신고가 있습니다.");
+        }
+
+        Report report = reportRepository.save(Report.forComment(reporter, comment, request.reason()));
+        return new ReportCreateResponse(report.getId(), report.getTargetType(), report.getStatus());
+    }
+
+    @Transactional
+    public ReportResolveResponse resolveReport(Long reportId, ReportResolveRequest request) {
+        Report report = findReport(reportId);
+        User resolver = findUser(request.resolverId());
+
+        if (report.getStatus() == ReportStatus.RESOLVED) {
+            throw new CustomException(HttpStatus.CONFLICT, "REPORT_ALREADY_RESOLVED", "이미 처리 완료된 신고입니다.");
+        }
+
+        applyResolution(report, request.resolutionType());
+        report.resolve(resolver, request.resolutionType());
+
+        return new ReportResolveResponse(report.getId(), report.getStatus(), report.getResolutionType());
+    }
+
+    private void applyResolution(Report report, ReportResolutionType resolutionType) {
+        switch (resolutionType) {
+            case HIDE_POST -> {
+                if (report.getPost() == null) {
+                    throw new CustomException(HttpStatus.BAD_REQUEST, "INVALID_RESOLUTION", "댓글 신고에는 게시글 숨김 처리를 할 수 없습니다.");
+                }
+                if (report.getPost().getStatus() == PostStatus.HIDDEN) {
+                    throw new CustomException(HttpStatus.CONFLICT, "POST_ALREADY_HIDDEN", "이미 숨김 처리된 게시글입니다.");
+                }
+                report.getPost().hide();
+            }
+            case HIDE_COMMENT -> {
+                if (report.getComment() == null) {
+                    throw new CustomException(HttpStatus.BAD_REQUEST, "INVALID_RESOLUTION", "게시글 신고에는 댓글 숨김 처리를 할 수 없습니다.");
+                }
+                if (report.getComment().getStatus() == CommentStatus.HIDDEN) {
+                    throw new CustomException(HttpStatus.CONFLICT, "COMMENT_ALREADY_HIDDEN", "이미 숨김 처리된 댓글입니다.");
+                }
+                report.getComment().hide();
+            }
+            case REJECT -> {
+                // Intentionally left blank. Reject only changes the report state.
+            }
+        }
+    }
+
+    private Report findReport(Long reportId) {
+        return reportRepository.findById(reportId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "REPORT_NOT_FOUND", "해당 신고를 찾을 수 없습니다."));
+    }
+
+    private Post findPost(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "POST_NOT_FOUND", "해당 게시글을 찾을 수 없습니다."));
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "해당 사용자를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/example/demo/domain/user/entity/User.java
+++ b/src/main/java/com/example/demo/domain/user/entity/User.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "user")
+@Table(name = "users")
 public class User extends BaseEntity {
 
     // 유저 아이디
@@ -31,4 +31,12 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user")
     private List<Comment> comments = new ArrayList<>();
+
+    private User(String name) {
+        this.name = name;
+    }
+
+    public static User of(String name) {
+        return new User(name);
+    }
 }

--- a/src/main/java/com/example/demo/dto/RepeatRequest.java
+++ b/src/main/java/com/example/demo/dto/RepeatRequest.java
@@ -1,4 +1,10 @@
 package com.example.demo.dto;
 
-public record RepeatRequest(String value) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "문자열 반복 요청")
+public record RepeatRequest(
+        @Schema(description = "반복할 문자열", example = "hello")
+        String value
+) {
 }

--- a/src/main/java/com/example/demo/dto/RepeatResponse.java
+++ b/src/main/java/com/example/demo/dto/RepeatResponse.java
@@ -1,4 +1,12 @@
 package com.example.demo.dto;
 
-public record RepeatResponse(String string_one, String string_two) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "문자열 반복 응답")
+public record RepeatResponse(
+        @Schema(description = "첫 번째 문자열", example = "hello")
+        String string_one,
+        @Schema(description = "두 번째 문자열", example = "hello")
+        String string_two
+) {
 }

--- a/src/main/java/com/example/demo/global/config/OpenApiConfig.java
+++ b/src/main/java/com/example/demo/global/config/OpenApiConfig.java
@@ -1,0 +1,23 @@
+package com.example.demo.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Demo API")
+                        .description("게시글, 댓글, 신고 도메인을 포함한 데모 서버 API 문서입니다.")
+                        .version("v1")
+                        .contact(new Contact().name("Byun Seunghyun"))
+                        .license(new License().name("Internal Study Project")));
+    }
+}

--- a/src/main/java/com/example/demo/global/response/ApiResponse.java
+++ b/src/main/java/com/example/demo/global/response/ApiResponse.java
@@ -1,9 +1,16 @@
 package com.example.demo.global.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "공통 API 응답 형식")
 public record ApiResponse<T>(
+        @Schema(description = "요청 성공 여부", example = "true")
         boolean success,
+        @Schema(description = "응답 코드", example = "POST_CREATE_SUCCESS")
         String code,
+        @Schema(description = "응답 메시지", example = "게시글 생성 성공")
         String message,
+        @Schema(description = "응답 데이터")
         T data
 ) {
     public static <T> ApiResponse<T> success(String code, String message, T data) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,5 +4,5 @@ spring.datasource.url=jdbc:mysql://localhost:3306/leets_db
 spring.datasource.username=root
 spring.datasource.password=
 
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,5 @@ spring.datasource.password=
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.api-docs.path=/api-docs

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

- [x] 기존에 구현 중인 서버 프로젝트에 Swagger를 추가한다.
- [x] 실행 후 Swagger UI 페이지에 접속할 수 있어야 한다.
- [x] 현재 프로젝트에 구현되어 있는 API가 Swagger 문서에 표시되어야 한다.
- [x] 문서를 보고 각 API의 요청 방식과 URL, 요청값, 응답값을 확인할 수 있어야 한다.

## 2. 핵심 변경 사항
 
1. SwaggerConfig 클래스에서 API 문서 기본 정보 설정
2. Controller의 각 API마다 Operation, ApiResponses 애노테이션 추가 (API 설명, 성공/실패 응답)
3. DTO의 각 속성마다 Schema 애노테이션 추가 (설명, 예시)
4. global.exception.ErrorResponse 클래스 추가 (에러 발생 시 반환 되는 응답 구조 지정) -> Swagger의 ApiResponse 애노테이션에서 사용


## 3. 실행 및 검증 결과
<img width="1479" height="751" alt="스크린샷 2026-05-05 18 48 41" src="https://github.com/user-attachments/assets/94b72218-3470-4a1a-aec1-795e32b72f92" />



## 4. 완료 사항

Swagger 문서화 추가

## 5. 추가 사항

#190 

## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고

<!--
BE: rootTiket, soyesenna
FE: One-HyeWon, woneeee
-->
