### PR TITLE
[5주차] 조연준/[feat] swagger 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.17'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/leets_exercise1/swagger/ApiErrorCodeExample.java
+++ b/src/main/java/com/example/leets_exercise1/swagger/ApiErrorCodeExample.java
@@ -1,0 +1,103 @@
+package com.example.leets_exercise1.swagger;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApiErrorCodeExample {
+
+    BAD_REQUEST(
+            "잘못된 요청",
+            "필수값 누락 또는 형식 오류",
+            """
+            {
+              "success": false,
+              "code": "4000",
+              "message": "잘못된 요청입니다.",
+              "result": {
+                "message": "입력값을 다시 확인해주세요."
+              }
+            }
+            """
+    ),
+
+    POST_NOT_FOUND(
+            "게시글 없음",
+            "존재하지 않는 게시글 ID 요청",
+            """
+            {
+              "success": false,
+              "code": "4040",
+              "message": "해당 게시글을 찾을 수 없습니다.",
+              "result": {
+                "message": "해당 게시글을 찾을 수 없습니다."
+              }
+            }
+            """
+    ),
+
+    COMMENT_NOT_FOUND(
+            "댓글 없음",
+            "존재하지 않는 댓글 ID 요청",
+            """
+            {
+              "success": false,
+              "code": "4042",
+              "message": "해당 댓글을 찾을 수 없습니다.",
+              "result": {
+                "message": "해당 댓글을 찾을 수 없습니다."
+              }
+            }
+            """
+    ),
+
+    REPORT_NOT_FOUND(
+            "신고 없음",
+            "존재하지 않는 신고 ID 요청",
+            """
+            {
+              "success": false,
+              "code": "4043",
+              "message": "해당 신고를 찾을 수 없습니다.",
+              "result": {
+                "message": "해당 신고를 찾을 수 없습니다."
+              }
+            }
+            """
+    ),
+
+    DUPLICATE_REPORT(
+            "중복 신고",
+            "같은 사용자가 동일 대상을 다시 신고",
+            """
+            {
+              "success": false,
+              "code": "4090",
+              "message": "이미 신고한 대상입니다.",
+              "result": {
+                "message": "이미 신고한 대상입니다."
+              }
+            }
+            """
+    ),
+
+    INTERNAL_SERVER_ERROR(
+            "서버 내부 오류",
+            "예상하지 못한 서버 오류",
+            """
+            {
+              "success": false,
+              "code": "5000",
+              "message": "서버 내부 오류가 발생했습니다.",
+              "result": {
+                "message": "서버 내부 오류가 발생했습니다."
+              }
+            }
+            """
+    );
+
+    private final String summary;
+    private final String description;
+    private final String body;
+}

--- a/src/main/java/com/example/leets_exercise1/swagger/SwaggerConfig.java
+++ b/src/main/java/com/example/leets_exercise1/swagger/SwaggerConfig.java
@@ -1,0 +1,27 @@
+package com.example.leets_exercise1.swagger;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Leets Exercise API")
+                        .description("게시글 / 댓글 / 신고 도메인 기반 API 문서입니다.")
+                        .version("v1.0.0")
+                        .contact(new Contact().name("조연준")))
+                .servers(List.of(
+                        new Server().url("http://localhost:8081").description("Local Server")
+                ));
+    }
+}

--- a/src/main/java/com/example/leets_exercise1/swagger/SwaggerOperationCustomizer.java
+++ b/src/main/java/com/example/leets_exercise1/swagger/SwaggerOperationCustomizer.java
@@ -1,0 +1,68 @@
+package com.example.leets_exercise1.swagger;
+
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+@Component
+public class SwaggerOperationCustomizer implements OperationCustomizer {
+
+    @Override
+    public io.swagger.v3.oas.models.Operation customize(
+            io.swagger.v3.oas.models.Operation operation,
+            HandlerMethod handlerMethod
+    ) {
+        ApiResponses responses = operation.getResponses();
+
+        addExampleResponse(responses, "400", "잘못된 요청", ApiErrorCodeExample.BAD_REQUEST);
+        addExampleResponse(responses, "500", "서버 내부 오류", ApiErrorCodeExample.INTERNAL_SERVER_ERROR);
+
+        String controllerName = handlerMethod.getBeanType().getSimpleName();
+        String methodName = handlerMethod.getMethod().getName();
+
+        if (controllerName.equals("PostController")) {
+            addExampleResponse(responses, "404", "게시글 없음", ApiErrorCodeExample.POST_NOT_FOUND);
+        }
+
+        if (controllerName.equals("ReportController")) {
+            addExampleResponse(responses, "404", "댓글/신고 없음", ApiErrorCodeExample.REPORT_NOT_FOUND);
+            addExampleResponse(responses, "409", "중복 신고", ApiErrorCodeExample.DUPLICATE_REPORT);
+        }
+
+        if (controllerName.equals("CommentController")) {
+            addExampleResponse(responses, "404", "댓글 없음", ApiErrorCodeExample.COMMENT_NOT_FOUND);
+        }
+
+        return operation;
+    }
+
+    private void addExampleResponse(
+            ApiResponses responses,
+            String statusCode,
+            String description,
+            ApiErrorCodeExample exampleCode
+    ) {
+        Example example = new Example()
+                .summary(exampleCode.getSummary())
+                .description(exampleCode.getDescription())
+                .value(exampleCode.getBody());
+
+        MediaType mediaType = new MediaType()
+                .addExamples(exampleCode.name(), example);
+
+        Content content = new Content()
+                .addMediaType(org.springframework.http.MediaType.APPLICATION_JSON_VALUE, mediaType);
+
+        io.swagger.v3.oas.models.responses.ApiResponse apiResponse =
+                new io.swagger.v3.oas.models.responses.ApiResponse()
+                        .description(description)
+                        .content(content);
+
+        responses.addApiResponse(statusCode, apiResponse);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,5 @@ spring.jpa.properties.hibernate.format_sql=true
 
 spring.sql.init.mode=always
 spring.jpa.defer-datasource-initialization=true
+
+springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
<!--
제목: [주차] {이름}/[타입] {작업 내용}
예시: [1주차] 조혜원/[feat] 초기 프로젝트 설정
-->

## 1. 과제 요구사항 중 구현한 내용

- [x] 기존 서버 프로젝트에 Swagger 추가
- [x] 실행 후 Swagger UI 페이지 접속 가능하도록 설정
- [x] 현재 구현된 API가 Swagger 문서에 표시되도록 구성
- [x] 문서를 통해 각 API의 요청 방식 / URL / 요청값 / 응답값 확인 가능하도록 구성


## 2. 핵심 변경 사항

- Spring Boot 프로젝트에 `springdoc-openapi` 의존성을 추가했습니다.
- Swagger UI 경로를 설정하여 브라우저에서 문서 페이지에 접속할 수 있도록 구성했습니다.
- 기존에 구현된 게시글 / 댓글 / 신고 관련 API가 Swagger 문서에 표시되도록 반영했습니다.
- 필요한 Controller / DTO에 설명 및 예시를 추가하여 문서 가독성을 보완했습니다.
- 공통 응답 및 에러 응답 구조가 Swagger 상에서 확인될 수 있도록 구성했습니다.


## 3. 실행 및 검증 결과

- 실행 결과:
  - Spring Boot 애플리케이션 정상 실행 확인
  - Swagger UI 페이지 정상 접속 확인

- Swagger 확인 내용:
  - 현재 구현된 API 목록 표시 확인
  - 각 API의 Method / URL 확인
  - Request Body / Parameter 확인
  - Response Body / 상태 코드 확인

- 접속 경로:
  - `http://localhost:8081/swagger-ui.html`

- 필요 시 실행 캡처는 본문 또는 댓글에 추가 예정입니다.

<img width="1901" height="936" alt="스웨거 url 접속" src="https://github.com/user-attachments/assets/ae06a034-cd06-49ef-98a0-393c83f9d819" />
<img width="1806" height="868" alt="get posts 스웨거" src="https://github.com/user-attachments/assets/a670444e-51a6-4076-aa95-8fe9057430de" />
<img width="1900" height="922" alt="get posts 스웨거_2" src="https://github.com/user-attachments/assets/acddedac-92ac-42df-96b3-b9061b0e813e" />
<img width="1882" height="922" alt="get posts 스웨거_3" src="https://github.com/user-attachments/assets/381f9426-aee8-4dbb-aed5-c9eccd4861b3" />



## 4. 완료 사항

1. Swagger 의존성 추가
2. Swagger UI 경로 설정
3. 기존 API 문서 자동 노출 확인
4. 요청 / 응답 구조 확인 가능하도록 구성
5. 일부 API 설명 및 예시 보강


## 5. 추가 사항

- 관련 이슈: `closes #이슈번호`
- 이번 과제에서는 새 API를 추가하지 않고, 기존 API 문서화에 집중했습니다.
- 필요한 경우 이후 Swagger 설명을 추가로 보완할 예정입니다.


## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고

<!--
BE: rootTiket, soyesenna
FE: One-HyeWon, woneeee
-->

