### PR TITLE
[5주차] 이예서/[feat] swagger 문서화

### DIFF
--- a/leeyeseo/build.gradle
+++ b/leeyeseo/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     runtimeOnly 'com.h2database:h2'
+
+    // Swagger (springdoc-openapi)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.17'
 }
 
 tasks.named('test') {

--- a/leeyeseo/src/main/java/com/example/blog/config/SwaggerConfig.java
+++ b/leeyeseo/src/main/java/com/example/blog/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.example.blog.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("LEETS Blog API")
+                        .version("v1.0.0")
+                        .description("LEETS 7기 백엔드 블로그 프로젝트 API 명세서"));
+    }
+}

--- a/leeyeseo/src/main/java/com/example/blog/domain/comment/controller/CommentController.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/comment/controller/CommentController.java
@@ -1,0 +1,62 @@
+package com.example.blog.domain.comment.controller;
+
+import com.example.blog.domain.comment.service.CommentService;
+import com.example.blog.dto.comment.CommentCreateRequest;
+import com.example.blog.dto.comment.CommentResponse;
+import com.example.blog.dto.comment.CommentUpdateRequest;
+import com.example.blog.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Comment", description = "댓글 API")
+@RestController
+@RequestMapping("/posts/{postId}/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    // GET /posts/{postId}/comments - 댓글 목록 조회
+    @Operation(summary = "댓글 목록 조회", description = "특정 게시글에 달린 모든 댓글을 작성 시간 오름차순으로 조회합니다.")
+    @GetMapping
+    public ApiResponse<List<CommentResponse>> getComments(@PathVariable Long postId) {
+        return ApiResponse.onSuccess(commentService.getComments(postId));
+    }
+
+    // POST /posts/{postId}/comments - 댓글 작성
+    @Operation(summary = "댓글 작성", description = "특정 게시글에 댓글을 작성합니다. 헤더의 X-USER-ID로 작성자를 식별합니다.")
+    @PostMapping
+    public ApiResponse<CommentResponse> createComment(
+            @RequestHeader("X-USER-ID") Long userId,
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentCreateRequest request) {
+        return ApiResponse.onSuccess(commentService.createComment(userId, postId, request));
+    }
+
+    // PATCH /posts/{postId}/comments/{commentId} - 댓글 수정
+    @Operation(summary = "댓글 수정", description = "특정 게시글의 댓글을 수정합니다. 작성자만 수정 가능합니다.")
+    @PatchMapping("/{commentId}")
+    public ApiResponse<CommentResponse> updateComment(
+            @RequestHeader("X-USER-ID") Long userId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @Valid @RequestBody CommentUpdateRequest request) {
+        return ApiResponse.onSuccess(commentService.updateComment(userId, postId, commentId, request));
+    }
+
+    // DELETE /posts/{postId}/comments/{commentId} - 댓글 삭제
+    @Operation(summary = "댓글 삭제", description = "특정 게시글의 댓글을 삭제합니다 (soft delete). 작성자만 삭제 가능합니다.")
+    @DeleteMapping("/{commentId}")
+    public ApiResponse<Void> deleteComment(
+            @RequestHeader("X-USER-ID") Long userId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId) {
+        commentService.deleteComment(userId, postId, commentId);
+        return ApiResponse.onSuccess();
+    }
+}

--- a/leeyeseo/src/main/java/com/example/blog/domain/comment/converter/CommentConverter.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/comment/converter/CommentConverter.java
@@ -1,0 +1,32 @@
+package com.example.blog.domain.comment.converter;
+
+import com.example.blog.domain.comment.entity.Comment;
+import com.example.blog.domain.post.entity.Post;
+import com.example.blog.domain.user.entity.User;
+import com.example.blog.dto.comment.CommentCreateRequest;
+import com.example.blog.dto.comment.CommentResponse;
+
+public class CommentConverter {
+
+    // CommentCreateRequest + User + Post → Comment Entity
+    public static Comment toEntity(CommentCreateRequest request, User user, Post post) {
+        return Comment.builder()
+                .user(user)
+                .post(post)
+                .content(request.getContent())
+                .build();
+    }
+
+    // Comment Entity → CommentResponse
+    public static CommentResponse toResponse(Comment comment) {
+        return CommentResponse.builder()
+                .id(comment.getId())
+                .postId(comment.getPost().getId())
+                .authorId(comment.getUser().getId())
+                .authorNickname(comment.getUser().getNickname())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .build();
+    }
+}

--- a/leeyeseo/src/main/java/com/example/blog/domain/comment/repository/CommentRepository.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,16 @@
+package com.example.blog.domain.comment.repository;
+
+import com.example.blog.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    // 게시글의 댓글 목록 조회 (삭제되지 않은 것만, 작성 시간 오름차순)
+    List<Comment> findAllByPostIdAndDeletedAtIsNullOrderByCreatedAtAsc(Long postId);
+
+    // 댓글 단건 조회 (삭제되지 않은 것만)
+    Optional<Comment> findByIdAndDeletedAtIsNull(Long id);
+}

--- a/leeyeseo/src/main/java/com/example/blog/domain/comment/service/CommentService.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/comment/service/CommentService.java
@@ -1,0 +1,93 @@
+package com.example.blog.domain.comment.service;
+
+import com.example.blog.domain.comment.converter.CommentConverter;
+import com.example.blog.domain.comment.entity.Comment;
+import com.example.blog.domain.comment.repository.CommentRepository;
+import com.example.blog.domain.post.entity.Post;
+import com.example.blog.domain.post.repository.PostRepository;
+import com.example.blog.domain.user.entity.User;
+import com.example.blog.domain.user.repository.UserRepository;
+import com.example.blog.dto.comment.CommentCreateRequest;
+import com.example.blog.dto.comment.CommentResponse;
+import com.example.blog.dto.comment.CommentUpdateRequest;
+import com.example.blog.exception.CommentForbiddenException;
+import com.example.blog.exception.CommentNotFoundException;
+import com.example.blog.exception.PostNotFoundException;
+import com.example.blog.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    // 댓글 목록 조회 (특정 게시글)
+    @Transactional(readOnly = true)
+    public List<CommentResponse> getComments(Long postId) {
+        // 게시글 존재 여부 확인
+        postRepository.findByIdAndDeletedAtIsNull(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        return commentRepository.findAllByPostIdAndDeletedAtIsNullOrderByCreatedAtAsc(postId)
+                .stream()
+                .map(CommentConverter::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    // 댓글 작성
+    @Transactional
+    public CommentResponse createComment(Long userId, Long postId, CommentCreateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        Post post = postRepository.findByIdAndDeletedAtIsNull(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        Comment comment = CommentConverter.toEntity(request, user, post);
+        commentRepository.save(comment);
+        return CommentConverter.toResponse(comment);
+    }
+
+    // 댓글 수정
+    @Transactional
+    public CommentResponse updateComment(Long userId, Long postId, Long commentId, CommentUpdateRequest request) {
+        // 게시글 존재 여부 확인
+        postRepository.findByIdAndDeletedAtIsNull(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new CommentForbiddenException();
+        }
+
+        comment.update(request.getContent());
+        return CommentConverter.toResponse(comment);
+    }
+
+    // 댓글 삭제 (soft delete)
+    @Transactional
+    public void deleteComment(Long userId, Long postId, Long commentId) {
+        // 게시글 존재 여부 확인
+        postRepository.findByIdAndDeletedAtIsNull(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new CommentForbiddenException();
+        }
+
+        comment.delete();
+    }
+}

--- a/leeyeseo/src/main/java/com/example/blog/domain/post/controller/PostController.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/post/controller/PostController.java
@@ -6,12 +6,15 @@ import com.example.blog.dto.post.PostDetailResponse;
 import com.example.blog.dto.post.PostSummaryResponse;
 import com.example.blog.dto.post.PostUpdateRequest;
 import com.example.blog.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Post", description = "게시글 API")
 @RestController
 @RequestMapping("/posts")
 @RequiredArgsConstructor
@@ -20,18 +23,21 @@ public class PostController {
     private final PostService postService;
 
     // GET /posts - 게시글 목록 조회
+    @Operation(summary = "게시글 목록 조회", description = "활성 상태인 모든 게시글 목록을 조회합니다.")
     @GetMapping
     public ApiResponse<List<PostSummaryResponse>> getPosts() {
         return ApiResponse.onSuccess(postService.getPosts());
     }
 
     // GET /posts/{postId} - 게시글 상세 조회
+    @Operation(summary = "게시글 상세 조회", description = "특정 게시글의 상세 정보를 조회합니다.")
     @GetMapping("/{postId}")
     public ApiResponse<PostDetailResponse> getPost(@PathVariable Long postId) {
         return ApiResponse.onSuccess(postService.getPost(postId));
     }
 
     // POST /posts - 게시글 작성
+    @Operation(summary = "게시글 작성", description = "새로운 게시글을 작성합니다. 헤더의 X-USER-ID로 작성자를 식별합니다.")
     @PostMapping
     public ApiResponse<PostDetailResponse> createPost(
             @RequestHeader("X-USER-ID") Long userId,
@@ -40,6 +46,7 @@ public class PostController {
     }
 
     // PATCH /posts/{postId} - 게시글 수정
+    @Operation(summary = "게시글 수정", description = "게시글의 제목과 내용을 수정합니다. 작성자만 수정 가능합니다.")
     @PatchMapping("/{postId}")
     public ApiResponse<PostDetailResponse> updatePost(
             @RequestHeader("X-USER-ID") Long userId,
@@ -49,6 +56,7 @@ public class PostController {
     }
 
     // DELETE /posts/{postId} - 게시글 삭제
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다 (soft delete). 작성자만 삭제 가능합니다.")
     @DeleteMapping("/{postId}")
     public ApiResponse<Void> deletePost(
             @RequestHeader("X-USER-ID") Long userId,
@@ -58,6 +66,11 @@ public class PostController {
     }
 
     // PATCH /posts/{postId}/hide - 게시글 숨김
+    @Operation(
+            summary = "게시글 숨김",
+            description = "작성자가 자신의 게시글을 임시 비공개 상태(HIDDEN)로 전환합니다. " +
+                    "관리자에 의한 부적절 콘텐츠 차단은 신고 처리 도메인에서 다룹니다."
+    )
     @PatchMapping("/{postId}/hide")
     public ApiResponse<Void> hidePost(
             @RequestHeader("X-USER-ID") Long userId,

--- a/leeyeseo/src/main/java/com/example/blog/domain/report/controller/ReportController.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/report/controller/ReportController.java
@@ -4,10 +4,13 @@ import com.example.blog.domain.report.service.ReportService;
 import com.example.blog.dto.report.ReportCreateRequest;
 import com.example.blog.dto.report.ReportResponse;
 import com.example.blog.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Report", description = "게시글 신고 API")
 @RestController
 @RequiredArgsConstructor
 public class ReportController {
@@ -15,6 +18,11 @@ public class ReportController {
     private final ReportService reportService;
 
     // POST /posts/{postId}/reports - 게시물 신고
+    @Operation(
+            summary = "게시글 신고",
+            description = "특정 게시글을 신고합니다. " +
+                    "동일 사용자가 같은 게시글을 중복 신고할 수 없습니다."
+    )
     @PostMapping("/posts/{postId}/reports")
     public ApiResponse<ReportResponse> createReport(
             @RequestHeader("X-USER-ID") Long userId,
@@ -24,6 +32,11 @@ public class ReportController {
     }
 
     // PATCH /reports/{reportId}/resolve - 신고 처리 완료
+    @Operation(
+            summary = "신고 처리 완료",
+            description = "PENDING 상태인 신고를 RESOLVED 상태로 변경합니다. " +
+                    "이미 처리된 신고는 다시 처리할 수 없습니다."
+    )
     @PatchMapping("/reports/{reportId}/resolve")
     public ApiResponse<ReportResponse> resolveReport(
             @PathVariable Long reportId) {

--- a/leeyeseo/src/main/java/com/example/blog/dto/comment/CommentCreateRequest.java
+++ b/leeyeseo/src/main/java/com/example/blog/dto/comment/CommentCreateRequest.java
@@ -1,0 +1,18 @@
+package com.example.blog.dto.comment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "댓글 작성 요청 DTO")
+public class CommentCreateRequest {
+
+    @Schema(description = "댓글 내용", example = "좋은 글이네요!", maxLength = 500)
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Size(max = 500, message = "댓글은 최대 500자까지 입력 가능합니다.")
+    private String content;
+}

--- a/leeyeseo/src/main/java/com/example/blog/dto/comment/CommentResponse.java
+++ b/leeyeseo/src/main/java/com/example/blog/dto/comment/CommentResponse.java
@@ -1,0 +1,38 @@
+package com.example.blog.dto.comment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "댓글 응답 DTO")
+public class CommentResponse {
+
+    @Schema(description = "댓글 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "댓글이 달린 게시글 ID", example = "5")
+    private Long postId;
+
+    @Schema(description = "작성자 ID", example = "10")
+    private Long authorId;
+
+    @Schema(description = "작성자 닉네임", example = "yeseo")
+    private String authorNickname;
+
+    @Schema(description = "댓글 내용", example = "좋은 글이네요!")
+    private String content;
+
+    @Schema(description = "작성 일시", example = "2026-04-29T10:30:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 일시", example = "2026-04-29T11:00:00")
+    private LocalDateTime updatedAt;
+}

--- a/leeyeseo/src/main/java/com/example/blog/dto/comment/CommentUpdateRequest.java
+++ b/leeyeseo/src/main/java/com/example/blog/dto/comment/CommentUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.example.blog.dto.comment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "댓글 수정 요청 DTO")
+public class CommentUpdateRequest {
+
+    @Schema(description = "수정할 댓글 내용", example = "수정된 댓글입니다.", maxLength = 500)
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Size(max = 500, message = "댓글은 최대 500자까지 입력 가능합니다.")
+    private String content;
+}

--- a/leeyeseo/src/main/java/com/example/blog/dto/post/PostCreateRequest.java
+++ b/leeyeseo/src/main/java/com/example/blog/dto/post/PostCreateRequest.java
@@ -1,5 +1,6 @@
 package com.example.blog.dto.post;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -7,14 +8,18 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "게시글 작성 요청 DTO")
 public class PostCreateRequest {
 
+    @Schema(description = "게시글 제목", example = "첫 게시글입니다", maxLength = 255)
     @NotBlank(message = "제목은 필수입니다.")
     @Size(max = 255, message = "제목은 최대 255자까지 입력 가능합니다.")
     private String title;
 
+    @Schema(description = "게시글 본문", example = "안녕하세요, 반갑습니다!")
     @NotBlank(message = "본문은 필수입니다.")
     private String content;
 
+    @Schema(description = "이미지 URL (선택)", example = "https://example.com/image.png")
     private String imageUrl;
 }

--- a/leeyeseo/src/main/java/com/example/blog/dto/post/PostDetailResponse.java
+++ b/leeyeseo/src/main/java/com/example/blog/dto/post/PostDetailResponse.java
@@ -1,5 +1,6 @@
 package com.example.blog.dto.post;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,13 +12,27 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "게시글 상세 조회 응답 DTO")
 public class PostDetailResponse {
 
+    @Schema(description = "게시글 ID", example = "1")
     private Long id;
+
+    @Schema(description = "게시글 제목", example = "첫 게시글입니다")
     private String title;
+
+    @Schema(description = "게시글 본문", example = "안녕하세요, 반갑습니다!")
     private String content;
+
+    @Schema(description = "이미지 URL", example = "https://example.com/image.png")
     private String imageUrl;
+
+    @Schema(description = "작성자 닉네임", example = "yeseo")
     private String authorNickname;
+
+    @Schema(description = "작성 일시", example = "2026-04-29T10:30:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "수정 일시", example = "2026-04-29T11:00:00")
     private LocalDateTime updatedAt;
 }

--- a/leeyeseo/src/main/java/com/example/blog/dto/post/PostSummaryResponse.java
+++ b/leeyeseo/src/main/java/com/example/blog/dto/post/PostSummaryResponse.java
@@ -1,5 +1,6 @@
 package com.example.blog.dto.post;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,10 +12,18 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "게시글 목록 조회 응답 DTO")
 public class PostSummaryResponse {
 
+    @Schema(description = "게시글 ID", example = "1")
     private Long id;
+
+    @Schema(description = "게시글 제목", example = "첫 게시글입니다")
     private String title;
+
+    @Schema(description = "작성자 닉네임", example = "yeseo")
     private String authorNickname;
+
+    @Schema(description = "작성 일시", example = "2026-04-29T10:30:00")
     private LocalDateTime createdAt;
 }

--- a/leeyeseo/src/main/java/com/example/blog/dto/post/PostUpdateRequest.java
+++ b/leeyeseo/src/main/java/com/example/blog/dto/post/PostUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.example.blog.dto.post;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -7,14 +8,18 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "게시글 수정 요청 DTO")
 public class PostUpdateRequest {
 
+    @Schema(description = "수정할 게시글 제목", example = "수정된 제목입니다", maxLength = 255)
     @NotBlank(message = "제목은 필수입니다.")
     @Size(max = 255, message = "제목은 최대 255자까지 입력 가능합니다.")
     private String title;
 
+    @Schema(description = "수정할 게시글 본문", example = "수정된 본문 내용입니다.")
     @NotBlank(message = "본문은 필수입니다.")
     private String content;
 
+    @Schema(description = "수정할 이미지 URL (선택)", example = "https://example.com/new-image.png")
     private String imageUrl;
 }

--- a/leeyeseo/src/main/java/com/example/blog/dto/report/ReportCreateRequest.java
+++ b/leeyeseo/src/main/java/com/example/blog/dto/report/ReportCreateRequest.java
@@ -1,5 +1,6 @@
 package com.example.blog.dto.report;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -7,8 +8,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "게시글 신고 요청 DTO")
 public class ReportCreateRequest {
 
+    @Schema(description = "신고 사유", example = "부적절한 홍보성 게시글입니다.", maxLength = 500)
     @NotBlank(message = "신고 사유는 필수입니다.")
     @Size(max = 500, message = "신고 사유는 최대 500자까지 입력 가능합니다.")
     private String reason;

--- a/leeyeseo/src/main/java/com/example/blog/dto/report/ReportResponse.java
+++ b/leeyeseo/src/main/java/com/example/blog/dto/report/ReportResponse.java
@@ -1,6 +1,7 @@
 package com.example.blog.dto.report;
 
 import com.example.blog.domain.report.entity.ReportStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,12 +13,24 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "신고 응답 DTO")
 public class ReportResponse {
 
+    @Schema(description = "신고 ID", example = "1")
     private Long id;
+
+    @Schema(description = "신고된 게시글 ID", example = "5")
     private Long postId;
+
+    @Schema(description = "신고자 ID", example = "10")
     private Long reporterId;
+
+    @Schema(description = "신고 사유", example = "부적절한 홍보성 게시글입니다.")
     private String reason;
+
+    @Schema(description = "신고 처리 상태 (PENDING: 대기, RESOLVED: 처리완료)", example = "PENDING")
     private ReportStatus status;
+
+    @Schema(description = "신고 일시", example = "2026-04-29T10:30:00")
     private LocalDateTime createdAt;
 }

--- a/leeyeseo/src/main/java/com/example/blog/exception/CommentForbiddenException.java
+++ b/leeyeseo/src/main/java/com/example/blog/exception/CommentForbiddenException.java
@@ -1,0 +1,15 @@
+package com.example.blog.exception;
+
+public class CommentForbiddenException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CommentForbiddenException() {
+        super(ErrorCode.NOT_COMMENT_OWNER.getMessage());
+        this.errorCode = ErrorCode.NOT_COMMENT_OWNER;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/leeyeseo/src/main/java/com/example/blog/exception/CommentNotFoundException.java
+++ b/leeyeseo/src/main/java/com/example/blog/exception/CommentNotFoundException.java
@@ -1,0 +1,15 @@
+package com.example.blog.exception;
+
+public class CommentNotFoundException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CommentNotFoundException(Long commentId) {
+        super(ErrorCode.COMMENT_NOT_FOUND.getMessage() + " id: " + commentId);
+        this.errorCode = ErrorCode.COMMENT_NOT_FOUND;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/leeyeseo/src/main/java/com/example/blog/exception/ErrorCode.java
+++ b/leeyeseo/src/main/java/com/example/blog/exception/ErrorCode.java
@@ -16,12 +16,14 @@ public enum ErrorCode {
     // 403
     FORBIDDEN(HttpStatus.FORBIDDEN, "403_000", "접근 권한이 없습니다."),
     NOT_POST_OWNER(HttpStatus.FORBIDDEN, "403_001", "해당 게시글의 작성자가 아닙니다."),
+    NOT_COMMENT_OWNER(HttpStatus.FORBIDDEN, "403_002", "해당 댓글의 작성자가 아닙니다."),
 
     // 404
     NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, "404_000", "존재하지 않는 API 경로입니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "404_001", "요청하신 게시글을 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "404_002", "사용자를 찾을 수 없습니다."),
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "404_003", "요청하신 신고를 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "404_004", "요청하신 댓글을 찾을 수 없습니다."),
 
     // 409 (중복/충돌)
     DUPLICATE_REPORT(HttpStatus.CONFLICT, "409_001", "이미 신고한 게시글입니다."),

--- a/leeyeseo/src/main/java/com/example/blog/exception/GlobalExceptionHandler.java
+++ b/leeyeseo/src/main/java/com/example/blog/exception/GlobalExceptionHandler.java
@@ -99,6 +99,28 @@ public class GlobalExceptionHandler {
                 ));
     }
 
+    // 댓글 없음 404
+    @ExceptionHandler(CommentNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCommentNotFound(CommentNotFoundException e) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.onFailure(
+                        e.getErrorCode().getCode(),
+                        e.getMessage()
+                ));
+    }
+
+    // 댓글 권한 없음 403
+    @ExceptionHandler(CommentForbiddenException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCommentForbidden(CommentForbiddenException e) {
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.onFailure(
+                        e.getErrorCode().getCode(),
+                        e.getMessage()
+                ));
+    }
+
     // @Valid 검증 실패 400
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException e) {

--- a/leeyeseo/src/main/java/com/example/blog/global/response/ApiResponse.java
+++ b/leeyeseo/src/main/java/com/example/blog/global/response/ApiResponse.java
@@ -3,18 +3,25 @@ package com.example.blog.global.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 @JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+@Schema(description = "공통 API 응답 포맷")
 public class ApiResponse<T> {
 
+    @Schema(description = "요청 성공 여부", example = "true")
     @JsonProperty("isSuccess")
     private final Boolean isSuccess;
 
+    @Schema(description = "응답 코드 (성공: 2000, 실패: 4xx_xxx / 5xx_xxx)", example = "2000")
     private final String code;
+
+    @Schema(description = "응답 메시지", example = "OK")
     private final String message;
 
+    @Schema(description = "응답 데이터 (실패 시 null)")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final T result;
 


### PR DESCRIPTION
<!--
제목: [주차] {이름}/[타입] {작업 내용}
예시: [1주차] 조혜원/[feat] 초기 프로젝트 설정
-->

## 1. 과제 요구사항 중 구현한 내용

- **Swagger 적용**: `springdoc-openapi`를 통해 모든 API 명세를 `/swagger-ui.html`에서 확인 가능하도록 구성
- **Tag 그룹화**: Post / Report / Comment 도메인별로 API 분류
- **DTO 문서화**: 모든 Request/Response DTO 필드에 description / example 명시
- **공통 응답 포맷 문서화**: `ApiResponse`의 isSuccess / code / message / result 필드에 `@Schema` 적용
- **댓글(Comment) 도메인 API 신규 구현**: 문서화 작업 중 발견한 누락 도메인 보완


## 2. 핵심 변경 사항

### Swagger 문서화 
- `springdoc-openapi-starter-webmvc-ui:2.8.17` 의존성 추가
- `SwaggerConfig` 신규 생성 (OpenAPI 메타 정보 설정)
- Controller에 `@Tag` / `@Operation` 어노테이션 추가
- DTO에 `@Schema` 어노테이션으로 description / example 명시
- `ApiResponse` 공통 응답 포맷 문서화
- `hide` API description에 4주차 코드리뷰 답변 내용 반영 ("작성자 본인의 임시 비공개 용도이며, 부적절 콘텐츠 차단은 신고 처리 도메인에서 다룸")

### 댓글(Comment) 도메인 API 추가
Swagger로 전체 API를 정리하면서 **블로그의 핵심 기능인 댓글 API가 누락되어 있음**을 발견하여 함께 구현했습니다.
- `CommentRepository`, `CommentService`, `CommentController`, `CommentConverter` 신규 생성
- DTO 3종 (`CommentCreateRequest`, `CommentUpdateRequest`, `CommentResponse`)
- 예외 처리: `CommentNotFoundException`, `CommentForbiddenException` + `ErrorCode` / `GlobalExceptionHandler` 보강
- 작성자 본인만 수정/삭제 가능한 권한 검증 로직
- soft delete 적용

## 3. 실행 및 검증 결과

<img width="656" height="704" alt="스크린샷 2026-05-05 오후 11 21 54" src="https://github.com/user-attachments/assets/0c81a36f-2a77-474f-b1f0-9de93c8ff2a6" />
<img width="649" height="493" alt="스크린샷 2026-05-05 오후 11 25 53" src="https://github.com/user-attachments/assets/6448dd00-7012-4cd5-a52d-896db0fad284" />
<img width="647" height="572" alt="스크린샷 2026-05-05 오후 11 26 03" src="https://github.com/user-attachments/assets/0d0f5282-dbab-458b-8254-a1dd22ee4000" />
<img width="657" height="634" alt="스크린샷 2026-05-05 오후 11 24 02" src="https://github.com/user-attachments/assets/85c3627b-eb90-45c8-83af-a1e540f528b4" />
<img width="647" height="472" alt="스크린샷 2026-05-05 오후 11 24 11" src="https://github.com/user-attachments/assets/29274744-290c-4db7-bf19-03e25e247d09" />






- 실행 결과:
- `GET /health` 응답:
- `POST /string/repeat` 요청/응답:


## 4. 완료 사항

- [x] Swagger 의존성 추가 및 정상 빌드
- [x] `http://localhost:8080/swagger-ui.html` 접속 확인
- [x] 모든 API가 도메인별 Tag로 그룹화되어 표시
- [x] DTO 필드 description / example 적용
- [x] 댓글 작성/조회/수정/삭제 정상 동작
- [x] 댓글 권한 검증 (작성자 외 수정/삭제 시 403)
- [x] Try it out으로 직접 요청 테스트 정상 동작


## 5. 추가 사항

- 관련 이슈: `closed #이슈번호`
- 문서화 과정에서 Comment 도메인이 엔티티만 정의되고 API가 누락된 상태임을 발견했습니다. 블로그 프로젝트의 핵심 기능인 만큼 같은 PR에 함께 보완했습니다.

## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고

<!--
BE: rootTiket, soyesenna
FE: One-HyeWon, woneeee
-->
