### PR TITLE
[6주차] 김지훈/[feat] Spring Security + JWT 인증/인가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,16 +26,27 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 
-	//swagger
+	// swagger
 	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0"
 
 	// validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// Mysql
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/example/leets_7th/common/auth/CustomUserDetails.java
+++ b/src/main/java/com/example/leets_7th/common/auth/CustomUserDetails.java
@@ -1,0 +1,61 @@
+package com.example.leets_7th.common.auth;
+
+import com.example.leets_7th.domain.user.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    // 권한 반환 (ROLE_USER, ROLE_ADMIN 등)
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+    }
+
+    // 인증 정보
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    // 계정 상태
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    // 편의 메서드
+    public Long getUserId() {
+        return user.getId();
+    }
+}

--- a/src/main/java/com/example/leets_7th/common/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/example/leets_7th/common/auth/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package com.example.leets_7th.common.auth;
+
+import com.example.leets_7th.common.exception.GeneralException;
+import com.example.leets_7th.common.status.ErrorStatus;
+import com.example.leets_7th.domain.user.entity.User;
+import com.example.leets_7th.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/com/example/leets_7th/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/leets_7th/common/config/SecurityConfig.java
@@ -1,0 +1,117 @@
+package com.example.leets_7th.common.config;
+
+
+import com.example.leets_7th.common.jwt.JwtAccessDeniedHandler;
+import com.example.leets_7th.common.jwt.JwtAuthenticationEntryPoint;
+import com.example.leets_7th.common.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    /** Swagger 관련 경로 */
+    private static final String[] SWAGGER_URIS = {
+            "/",
+            "/swagger-ui/**",
+            "/api-docs/**",
+            "/v3/api-docs/**",
+            "/swagger-resources/**",
+            "/swagger-ui.html"
+    };
+
+    /** 인증(회원가입, 로그인 등) 관련 경로 */
+    private static final String[] AUTH_URIS = {
+            "/api/auth/signup",
+            "/api/auth/login",
+            "/api/auth/reissue"
+    };
+
+    /** 소셜 인증(카카오, 네이버) 관련 경로 */
+    private static final String[] OAUTH_URIS = {
+            "/api/oauth/kakao/login-uri",
+            "/api/oauth/kakao/login",
+            "/api/oauth/kakao/test/login",
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+
+                // 인증/인가 예외 핸들러 등록
+                .exceptionHandling(exception ->
+                        exception
+                                .authenticationEntryPoint(jwtAuthenticationEntryPoint) // 401
+                                .accessDeniedHandler(jwtAccessDeniedHandler)           // 403
+                )
+
+                // 요청별 인가 설정
+                .authorizeHttpRequests(auth ->
+                        auth
+                                .requestMatchers(SWAGGER_URIS).permitAll()
+                                .requestMatchers(AUTH_URIS).permitAll()
+                                .requestMatchers(OAUTH_URIS).permitAll()
+                                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                                .anyRequest().authenticated()
+                )
+
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:5173", "http://localhost:8080"));
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "DELETE", "PATCH", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("*"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration authenticationConfiguration
+    ) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/leets_7th/common/exception/GeneralExceptionAdvice.java
+++ b/src/main/java/com/example/leets_7th/common/exception/GeneralExceptionAdvice.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.security.core.AuthenticationException;
 
 @Slf4j
 @RestControllerAdvice
@@ -37,6 +38,12 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
         String errorMessage = "잘못된 요청입니다: " + e.getMessage();
         log.error("[*] IllegalArgumentException :", e);
         return ApiResponse.error(ErrorStatus.BAD_REQUEST, errorMessage);
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAuthenticationException(AuthenticationException e) {
+        log.error("[*] AuthenticationException : {}", e.getMessage());
+        return ApiResponse.error(ErrorStatus.LOGIN_FAILED);
     }
 
     @ExceptionHandler(NullPointerException.class)

--- a/src/main/java/com/example/leets_7th/common/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/example/leets_7th/common/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package com.example.leets_7th.common.jwt;
+
+import com.example.leets_7th.common.status.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+
+        ErrorStatus errorStatus = ErrorStatus.FORBIDDEN;
+
+        response.setStatus(errorStatus.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("code", errorStatus.getCode());
+        body.put("message", errorStatus.getMessage());
+
+        new ObjectMapper().writeValue(response.getOutputStream(), body);
+    }
+}

--- a/src/main/java/com/example/leets_7th/common/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/leets_7th/common/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,38 @@
+package com.example.leets_7th.common.jwt;
+
+import com.example.leets_7th.common.status.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+
+        ErrorStatus errorStatus = ErrorStatus.UNAUTHORIZED;
+
+        response.setStatus(errorStatus.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("code", errorStatus.getCode());
+        body.put("message", errorStatus.getMessage());
+
+        new ObjectMapper().writeValue(response.getOutputStream(), body);
+    }
+}

--- a/src/main/java/com/example/leets_7th/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/leets_7th/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package com.example.leets_7th.common.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        // 쿠키에서 Access Token 추출
+        String token = jwtProvider.resolveTokenFromCookie(request);
+
+        // 토큰 유효성 검사 후 SecurityContext에 인증 저장
+        if (StringUtils.hasText(token) && jwtProvider.validateToken(token)) {
+            Authentication authentication = jwtProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("Security Context에 '{}' 인증 정보 저장", authentication.getName());
+        } else {
+            log.debug("유효한 JWT 토큰이 없습니다. URI: {}", request.getRequestURI());
+        }
+
+        // 3. 다음 필터로 전달
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/leets_7th/common/jwt/JwtProvider.java
+++ b/src/main/java/com/example/leets_7th/common/jwt/JwtProvider.java
@@ -1,0 +1,133 @@
+package com.example.leets_7th.common.jwt;
+
+import com.example.leets_7th.common.status.ErrorStatus;
+import com.example.leets_7th.common.exception.GeneralException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final String ACCESS_TOKEN_COOKIE = "access_token";
+
+    private final Key key;
+    private final long accessTokenExpireMs;
+    private final long refreshTokenExpireMs;
+
+    public JwtProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-expire-ms}") long accessTokenExpireMs,
+            @Value("${jwt.refresh-token-expire-ms}") long refreshTokenExpireMs
+    ) {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenExpireMs = accessTokenExpireMs;
+        this.refreshTokenExpireMs = refreshTokenExpireMs;
+    }
+
+    // 토큰 생성
+    public String createAccessToken(Authentication authentication) {
+        return createToken(authentication, accessTokenExpireMs);
+    }
+
+    public String createRefreshToken(Authentication authentication) {
+        return createToken(authentication, refreshTokenExpireMs);
+    }
+
+    private String createToken(Authentication authentication, long expireMs) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = System.currentTimeMillis();
+
+        return Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim(AUTHORITIES_KEY, authorities)
+                .setIssuedAt(new Date(now))
+                .setExpiration(new Date(now + expireMs))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 쿠키에서 토큰 추출
+    public String resolveTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> ACCESS_TOKEN_COOKIE.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+
+    // 토큰 → Authentication 객체 변환
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+
+        if (claims.get(AUTHORITIES_KEY) == null) {
+            throw new GeneralException(ErrorStatus.NO_AUTHORITY);
+        }
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            throw new GeneralException(ErrorStatus.INVALID_TOKEN);
+        } catch (ExpiredJwtException e) {
+            throw new GeneralException(ErrorStatus.EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            throw new GeneralException(ErrorStatus.UNSUPPORTED_TOKEN);
+        } catch (IllegalArgumentException e) {
+            throw new GeneralException(ErrorStatus.EMPTY_TOKEN);
+        }
+    }
+
+    // 내부 유틸
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/example/leets_7th/common/status/ErrorStatus.java
+++ b/src/main/java/com/example/leets_7th/common/status/ErrorStatus.java
@@ -16,22 +16,31 @@ public enum ErrorStatus implements BaseStatus {
      * Common
      */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMM_400", "잘못된 요청입니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMM_401", "인증이 필요합니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMM_401", "로그인이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMM_403", "접근 권한이 없습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "COMM_404", "요청한 자원을 찾을 수 없습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMM_405", "허용되지 않은 메소드입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMM_500", "서버 내부 오류입니다."),
 
     // User
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"USER_404","사용자를 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"USER_4041","사용자를 찾을 수 없습니다."),
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST,"AUTH_4001","이미 존재하는 이메일 입니다."),
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_4011", "이메일 또는 비밀번호가 올바르지 않습니다."),
+
+    // JWT 관련
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_4012", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_4013", "만료된 토큰입니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_4014", "지원하지 않는 토큰입니다."),
+    EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_4015", "토큰이 비어있습니다."),
+    NO_AUTHORITY(HttpStatus.UNAUTHORIZED, "AUTH_4016", "권한 정보가 없는 토큰입니다."),
 
 
     // Post
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND,"POST_404","게시글이 존재하지 않습니다."),
-    POST_ALREADY_DELETED(HttpStatus.BAD_REQUEST,"POST_400","이미 삭제된 게시글입니다."),
-    ALREADY_LIKED_POST(HttpStatus.CONFLICT, "POST_409", "이미 좋아요를 누른 게시글입니다."),
-    POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND,"POST_404","게시글에 좋아요 취소할 좋아요가 없습니다."),
-    ALREADY_REPORTED_POST(HttpStatus.CONFLICT, "POST_409", "이미 신고한 게시글입니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND,"POST_4041","게시글이 존재하지 않습니다."),
+    POST_ALREADY_DELETED(HttpStatus.BAD_REQUEST,"POST_4001","이미 삭제된 게시글입니다."),
+    ALREADY_LIKED_POST(HttpStatus.CONFLICT, "POST_4091", "이미 좋아요를 누른 게시글입니다."),
+    POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND,"POST_4042","게시글에 좋아요 취소할 좋아요가 없습니다."),
+    ALREADY_REPORTED_POST(HttpStatus.CONFLICT, "POST_4092", "이미 신고한 게시글입니다."),
 
 
     // Comment

--- a/src/main/java/com/example/leets_7th/common/status/SuccessStatus.java
+++ b/src/main/java/com/example/leets_7th/common/status/SuccessStatus.java
@@ -13,6 +13,11 @@ public enum SuccessStatus implements BaseStatus {
     HEALTH_CHECK_SUCCESS_STATUS(HttpStatus.OK, "TEST_200", "OK"),
     STRING_REPEAT_SUCCESS(HttpStatus.CREATED, "TEST_201", "문자열을 성공적으로 출력했습니다."),
 
+    // User
+    CREATE_USER_SUCCESS(HttpStatus.CREATED,"AUTH_2011","회원가입에 성공했습니다."),
+    LOGIN_SUCCESS(HttpStatus.OK,"AUTH_2001","로그인에 성공했습니다."),
+    LOGOUT_SUCCESS(HttpStatus.OK,"AUTH_2002","로그아웃에 성공했습니다."),
+    REISSUE_SUCCESS(HttpStatus.OK,"AUTH_2003","리프레쉬 토큰 재발급에 성공했습니다."),
 
     // Post
     GET_ALL_POST_SUCCESS(HttpStatus.OK, "POST_2001", "게시글 목록 조회에 성공했습니다."),

--- a/src/main/java/com/example/leets_7th/common/status/SuccessStatus.java
+++ b/src/main/java/com/example/leets_7th/common/status/SuccessStatus.java
@@ -17,7 +17,7 @@ public enum SuccessStatus implements BaseStatus {
     CREATE_USER_SUCCESS(HttpStatus.CREATED,"AUTH_2011","회원가입에 성공했습니다."),
     LOGIN_SUCCESS(HttpStatus.OK,"AUTH_2001","로그인에 성공했습니다."),
     LOGOUT_SUCCESS(HttpStatus.OK,"AUTH_2002","로그아웃에 성공했습니다."),
-    REISSUE_SUCCESS(HttpStatus.OK,"AUTH_2003","리프레쉬 토큰 재발급에 성공했습니다."),
+    REISSUE_SUCCESS(HttpStatus.OK,"AUTH_2003","토큰 재발급에 성공했습니다."),
 
     // Post
     GET_ALL_POST_SUCCESS(HttpStatus.OK, "POST_2001", "게시글 목록 조회에 성공했습니다."),

--- a/src/main/java/com/example/leets_7th/common/util/CookieUtil.java
+++ b/src/main/java/com/example/leets_7th/common/util/CookieUtil.java
@@ -1,0 +1,84 @@
+package com.example.leets_7th.common.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+public class CookieUtil {
+
+    private static final String ACCESS_TOKEN_COOKIE  = "access_token";
+    private static final String REFRESH_TOKEN_COOKIE = "refresh_token";
+
+    @Value("${jwt.access-token-expire-ms}")
+    private long accessTokenExpireMs;
+
+    @Value("${jwt.refresh-token-expire-ms}")
+    private long refreshTokenExpireMs;
+
+    public void addAccessTokenCookie(HttpServletResponse response, String token) {
+        addCookie(response, ACCESS_TOKEN_COOKIE, token, (int) (accessTokenExpireMs / 1000));
+    }
+
+    public void addRefreshTokenCookie(HttpServletResponse response, String token) {
+        addCookie(response, REFRESH_TOKEN_COOKIE, token, (int) (refreshTokenExpireMs / 1000));
+    }
+
+    // 쿠키에서 값 읽기
+    public Optional<String> getAccessToken(HttpServletRequest request) {
+        return getCookieValue(request, ACCESS_TOKEN_COOKIE);
+    }
+
+    public Optional<String> getRefreshToken(HttpServletRequest request) {
+        return getCookieValue(request, REFRESH_TOKEN_COOKIE);
+    }
+
+
+    // Access / Refresh Token 쿠키 삭제 (로그아웃)
+    public void deleteAccessTokenCookie(HttpServletResponse response) {
+        deleteCookie(response, ACCESS_TOKEN_COOKIE);
+    }
+
+    public void deleteRefreshTokenCookie(HttpServletResponse response) {
+        deleteCookie(response, REFRESH_TOKEN_COOKIE);
+    }
+
+
+    // 내부 공통 메서드
+    private void addCookie(HttpServletResponse response, String name, String value, int maxAgeSeconds) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);   // XSS 방어
+        cookie.setSecure(true);     // HTTPS 에서만 전송
+        cookie.setPath("/");        // 모든 경로에서 전송
+        cookie.setMaxAge(maxAgeSeconds);
+
+        // SameSite=Strict 설정 (CSRF 방어) — Cookie API가 SameSite 미지원이므로 헤더 직접 추가
+        String cookieHeader = String.format(
+                "%s=%s; Max-Age=%d; Path=/; HttpOnly; Secure; SameSite=Strict",
+                name, value, maxAgeSeconds
+        );
+        response.addHeader("Set-Cookie", cookieHeader);
+    }
+
+    private void deleteCookie(HttpServletResponse response, String name) {
+        String cookieHeader = String.format(
+                "%s=; Max-Age=0; Path=/; HttpOnly; Secure; SameSite=Strict",
+                name
+        );
+        response.addHeader("Set-Cookie", cookieHeader);
+    }
+
+    private Optional<String> getCookieValue(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return Optional.empty();
+
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> name.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst();
+    }
+}

--- a/src/main/java/com/example/leets_7th/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/leets_7th/domain/user/controller/AuthController.java
@@ -1,0 +1,57 @@
+package com.example.leets_7th.domain.user.controller;
+
+import com.example.leets_7th.common.response.ApiResponse;
+import com.example.leets_7th.common.status.SuccessStatus;
+import com.example.leets_7th.domain.user.controller.docs.AuthControllerDocs;
+import com.example.leets_7th.domain.user.dto.request.LoginRequest;
+import com.example.leets_7th.domain.user.dto.request.SignUpRequest;
+import com.example.leets_7th.domain.user.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController implements AuthControllerDocs {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<Void>> signup(
+            @Valid @RequestBody SignUpRequest request
+    ) {
+        authService.signup(request);
+        return ApiResponse.success(SuccessStatus.CREATE_USER_SUCCESS);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<Void>> login(
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse response
+    ) {
+        authService.login(request, response);
+        return ApiResponse.success(SuccessStatus.LOGIN_SUCCESS);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response) {
+        authService.logout(response);
+        return ApiResponse.success(SuccessStatus.LOGOUT_SUCCESS);
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<Void>> refresh(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        authService.refresh(request, response);
+        return ApiResponse.success(SuccessStatus.REISSUE_SUCCESS);
+    }
+}

--- a/src/main/java/com/example/leets_7th/domain/user/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/example/leets_7th/domain/user/controller/docs/AuthControllerDocs.java
@@ -1,0 +1,90 @@
+package com.example.leets_7th.domain.user.controller.docs;
+
+import com.example.leets_7th.common.response.ApiResponse;
+import com.example.leets_7th.domain.user.dto.request.LoginRequest;
+import com.example.leets_7th.domain.user.dto.request.SignUpRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface AuthControllerDocs {
+    @Operation(
+            summary = "회원가입",
+            description = "사용자가 회원가입을 진행합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "회원가입 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 값",
+                    content = @Content(schema = @Schema())
+            )
+    })
+    @PostMapping("/signup")
+    ResponseEntity<ApiResponse<Void>> signup(
+            @Valid @RequestBody SignUpRequest request
+    );
+
+    @Operation(
+            summary = "로그인",
+            description = "이메일과 비밀번호로 로그인합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패"
+            )
+    })
+    @PostMapping("/login")
+    ResponseEntity<ApiResponse<Void>> login(
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse response
+    );
+
+    @Operation(
+            summary = "로그아웃",
+            description = "로그아웃을 진행하고 Refresh Token 쿠키를 삭제합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그아웃 성공"
+            )
+    })
+    @PostMapping("/logout")
+    ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response);
+
+    @Operation(
+            summary = "토큰 재발급",
+            description = "Refresh Token을 통해 Access Token을 재발급합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "토큰 재발급 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "유효하지 않은 Refresh Token"
+            )
+    })
+    @PostMapping("/reissue")
+    ResponseEntity<ApiResponse<Void>> refresh(
+            HttpServletRequest request,
+            HttpServletResponse response
+    );
+}

--- a/src/main/java/com/example/leets_7th/domain/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/example/leets_7th/domain/user/dto/request/LoginRequest.java
@@ -1,0 +1,14 @@
+package com.example.leets_7th.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest (
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = "이메일을 입력해주세요.")
+    String email,
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    String password
+    
+){}

--- a/src/main/java/com/example/leets_7th/domain/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/example/leets_7th/domain/user/dto/request/SignUpRequest.java
@@ -1,0 +1,27 @@
+package com.example.leets_7th.domain.user.dto.request;
+
+import com.example.leets_7th.domain.user.enums.Gender;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SignUpRequest(
+
+        @NotBlank(message = "이름을 입력해주세요.")
+        String name,
+
+        @NotNull(message = "성별을 입력해주세요.")
+        Gender gender,
+
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @NotBlank(message = "이메일을 입력해주세요.")
+        String email,
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        String password,
+
+        @Min(value = 0, message = "나이는 0 이상이어야 합니다.")
+        int age
+) {
+}

--- a/src/main/java/com/example/leets_7th/domain/user/dto/response/LoginResponse.java
+++ b/src/main/java/com/example/leets_7th/domain/user/dto/response/LoginResponse.java
@@ -1,0 +1,17 @@
+package com.example.leets_7th.domain.user.dto.response;
+
+import com.example.leets_7th.domain.user.entity.User;
+
+public record LoginResponse(
+        Long userId,
+        String email,
+        String name
+) {
+    public static LoginResponse from(User user) {
+        return new LoginResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getName()
+        );
+    }
+}

--- a/src/main/java/com/example/leets_7th/domain/user/dto/response/SignUpResponse.java
+++ b/src/main/java/com/example/leets_7th/domain/user/dto/response/SignUpResponse.java
@@ -1,0 +1,17 @@
+package com.example.leets_7th.domain.user.dto.response;
+
+import com.example.leets_7th.domain.user.entity.User;
+
+public record SignUpResponse(
+        Long userId,
+        String email,
+        String name
+) {
+    public static SignUpResponse from(User user) {
+        return new SignUpResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getName()
+        );
+    }
+}

--- a/src/main/java/com/example/leets_7th/domain/user/entity/User.java
+++ b/src/main/java/com/example/leets_7th/domain/user/entity/User.java
@@ -30,7 +30,7 @@ public class User extends BaseEntity {
     @Column(name = "email", length = 40)
     private String email;
 
-    @Column(name = "password", length = 20)
+    @Column(name = "password", length = 100)
     private String password;
 
     @Column(name = "age")

--- a/src/main/java/com/example/leets_7th/domain/user/entity/User.java
+++ b/src/main/java/com/example/leets_7th/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package com.example.leets_7th.domain.user.entity;
 import com.example.leets_7th.common.base.BaseEntity;
 import com.example.leets_7th.domain.comment.entity.Comment;
 import com.example.leets_7th.domain.user.enums.Gender;
+import com.example.leets_7th.domain.user.enums.Role;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -35,6 +36,10 @@ public class User extends BaseEntity {
     @Column(name = "age")
     private int age;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private Role role;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
@@ -45,6 +50,7 @@ public class User extends BaseEntity {
         user.email = email;
         user.password = password;
         user.age = age;
+        user.role = Role.USER;
         return user;
     }
 }

--- a/src/main/java/com/example/leets_7th/domain/user/enums/Role.java
+++ b/src/main/java/com/example/leets_7th/domain/user/enums/Role.java
@@ -1,0 +1,6 @@
+package com.example.leets_7th.domain.user.enums;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/example/leets_7th/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/leets_7th/domain/user/repository/UserRepository.java
@@ -3,5 +3,10 @@ package com.example.leets_7th.domain.user.repository;
 import com.example.leets_7th.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/leets_7th/domain/user/service/AuthService.java
+++ b/src/main/java/com/example/leets_7th/domain/user/service/AuthService.java
@@ -1,0 +1,98 @@
+package com.example.leets_7th.domain.user.service;
+
+
+import com.example.leets_7th.common.status.ErrorStatus;
+import com.example.leets_7th.common.exception.GeneralException;
+import com.example.leets_7th.common.jwt.JwtProvider;
+import com.example.leets_7th.common.util.CookieUtil;
+import com.example.leets_7th.domain.user.dto.request.LoginRequest;
+import com.example.leets_7th.domain.user.dto.request.SignUpRequest;
+import com.example.leets_7th.domain.user.entity.User;
+import com.example.leets_7th.domain.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtProvider jwtProvider;
+    private final CookieUtil cookieUtil;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void signup(SignUpRequest request) {
+
+        if (userRepository.existsByEmail(request.email())) {
+            throw new GeneralException(ErrorStatus.DUPLICATE_EMAIL);
+        }
+
+        String encodedPassword = passwordEncoder.encode(request.password());
+
+        User user = User.create(
+                request.name(),
+                request.gender(),
+                request.email(),
+                encodedPassword,
+                request.age()
+        );
+
+        userRepository.save(user);
+
+    }
+
+    @Transactional(readOnly = true)
+    public void login(LoginRequest request, HttpServletResponse response) {
+
+        // 이메일 + 비밀번호 인증
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(
+                        request.email(),
+                        request.password()
+                )
+        );
+
+        // JWT 발급
+        String accessToken  = jwtProvider.createAccessToken(authentication);
+        String refreshToken = jwtProvider.createRefreshToken(authentication);
+
+        // 쿠키에 세팅
+        cookieUtil.addAccessTokenCookie(response, accessToken);
+        cookieUtil.addRefreshTokenCookie(response, refreshToken);
+    }
+
+    // 로그아웃
+    public void logout(HttpServletResponse response) {
+        cookieUtil.deleteAccessTokenCookie(response);
+        cookieUtil.deleteRefreshTokenCookie(response);
+    }
+
+    // Access Token 재발급
+    public void refresh(HttpServletRequest request, HttpServletResponse response) {
+
+        // 쿠키에서 Refresh Token 추출
+        String refreshToken = cookieUtil.getRefreshToken(request)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.INVALID_TOKEN));
+
+        // Refresh Token 검증
+        jwtProvider.validateToken(refreshToken);
+
+        // 인증 객체 추출
+        Authentication authentication = jwtProvider.getAuthentication(refreshToken);
+
+        String newAccessToken  = jwtProvider.createAccessToken(authentication);
+        String newRefreshToken = jwtProvider.createRefreshToken(authentication);
+
+        cookieUtil.addAccessTokenCookie(response, newAccessToken);
+        cookieUtil.addRefreshTokenCookie(response, newRefreshToken);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,3 +18,8 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+
+jwt:
+  secret: dGhpcyBpcyBhIHZlcnkgbG9uZyBzZWNyZXQga2V5IGZvciBqd3Qgc2lnbmluZyEhMTIzNDU2Nzg=
+  access-token-expire-ms: 1800000      # 30분
+  refresh-token-expire-ms: 604800000   # 7일


### PR DESCRIPTION
1. 과제 요구사항 중 구현한 내용

 JWT 기반 쿠키 인증 구조 구성
 회원가입 API 구현 (POST /api/auth/signup)
 로그인 API 구현 (POST /api/auth/login)
 로그아웃 API 구현 (POST /api/auth/logout)
 Access Token, RefreshToken 재발급 API 구현 (POST /api/auth/reissue)

2. 핵심 변경 사항
Security 설정

SecurityConfig — SecurityFilterChain 구성, CSRF 비활성화, Stateless 세션 설정, JWT 필터 등록
JwtProvider — JWT 생성/검증/파싱, 쿠키에서 토큰 추출
JwtAuthenticationFilter — 매 요청마다 쿠키에서 Access Token 추출 후 SecurityContext 저장
JwtAuthenticationEntryPoint — 인증 실패 시 401 응답
JwtAccessDeniedHandler — 권한 부족 시 403 응답
CookieUtil — HttpOnly/Secure/SameSite=Strict 쿠키 생성·삭제 헬퍼

인증 API

AuthController / AuthService — 회원가입, 로그인, 로그아웃, 토큰 재발급 로직
CustomUserDetails / CustomUserDetailsService — Spring Security 유저 인증 연동

User 엔티티

Role enum 추가 (USER, ADMIN)
User 엔티티에 role 필드 추가, 기본값 ROLE_USER
password 컬럼 길이 BCrypt 대응으로 확장

예외처리

ErrorStatus에 JWT/인증 관련 에러코드 추가 (INVALID_TOKEN, EXPIRED_TOKEN, LOGIN_FAILED 등)
GeneralExceptionAdvice에 AuthenticationException 핸들러 추가

- 회원가입 API Request
<img width="822" height="647" alt="image" src="https://github.com/user-attachments/assets/3e0072fd-0e00-4025-b7dc-ba9ee61c340c" />

- 회원가입 API Response
<img width="532" height="152" alt="image" src="https://github.com/user-attachments/assets/1e80d743-f45a-4bdf-ba95-94a256933fc6" />

- 비밀번호 암호화 저장 (BCrypt)
<img width="945" height="422" alt="image" src="https://github.com/user-attachments/assets/7aebe409-fa15-4f88-a698-02847e90c292" />

- 로그인 성공 Response (AccessToken ,RefreshToken)
<img width="1630" height="667" alt="image" src="https://github.com/user-attachments/assets/38177cfa-4ada-4d93-ac07-fd74d61b72d5" />

- 엑세스 토큰 없이 서비스 요청 (allow_url을 제외한 서비스) 시 필터 errorCode
<img width="1642" height="580" alt="image" src="https://github.com/user-attachments/assets/828b3ff2-da46-4d18-8cdb-8b21b55c350e" />

- 로그아웃 시 토큰 삭제 및 로그아웃은 로그인 상태여야 로그아웃이 가능하도록 설정
<img width="1862" height="725" alt="image" src="https://github.com/user-attachments/assets/76ff2d33-9076-48b8-8ffd-5771f9c19419" />

- 잘못된 이메일 형식으로 로그인 시
<img width="1745" height="242" alt="image" src="https://github.com/user-attachments/assets/49b35e55-0523-4c08-b58a-282db4acdb46" />


## 5. 추가 사항

- 관련 이슈: closed #214 
<!-- 리뷰 시 참고할 포인트나 남은 작업이 있다면 작성해주세요. -->

다음주에 카카오 로그인을 구현하면서 기존에 있던 userId로 서비스 인증을 하는 방식을 userDetail을 이용하여 마이그레이션을 진행 + 리팩토링을 진행할 예정입니다. 

## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다
