### PR TITLE
[6주차] 이건희/[Feat] Spring Security + JWT 인증/인가

### DIFF
--- a/LeeKunHee/build.gradle
+++ b/LeeKunHee/build.gradle
@@ -25,12 +25,17 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	runtimeOnly 'com.h2database:h2' //임시 저장.

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/config/SecurityConfig.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.leets.assignment.domain.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/signup", "/login", "/auth/reissue").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/h2-console/**").permitAll()
+                        .anyRequest().permitAll()
+                )
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/config/SecurityConfig.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.leets.assignment.domain.auth.config;
 
+import com.leets.assignment.domain.auth.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,9 +10,13 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -23,9 +29,10 @@ public class SecurityConfig {
                         .requestMatchers("/auth/signup", "/login", "/auth/reissue").permitAll()
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
-                        .anyRequest().permitAll()
+                        .anyRequest().authenticated()
                 )
                 .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/controller/AuthApi.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/controller/AuthApi.java
@@ -1,0 +1,28 @@
+package com.leets.assignment.domain.auth.controller;
+
+import com.leets.assignment.domain.auth.dto.AuthRequestDTO;
+import com.leets.assignment.domain.auth.dto.AuthResponseDTO;
+import com.leets.assignment.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "03. Auth API", description = "회원가입 및 로그인 API")
+public interface AuthApi {
+
+    @Operation(summary = "회원가입", description = "이메일, 닉네임, 이름, 비밀번호로 회원가입을 진행합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER409_1", description = "이미 등록된 이메일",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = "{\"isSuccess\": false, \"code\": \"USER409_1\", \"message\": \"이미 등록된 이메일입니다.\", \"result\": null}"))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER409_2", description = "이미 등록된 닉네임",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = "{\"isSuccess\": false, \"code\": \"USER409_2\", \"message\": \"이미 등록된 닉네임입니다.\", \"result\": null}")))
+    })
+    ApiResponse<AuthResponseDTO.SignupResDTO> signup(@RequestBody AuthRequestDTO.SignupDTO request);
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/controller/AuthApi.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/controller/AuthApi.java
@@ -25,4 +25,22 @@ public interface AuthApi {
                             examples = @ExampleObject(value = "{\"isSuccess\": false, \"code\": \"USER409_2\", \"message\": \"이미 등록된 닉네임입니다.\", \"result\": null}")))
     })
     ApiResponse<AuthResponseDTO.SignupResDTO> signup(@RequestBody AuthRequestDTO.SignupDTO request);
+
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하고 Access Token과 Refresh Token을 발급받습니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH401_1", description = "비밀번호 불일치",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = "{\"isSuccess\": false, \"code\": \"AUTH401_1\", \"message\": \"비밀번호가 일치하지 않습니다.\", \"result\": null}")))
+    })
+    ApiResponse<AuthResponseDTO.TokenResDTO> login(@RequestBody AuthRequestDTO.LoginDTO request);
+
+    @Operation(summary = "토큰 재발급", description = "Refresh Token으로 새로운 Access Token과 Refresh Token을 발급받습니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH401_4", description = "유효하지 않은 Refresh Token",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = "{\"isSuccess\": false, \"code\": \"AUTH401_4\", \"message\": \"유효하지 않은 Refresh Token입니다.\", \"result\": null}")))
+    })
+    ApiResponse<AuthResponseDTO.TokenResDTO> reissue(@RequestBody AuthRequestDTO.ReissueDTO request);
 }

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/controller/AuthController.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/controller/AuthController.java
@@ -9,24 +9,40 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController implements AuthApi {
 
     private final AuthService authService;
 
     @Override
-    @PostMapping("/signup")
+    @PostMapping("/auth/signup")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<AuthResponseDTO.SignupResDTO> signup(
             @Valid @RequestBody AuthRequestDTO.SignupDTO request
     ) {
         AuthResponseDTO.SignupResDTO result = authService.signup(request);
         return ApiResponse.onSuccess("AUTH201_1", "회원가입이 성공했습니다.", result);
+    }
+
+    @Override
+    @PostMapping("/login")
+    public ApiResponse<AuthResponseDTO.TokenResDTO> login(
+            @Valid @RequestBody AuthRequestDTO.LoginDTO request
+    ) {
+        AuthResponseDTO.TokenResDTO result = authService.login(request);
+        return ApiResponse.onSuccess("AUTH200_1", "로그인이 성공했습니다.", result);
+    }
+
+    @Override
+    @PostMapping("/auth/reissue")
+    public ApiResponse<AuthResponseDTO.TokenResDTO> reissue(
+            @Valid @RequestBody AuthRequestDTO.ReissueDTO request
+    ) {
+        AuthResponseDTO.TokenResDTO result = authService.reissue(request);
+        return ApiResponse.onSuccess("AUTH200_2", "토큰 재발급이 성공했습니다.", result);
     }
 }

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/controller/AuthController.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/controller/AuthController.java
@@ -1,0 +1,32 @@
+package com.leets.assignment.domain.auth.controller;
+
+import com.leets.assignment.domain.auth.dto.AuthRequestDTO;
+import com.leets.assignment.domain.auth.dto.AuthResponseDTO;
+import com.leets.assignment.domain.auth.service.AuthService;
+import com.leets.assignment.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController implements AuthApi {
+
+    private final AuthService authService;
+
+    @Override
+    @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<AuthResponseDTO.SignupResDTO> signup(
+            @Valid @RequestBody AuthRequestDTO.SignupDTO request
+    ) {
+        AuthResponseDTO.SignupResDTO result = authService.signup(request);
+        return ApiResponse.onSuccess("AUTH201_1", "회원가입이 성공했습니다.", result);
+    }
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/dto/AuthRequestDTO.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/dto/AuthRequestDTO.java
@@ -1,0 +1,56 @@
+package com.leets.assignment.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AuthRequestDTO {
+
+    @Getter
+    @NoArgsConstructor
+    public static class SignupDTO {
+        @Schema(description = "이메일", example = "test@example.com")
+        @NotBlank(message = "AUTH400_1|이메일을 입력해주세요.")
+        @Email(message = "AUTH400_2|올바른 이메일 형식이 아닙니다.")
+        private String email;
+
+        @Schema(description = "닉네임", example = "leets")
+        @NotBlank(message = "AUTH400_3|닉네임을 입력해주세요.")
+        @Size(max = 50, message = "AUTH400_4|닉네임은 최대 50자까지 가능합니다.")
+        private String nickname;
+
+        @Schema(description = "이름", example = "홍길동")
+        @NotBlank(message = "AUTH400_5|이름을 입력해주세요.")
+        @Size(max = 50, message = "AUTH400_6|이름은 최대 50자까지 가능합니다.")
+        private String name;
+
+        @Schema(description = "비밀번호", example = "password1234")
+        @NotBlank(message = "AUTH400_7|비밀번호를 입력해주세요.")
+        @Size(min = 8, max = 100, message = "AUTH400_8|비밀번호는 8자 이상 100자 이하로 입력해주세요.")
+        private String password;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class LoginDTO {
+        @Schema(description = "이메일", example = "test@example.com")
+        @NotBlank(message = "AUTH400_1|이메일을 입력해주세요.")
+        @Email(message = "AUTH400_2|올바른 이메일 형식이 아닙니다.")
+        private String email;
+
+        @Schema(description = "비밀번호", example = "password1234")
+        @NotBlank(message = "AUTH400_7|비밀번호를 입력해주세요.")
+        private String password;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ReissueDTO {
+        @Schema(description = "Refresh Token")
+        @NotBlank(message = "AUTH400_9|Refresh Token을 입력해주세요.")
+        private String refreshToken;
+    }
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/dto/AuthResponseDTO.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/dto/AuthResponseDTO.java
@@ -1,0 +1,29 @@
+package com.leets.assignment.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+public class AuthResponseDTO {
+
+    @Builder
+    public record SignupResDTO(
+            @Schema(description = "사용자 ID", example = "1")
+            Long userId,
+            @Schema(description = "이메일", example = "test@example.com")
+            String email,
+            @Schema(description = "닉네임", example = "leets")
+            String nickname
+    ) {
+    }
+
+    @Builder
+    public record TokenResDTO(
+            @Schema(description = "토큰 타입", example = "Bearer")
+            String tokenType,
+            @Schema(description = "Access Token")
+            String accessToken,
+            @Schema(description = "Refresh Token")
+            String refreshToken
+    ) {
+    }
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/dto/AuthResponseDTO.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/dto/AuthResponseDTO.java
@@ -20,9 +20,9 @@ public class AuthResponseDTO {
     public record TokenResDTO(
             @Schema(description = "토큰 타입", example = "Bearer")
             String tokenType,
-            @Schema(description = "Access Token")
+            @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGV4YW1wbGUuY29tIiwidXNlcklkIjoxLCJuaWNrbmFtZSI6ImxlZXRzIiwiY2F0ZWdvcnkiOiJhY2Nlc3MiLCJpYXQiOjE3MTYxOTAwMDAsImV4cCI6MTcxNjE5MzYwMH0.sample-signature")
             String accessToken,
-            @Schema(description = "Refresh Token")
+            @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGV4YW1wbGUuY29tIiwidXNlcklkIjoxLCJuaWNrbmFtZSI6ImxlZXRzIiwiY2F0ZWdvcnkiOiJyZWZyZXNoIiwiaWF0IjoxNzE2MTkwMDAwLCJleHAiOjE3MTczOTk2MDB9.sample-signature")
             String refreshToken
     ) {
     }

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/exception/AuthException.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/exception/AuthException.java
@@ -1,0 +1,14 @@
+package com.leets.assignment.domain.auth.exception;
+
+import com.leets.assignment.domain.auth.exception.code.AuthErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AuthException extends RuntimeException {
+    private final AuthErrorCode errorCode;
+
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/exception/code/AuthErrorCode.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/exception/code/AuthErrorCode.java
@@ -1,0 +1,19 @@
+package com.leets.assignment.domain.auth.exception.code;
+
+import com.leets.assignment.global.exception.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+    INVALID_PASSWORD("AUTH401_1", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_TOKEN("AUTH401_2", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    EXPIRED_TOKEN("AUTH401_3", "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_REFRESH_TOKEN("AUTH401_4", "유효하지 않은 Refresh Token입니다.", HttpStatus.UNAUTHORIZED);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,88 @@
+package com.leets.assignment.domain.auth.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.leets.assignment.domain.auth.exception.AuthException;
+import com.leets.assignment.domain.auth.exception.code.AuthErrorCode;
+import com.leets.assignment.domain.user.entity.User;
+import com.leets.assignment.domain.user.service.UserService;
+import com.leets.assignment.global.common.ApiResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+    private final UserService userService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            jwtProvider.validateAccessToken(token);
+            String email = jwtProvider.getEmail(token);
+            User user = userService.findByEmail(email);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList());
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+        } catch (AuthException e) {
+            SecurityContextHolder.clearContext();
+            writeErrorResponse(response, e.getErrorCode());
+        }
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+
+        return authorizationHeader.substring(BEARER_PREFIX.length());
+    }
+
+    private void writeErrorResponse(HttpServletResponse response, AuthErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        ApiResponse<Void> apiResponse = ApiResponse.<Void>builder()
+                .isSuccess(false)
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .result(null)
+                .build();
+
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/jwt/JwtProvider.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/jwt/JwtProvider.java
@@ -1,0 +1,109 @@
+package com.leets.assignment.domain.auth.jwt;
+
+import com.leets.assignment.domain.auth.dto.AuthResponseDTO;
+import com.leets.assignment.domain.auth.exception.AuthException;
+import com.leets.assignment.domain.auth.exception.code.AuthErrorCode;
+import com.leets.assignment.domain.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private static final String TOKEN_TYPE = "Bearer";
+    private static final String TOKEN_CATEGORY = "category";
+    private static final String ACCESS_TOKEN = "access";
+    private static final String REFRESH_TOKEN = "refresh";
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access-token-expiration-ms}")
+    private long accessTokenExpirationMs;
+
+    @Value("${jwt.refresh-token-expiration-ms}")
+    private long refreshTokenExpirationMs;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void init() {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public AuthResponseDTO.TokenResDTO createTokenResponse(User user) {
+        return AuthResponseDTO.TokenResDTO.builder()
+                .tokenType(TOKEN_TYPE)
+                .accessToken(createAccessToken(user))
+                .refreshToken(createRefreshToken(user))
+                .build();
+    }
+
+    public String createAccessToken(User user) {
+        return createToken(user, ACCESS_TOKEN, accessTokenExpirationMs);
+    }
+
+    public String createRefreshToken(User user) {
+        return createToken(user, REFRESH_TOKEN, refreshTokenExpirationMs);
+    }
+
+    public String getEmail(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    public void validateAccessToken(String token) {
+        validateToken(token, ACCESS_TOKEN, AuthErrorCode.INVALID_TOKEN);
+    }
+
+    public void validateRefreshToken(String token) {
+        validateToken(token, REFRESH_TOKEN, AuthErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    private String createToken(User user, String category, long expirationMs) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + expirationMs);
+
+        return Jwts.builder()
+                .subject(user.getEmail())
+                .claim("userId", user.getUserId())
+                .claim("nickname", user.getNickname())
+                .claim(TOKEN_CATEGORY, category)
+                .issuedAt(now)
+                .expiration(expiration)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    private void validateToken(String token, String expectedCategory, AuthErrorCode invalidTokenErrorCode) {
+        Claims claims = parseClaims(token);
+        String category = claims.get(TOKEN_CATEGORY, String.class);
+
+        if (!expectedCategory.equals(category)) {
+            throw new AuthException(invalidTokenErrorCode);
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(AuthErrorCode.EXPIRED_TOKEN);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
+    }
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/service/AuthService.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/service/AuthService.java
@@ -2,6 +2,9 @@ package com.leets.assignment.domain.auth.service;
 
 import com.leets.assignment.domain.auth.dto.AuthRequestDTO;
 import com.leets.assignment.domain.auth.dto.AuthResponseDTO;
+import com.leets.assignment.domain.auth.exception.AuthException;
+import com.leets.assignment.domain.auth.exception.code.AuthErrorCode;
+import com.leets.assignment.domain.auth.jwt.JwtProvider;
 import com.leets.assignment.domain.user.entity.User;
 import com.leets.assignment.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +19,7 @@ public class AuthService {
 
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
 
     @Transactional
     public AuthResponseDTO.SignupResDTO signup(AuthRequestDTO.SignupDTO request) {
@@ -36,5 +40,24 @@ public class AuthService {
                 .email(savedUser.getEmail())
                 .nickname(savedUser.getNickname())
                 .build();
+    }
+
+    public AuthResponseDTO.TokenResDTO login(AuthRequestDTO.LoginDTO request) {
+        User user = userService.findByEmail(request.getEmail());
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new AuthException(AuthErrorCode.INVALID_PASSWORD);
+        }
+
+        return jwtProvider.createTokenResponse(user);
+    }
+
+    public AuthResponseDTO.TokenResDTO reissue(AuthRequestDTO.ReissueDTO request) {
+        jwtProvider.validateRefreshToken(request.getRefreshToken());
+
+        String email = jwtProvider.getEmail(request.getRefreshToken());
+        User user = userService.findByEmail(email);
+
+        return jwtProvider.createTokenResponse(user);
     }
 }

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/service/AuthService.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/service/AuthService.java
@@ -1,0 +1,40 @@
+package com.leets.assignment.domain.auth.service;
+
+import com.leets.assignment.domain.auth.dto.AuthRequestDTO;
+import com.leets.assignment.domain.auth.dto.AuthResponseDTO;
+import com.leets.assignment.domain.user.entity.User;
+import com.leets.assignment.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final UserService userService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public AuthResponseDTO.SignupResDTO signup(AuthRequestDTO.SignupDTO request) {
+        userService.validateEmailNotDuplicated(request.getEmail());
+        userService.validateNicknameNotDuplicated(request.getNickname());
+
+        User user = User.builder()
+                .email(request.getEmail())
+                .nickname(request.getNickname())
+                .name(request.getName())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .build();
+
+        User savedUser = userService.save(user);
+
+        return AuthResponseDTO.SignupResDTO.builder()
+                .userId(savedUser.getUserId())
+                .email(savedUser.getEmail())
+                .nickname(savedUser.getNickname())
+                .build();
+    }
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/user/exception/UserException.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/user/exception/UserException.java
@@ -1,0 +1,14 @@
+package com.leets.assignment.domain.user.exception;
+
+import com.leets.assignment.domain.user.exception.code.UserErrorCode;
+import lombok.Getter;
+
+@Getter
+public class UserException extends RuntimeException {
+    private final UserErrorCode errorCode;
+
+    public UserException(UserErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/user/exception/code/UserErrorCode.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/user/exception/code/UserErrorCode.java
@@ -1,0 +1,18 @@
+package com.leets.assignment.domain.user.exception.code;
+
+import com.leets.assignment.global.exception.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements BaseErrorCode {
+    USER_NOT_FOUND("USER404_1", "해당 사용자가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    EMAIL_ALREADY_EXISTS("USER409_1", "이미 등록된 이메일입니다.", HttpStatus.CONFLICT),
+    NICKNAME_ALREADY_EXISTS("USER409_2", "이미 등록된 닉네임입니다.", HttpStatus.CONFLICT);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/user/repository/UserRepository.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/user/repository/UserRepository.java
@@ -4,7 +4,13 @@ import com.leets.assignment.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    // 기본 findById는 JpaRepository가 제공합니다.
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
+
+    Optional<User> findByEmail(String email);
 }

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/user/service/UserService.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/user/service/UserService.java
@@ -1,0 +1,52 @@
+package com.leets.assignment.domain.user.service;
+
+import com.leets.assignment.domain.user.entity.User;
+import com.leets.assignment.domain.user.exception.UserException;
+import com.leets.assignment.domain.user.exception.code.UserErrorCode;
+import com.leets.assignment.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public boolean existsByEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
+
+    public boolean existsByNickname(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+
+    public User findById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    public void validateEmailNotDuplicated(String email) {
+        if (existsByEmail(email)) {
+            throw new UserException(UserErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+    }
+
+    public void validateNicknameNotDuplicated(String nickname) {
+        if (existsByNickname(nickname)) {
+            throw new UserException(UserErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+    }
+
+    @Transactional
+    public User save(User user) {
+        return userRepository.save(user);
+    }
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/global/exception/GlobalExceptionHandler.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.leets.assignment.global.exception;
 
 import com.leets.assignment.domain.post.exception.code.PostErrorCode;
 import com.leets.assignment.domain.post.exception.PostException;
+import com.leets.assignment.domain.auth.exception.AuthException;
+import com.leets.assignment.domain.auth.exception.code.AuthErrorCode;
 import com.leets.assignment.domain.report.exception.ReportException;
 import com.leets.assignment.domain.report.exception.code.ReportErrorCode;
 import com.leets.assignment.domain.user.exception.UserException;
@@ -61,6 +63,18 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(UserException.class)
     public ResponseEntity<ApiResponse<Void>> handleUserException(UserException e) {
         UserErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(
+                ApiResponse.<Void>builder()
+                        .isSuccess(false)
+                        .code(errorCode.getCode())
+                        .message(errorCode.getMessage())
+                        .build()
+        );
+    }
+
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAuthException(AuthException e) {
+        AuthErrorCode errorCode = e.getErrorCode();
         return ResponseEntity.status(errorCode.getHttpStatus()).body(
                 ApiResponse.<Void>builder()
                         .isSuccess(false)

--- a/LeeKunHee/src/main/java/com/leets/assignment/global/exception/GlobalExceptionHandler.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import com.leets.assignment.domain.post.exception.code.PostErrorCode;
 import com.leets.assignment.domain.post.exception.PostException;
 import com.leets.assignment.domain.report.exception.ReportException;
 import com.leets.assignment.domain.report.exception.code.ReportErrorCode;
+import com.leets.assignment.domain.user.exception.UserException;
+import com.leets.assignment.domain.user.exception.code.UserErrorCode;
 import com.leets.assignment.global.common.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -47,6 +49,18 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(PostException.class)
     public ResponseEntity<ApiResponse<Void>> handlePostException(PostException e) {
         PostErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(
+                ApiResponse.<Void>builder()
+                        .isSuccess(false)
+                        .code(errorCode.getCode())
+                        .message(errorCode.getMessage())
+                        .build()
+        );
+    }
+
+    @ExceptionHandler(UserException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUserException(UserException e) {
+        UserErrorCode errorCode = e.getErrorCode();
         return ResponseEntity.status(errorCode.getHttpStatus()).body(
                 ApiResponse.<Void>builder()
                         .isSuccess(false)

--- a/LeeKunHee/src/main/resources/application.properties
+++ b/LeeKunHee/src/main/resources/application.properties
@@ -23,3 +23,8 @@ springdoc.packages-to-scan=com.leets.assignment
 
 springdoc.model-and-view-allowed=true
 springdoc.override-with-generic-response=true
+
+# JWT
+jwt.secret=leets-assignment-jwt-secret-key-must-be-at-least-32-bytes
+jwt.access-token-expiration-ms=3600000
+jwt.refresh-token-expiration-ms=1209600000

--- a/LeeKunHee/src/main/resources/data.sql
+++ b/LeeKunHee/src/main/resources/data.sql
@@ -1,23 +1,19 @@
--- 1번 유저
 INSERT INTO users (user_id, email, name, nickname, password, created_at, updated_at)
-VALUES (1, 'test1@test.com', '강아지1', '가나디1', '1234', NOW(), NOW());
+VALUES (1, 'test1@test.com', 'test user 1', 'tester1', '1234', NOW(), NOW());
 
--- 2번 유저
 INSERT INTO users (user_id, email, name, nickname, password, created_at, updated_at)
-VALUES (2, 'test2@test.com', '강아지2', '가나디2', '1234', NOW(), NOW());
+VALUES (2, 'test2@test.com', 'test user 2', 'tester2', '1234', NOW(), NOW());
 
--- 3번 유저
 INSERT INTO users (user_id, email, name, nickname, password, created_at, updated_at)
-VALUES (3, 'test3@test.com', '강아지3', '가나디3', '1234', NOW(), NOW());
+VALUES (3, 'test3@test.com', 'test user 3', 'tester3', '1234', NOW(), NOW());
 
--- 4번 유저
 INSERT INTO users (user_id, email, name, nickname, password, created_at, updated_at)
-VALUES (4, 'test4@test.com', '강아지4', '가나디4', '1234', NOW(), NOW());
+VALUES (4, 'test4@test.com', 'test user 4', 'tester4', '1234', NOW(), NOW());
 
--- 5번 유저
 INSERT INTO users (user_id, email, name, nickname, password, created_at, updated_at)
-VALUES (5, 'test5@test.com', '강아지5', '가나디5', '1234', NOW(), NOW());
+VALUES (5, 'test5@test.com', 'test user 5', 'tester5', '1234', NOW(), NOW());
 
--- 6번 유저
 INSERT INTO users (user_id, email, name, nickname, password, created_at, updated_at)
-VALUES (6, 'test6@test.com', '강아지6', '가나디6', '1234', NOW(), NOW());
+VALUES (6, 'test6@test.com', 'test user 6', 'tester6', '1234', NOW(), NOW());
+
+ALTER TABLE users ALTER COLUMN user_id RESTART WITH 7;


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

- [x] User 및 Auth 도메인 구현.
- [x] Spring Security 기반 인증/인가 로직 구현
- [x] JWT AccessToken / RefreshToken 발급 구현
- [x] 이메일 회원가입, 로그인 API 구현
- [x] 이메일, 닉네임 중복 방지


## 2. 핵심 변경 사항
- POST /auth/signup 회원가입 구현
이메일/닉네임 중복 검증
비밀번호 BCrypt 암호화 저장

- POST /login 로그인 구현
이메일 로그인
비밀번호 검증
access token, refresh token 발급

- POST /auth/reissue 토큰 재발급 구현
refresh token 검증
새 토큰 발급

- JWT 인증 필터 구현
Authorization: Bearer <accessToken> 방식 인증
SecurityContext 인증 정보 저장

- Spring Security 설정
stateless 인증 적용
인증 필요 API 보호
회원가입/로그인/재발급 API 허용

## 3. 실행 및 검증 결과

회원가입
<img width="1168" height="1363" alt="회원가입" src="https://github.com/user-attachments/assets/ef3d1e75-e857-4bc8-ad25-272d8c1448e3" />

로그인
<img width="1176" height="1324" alt="로그인" src="https://github.com/user-attachments/assets/cc7b9c9e-df4a-4ef4-8c92-b69f916b2e81" />

토큰 재발급
<img width="1174" height="1123" alt="토큰 재발급" src="https://github.com/user-attachments/assets/a4c97217-7590-41b9-940c-220774a6049d" />



## 4. 완료 사항

1.Spring Security 기반 인증/인가 로직 구현
2.JWT AccessToken / RefreshToken 발급 구현
3. 이메일 회원가입, 로그인 API 구현
4. 이메일, 닉네임 중복 방지


## 5. 추가 사항

- 관련 이슈: `closed #224

## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고
