### PR TITLE
[6주차] 남유정/[feat] Spring Security + JWT 인증/인가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,14 @@ dependencies {
 
 	//Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/leets7th/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/leets7th/domain/auth/controller/AuthController.java
@@ -1,0 +1,78 @@
+package com.example.leets7th.domain.auth.controller;
+
+import com.example.leets7th.domain.auth.dto.LoginRequest;
+import com.example.leets7th.domain.auth.dto.SignUpRequest;
+import com.example.leets7th.domain.auth.dto.TokenResponse;
+import com.example.leets7th.domain.auth.service.AuthService;
+import com.example.leets7th.global.common.ApiResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController implements AuthControllerDocs {
+
+    private static final String ACCESS_TOKEN_COOKIE = "accessToken";
+    private static final String REFRESH_TOKEN_COOKIE = "refreshToken";
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<Void>> signUp(@Valid @RequestBody SignUpRequest request) {
+        authService.signUp(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<Void>> login(@Valid @RequestBody LoginRequest request,
+                                                    HttpServletResponse response) {
+        TokenResponse tokens = authService.login(request);
+        addCookie(response, ACCESS_TOKEN_COOKIE, tokens.accessToken(), Duration.ofHours(1));
+        addCookie(response, REFRESH_TOKEN_COOKIE, tokens.refreshToken(), Duration.ofDays(14));
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<Void>> refresh(
+            @CookieValue(name = "refreshToken") String refreshToken,
+            HttpServletResponse response) {
+        String newAccessToken = authService.refresh(refreshToken);
+        addCookie(response, ACCESS_TOKEN_COOKIE, newAccessToken, Duration.ofHours(1));
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response) {
+        deleteCookie(response, ACCESS_TOKEN_COOKIE);
+        deleteCookie(response, REFRESH_TOKEN_COOKIE);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    private void addCookie(HttpServletResponse response, String name, String value, Duration maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .path("/")
+                .maxAge(maxAge)
+                .sameSite("Strict")
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    private void deleteCookie(HttpServletResponse response, String name) {
+        ResponseCookie cookie = ResponseCookie.from(name, "")
+                .httpOnly(true)
+                .path("/")
+                .maxAge(Duration.ZERO)
+                .sameSite("Strict")
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+}

--- a/src/main/java/com/example/leets7th/domain/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/com/example/leets7th/domain/auth/controller/AuthControllerDocs.java
@@ -1,0 +1,44 @@
+package com.example.leets7th.domain.auth.controller;
+
+import com.example.leets7th.domain.auth.dto.LoginRequest;
+import com.example.leets7th.domain.auth.dto.SignUpRequest;
+import com.example.leets7th.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Auth", description = "인증 관련 API")
+public interface AuthControllerDocs {
+
+    @Operation(summary = "이메일 회원가입", description = "이메일, 비밀번호, 닉네임으로 회원가입합니다. 이메일과 닉네임은 중복될 수 없습니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이메일 또는 닉네임 중복")
+    })
+    ResponseEntity<ApiResponse<Void>> signUp(@Valid @RequestBody SignUpRequest request);
+
+    @Operation(summary = "이메일 로그인", description = "이메일과 비밀번호로 로그인합니다. 성공 시 accessToken(1시간)과 refreshToken(14일)이 HttpOnly 쿠키로 발급됩니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "이메일 또는 비밀번호 불일치")
+    })
+    ResponseEntity<ApiResponse<Void>> login(@Valid @RequestBody LoginRequest request,
+                                             HttpServletResponse response);
+
+    @Operation(summary = "토큰 재발급", description = "refreshToken 쿠키를 검증하여 새로운 accessToken 쿠키를 발급합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "재발급 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 리프레시 토큰")
+    })
+    ResponseEntity<ApiResponse<Void>> refresh(@CookieValue(name = "refreshToken") String refreshToken,
+                                               HttpServletResponse response);
+
+    @Operation(summary = "로그아웃", description = "accessToken, refreshToken 쿠키를 삭제합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그아웃 성공")
+    ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response);
+}

--- a/src/main/java/com/example/leets7th/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/example/leets7th/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.example.leets7th.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank @Email
+        String email,
+
+        @NotBlank
+        String password
+) {
+}

--- a/src/main/java/com/example/leets7th/domain/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/example/leets7th/domain/auth/dto/SignUpRequest.java
@@ -1,0 +1,17 @@
+package com.example.leets7th.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SignUpRequest(
+        @NotBlank @Email
+        String email,
+
+        @NotBlank @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+        String password,
+
+        @NotBlank @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하이어야 합니다.")
+        String nickname
+) {
+}

--- a/src/main/java/com/example/leets7th/domain/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/example/leets7th/domain/auth/dto/TokenRefreshRequest.java
@@ -1,0 +1,9 @@
+package com.example.leets7th.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRefreshRequest(
+        @NotBlank
+        String refreshToken
+) {
+}

--- a/src/main/java/com/example/leets7th/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/com/example/leets7th/domain/auth/dto/TokenResponse.java
@@ -1,0 +1,7 @@
+package com.example.leets7th.domain.auth.dto;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/example/leets7th/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/leets7th/domain/auth/service/AuthService.java
@@ -1,0 +1,73 @@
+package com.example.leets7th.domain.auth.service;
+
+import com.example.leets7th.domain.auth.dto.LoginRequest;
+import com.example.leets7th.domain.auth.dto.SignUpRequest;
+import com.example.leets7th.domain.auth.dto.TokenResponse;
+import com.example.leets7th.domain.user.entity.User;
+import com.example.leets7th.domain.user.repository.UserRepository;
+import com.example.leets7th.global.exception.DuplicateEmailException;
+import com.example.leets7th.global.exception.DuplicateNicknameException;
+import com.example.leets7th.global.exception.InvalidCredentialsException;
+import com.example.leets7th.global.exception.InvalidTokenException;
+import com.example.leets7th.global.exception.UserNotFoundException;
+import com.example.leets7th.global.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public void signUp(SignUpRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new DuplicateEmailException();
+        }
+        if (userRepository.existsByNickname(request.nickname())) {
+            throw new DuplicateNicknameException();
+        }
+
+        String encodedPassword = passwordEncoder.encode(request.password());
+        userRepository.save(User.create(request.email(), encodedPassword, request.nickname()));
+    }
+
+    @Transactional
+    public TokenResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(InvalidCredentialsException::new);
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new InvalidCredentialsException();
+        }
+
+        String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getRole());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId());
+        user.updateRefreshToken(refreshToken);
+
+        return new TokenResponse(accessToken, refreshToken);
+    }
+
+    @Transactional
+    public String refresh(String refreshToken) {
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new InvalidTokenException();
+        }
+
+        Long userId = jwtProvider.getUserId(refreshToken);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        if (!refreshToken.equals(user.getRefreshToken())) {
+            throw new InvalidTokenException();
+        }
+
+        return jwtProvider.generateAccessToken(user.getId(), user.getRole());
+    }
+}

--- a/src/main/java/com/example/leets7th/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/leets7th/domain/comment/controller/CommentController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -22,7 +23,7 @@ public class CommentController implements CommentControllerDocs {
     public ResponseEntity<ApiResponse<Map<String, Object>>> createComment(
             @PathVariable Long postId,
             @RequestBody @Valid CommentCreateRequest request,
-            @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId
+            @AuthenticationPrincipal Long userId
     ) {
         Long commentId = commentService.createComment(postId, request, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(Map.of("commentId", commentId, "message", "댓글이 작성되었습니다.")));
@@ -32,7 +33,7 @@ public class CommentController implements CommentControllerDocs {
     public ResponseEntity<ApiResponse<Map<String, String>>> adoptComment(
             @PathVariable Long postId,
             @PathVariable Long commentId,
-            @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId
+            @AuthenticationPrincipal Long userId
     ) {
         commentService.adoptComment(postId, commentId, userId);
         return ResponseEntity.ok(ApiResponse.success(Map.of("message", "댓글이 채택되었습니다.")));

--- a/src/main/java/com/example/leets7th/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/leets7th/domain/comment/service/CommentService.java
@@ -10,6 +10,7 @@ import com.example.leets7th.domain.user.repository.UserRepository;
 import com.example.leets7th.global.exception.AlreadyAdoptedException;
 import com.example.leets7th.global.exception.CommentNotFoundException;
 import com.example.leets7th.global.exception.ForbiddenException;
+import com.example.leets7th.global.exception.InvalidCommentPostException;
 import com.example.leets7th.global.exception.PostNotFoundException;
 import com.example.leets7th.global.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +52,7 @@ public class CommentService {
 
         // 해당 게시글의 댓글인지 확인
         if (!comment.getPost().getId().equals(postId)) {
-            throw new IllegalArgumentException("해당 게시글에 속한 댓글이 아닙니다.");
+            throw new InvalidCommentPostException();
         }
 
         // 이미 채택된 댓글이 있는지 확인

--- a/src/main/java/com/example/leets7th/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/leets7th/domain/post/controller/PostController.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,11 +38,10 @@ public class PostController implements PostControllerDocs {
         return ResponseEntity.ok(ApiResponse.success("POST_DETAIL_SUCCESS", "게시글 상세 조회 성공", postService.getPost(postId)));
     }
 
-    // TODO: 실제 인증 구현 시 @AuthenticationPrincipal로 userId 주입
     @PostMapping
     public ResponseEntity<ApiResponse<Map<String, Object>>> createPost(
             @RequestBody @Valid PostCreateRequest request,
-            @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId
+            @AuthenticationPrincipal Long userId
     ) {
         Long postId = postService.createPost(request, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(Map.of("postId", postId, "message", "게시글이 생성되었습니다.")));
@@ -51,7 +51,7 @@ public class PostController implements PostControllerDocs {
     public ResponseEntity<ApiResponse<Map<String, String>>> updatePost(
             @PathVariable Long postId,
             @RequestBody PostUpdateRequest request,
-            @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId
+            @AuthenticationPrincipal Long userId
     ) {
         postService.updatePost(postId, request, userId);
         return ResponseEntity.ok(ApiResponse.success(Map.of("message", "게시글이 수정되었습니다.")));
@@ -60,7 +60,7 @@ public class PostController implements PostControllerDocs {
     @DeleteMapping("/{postId}")
     public ResponseEntity<ApiResponse<Map<String, String>>> deletePost(
             @PathVariable Long postId,
-            @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId
+            @AuthenticationPrincipal Long userId
     ) {
         postService.deletePost(postId, userId);
         return ResponseEntity.ok(ApiResponse.success(Map.of("message", "게시글이 삭제되었습니다.")));
@@ -69,7 +69,7 @@ public class PostController implements PostControllerDocs {
     @PatchMapping("/{postId}/hide")
     public ResponseEntity<ApiResponse<Map<String, String>>> hidePost(
             @PathVariable Long postId,
-            @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId
+            @AuthenticationPrincipal Long userId
     ) {
         postService.hidePost(postId, userId);
         return ResponseEntity.ok(ApiResponse.success(Map.of("message", "게시글이 숨김 처리되었습니다.")));

--- a/src/main/java/com/example/leets7th/domain/post/entity/PostStatus.java
+++ b/src/main/java/com/example/leets7th/domain/post/entity/PostStatus.java
@@ -2,5 +2,6 @@ package com.example.leets7th.domain.post.entity;
 
 public enum PostStatus {
     ACTIVE,
-    HIDDEN
+    HIDDEN,
+    DELETED
 }

--- a/src/main/java/com/example/leets7th/domain/report/controller/ReportController.java
+++ b/src/main/java/com/example/leets7th/domain/report/controller/ReportController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -21,7 +22,7 @@ public class ReportController implements ReportControllerDocs {
     public ResponseEntity<ApiResponse<Map<String, Object>>> reportPost(
             @PathVariable Long postId,
             @RequestBody @Valid ReportRequest request,
-            @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId
+            @AuthenticationPrincipal Long userId
     ) {
         Long reportId = reportService.reportPost(postId, request, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(Map.of("reportId", reportId, "message", "게시글이 신고되었습니다.")));
@@ -31,7 +32,7 @@ public class ReportController implements ReportControllerDocs {
     public ResponseEntity<ApiResponse<Map<String, Object>>> reportComment(
             @PathVariable Long commentId,
             @RequestBody @Valid ReportRequest request,
-            @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId
+            @AuthenticationPrincipal Long userId
     ) {
         Long reportId = reportService.reportComment(commentId, request, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(Map.of("reportId", reportId, "message", "댓글이 신고되었습니다.")));

--- a/src/main/java/com/example/leets7th/domain/user/entity/User.java
+++ b/src/main/java/com/example/leets7th/domain/user/entity/User.java
@@ -1,7 +1,7 @@
 package com.example.leets7th.domain.user.entity;
 
-import com.example.leets7th.domain.post.entity.Post;
 import com.example.leets7th.domain.comment.entity.Comment;
+import com.example.leets7th.domain.post.entity.Post;
 import com.example.leets7th.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -22,13 +22,25 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 선택 정보
-    private String username;
+    @Column(nullable = false, unique = true)
+    private String email;
 
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, unique = true)
     private String nickname;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+
+    private String username;
+
+    @Enumerated(EnumType.STRING)
     private Gender gender;
+
+    private String refreshToken;
 
     private LocalDateTime deletedAt;
 
@@ -38,10 +50,17 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user")
     private List<Comment> comments = new ArrayList<>();
 
-    public static User create(String nickname) {
+    public static User create(String email, String encodedPassword, String nickname) {
         User user = new User();
+        user.email = email;
+        user.password = encodedPassword;
         user.nickname = nickname;
+        user.role = UserRole.USER;
         return user;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 
     public void delete() {

--- a/src/main/java/com/example/leets7th/domain/user/entity/UserRole.java
+++ b/src/main/java/com/example/leets7th/domain/user/entity/UserRole.java
@@ -1,0 +1,5 @@
+package com.example.leets7th.domain.user.entity;
+
+public enum UserRole {
+    USER, ADMIN
+}

--- a/src/main/java/com/example/leets7th/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/leets7th/domain/user/repository/UserRepository.java
@@ -3,5 +3,13 @@ package com.example.leets7th.domain.user.repository;
 import com.example.leets7th.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/example/leets7th/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/leets7th/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.leets7th.global.config;
 
 import com.example.leets7th.global.jwt.JwtAuthenticationFilter;
 import com.example.leets7th.global.jwt.JwtProvider;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,6 +36,13 @@ public class SecurityConfig {
                                 "/swagger-ui.html"
                         ).permitAll()
                         .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.getWriter().write("{\"success\":false,\"code\":\"UNAUTHORIZED\",\"message\":\"인증이 필요합니다.\"}");
+                        })
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),
                         UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/example/leets7th/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/leets7th/global/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package com.example.leets7th.global.config;
+
+import com.example.leets7th.global.jwt.JwtAuthenticationFilter;
+import com.example.leets7th.global.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtProvider jwtProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/auth/**",
+                                "/swagger-ui/**",
+                                "/api-docs/**",
+                                "/swagger-ui.html"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),
+                        UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/leets7th/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/leets7th/global/config/SwaggerConfig.java
@@ -14,6 +14,6 @@ public class SwaggerConfig {
                 .info(new Info()
                         .title("Leets-7th BE Blog API")
                         .description("[남유정] 미션 API 명세서")
-                        .version("5주차"));
+                        .version("6주차"));
     }
 }

--- a/src/main/java/com/example/leets7th/global/exception/AlreadyAdoptedException.java
+++ b/src/main/java/com/example/leets7th/global/exception/AlreadyAdoptedException.java
@@ -1,8 +1,8 @@
 package com.example.leets7th.global.exception;
 
-public class AlreadyAdoptedException extends RuntimeException {
+public class AlreadyAdoptedException extends BusinessException {
 
     public AlreadyAdoptedException() {
-        super("이미 채택된 댓글이 존재합니다.");
+        super(ErrorCode.ALREADY_ADOPTED);
     }
 }

--- a/src/main/java/com/example/leets7th/global/exception/AlreadyHiddenException.java
+++ b/src/main/java/com/example/leets7th/global/exception/AlreadyHiddenException.java
@@ -1,8 +1,8 @@
 package com.example.leets7th.global.exception;
 
-public class AlreadyHiddenException extends RuntimeException {
+public class AlreadyHiddenException extends BusinessException {
 
     public AlreadyHiddenException() {
-        super("이미 숨김 처리된 게시글입니다.");
+        super(ErrorCode.ALREADY_HIDDEN);
     }
 }

--- a/src/main/java/com/example/leets7th/global/exception/AlreadyResolvedException.java
+++ b/src/main/java/com/example/leets7th/global/exception/AlreadyResolvedException.java
@@ -1,8 +1,8 @@
 package com.example.leets7th.global.exception;
 
-public class AlreadyResolvedException extends RuntimeException {
+public class AlreadyResolvedException extends BusinessException {
 
     public AlreadyResolvedException() {
-        super("이미 처리된 신고입니다.");
+        super(ErrorCode.ALREADY_RESOLVED);
     }
 }

--- a/src/main/java/com/example/leets7th/global/exception/BusinessException.java
+++ b/src/main/java/com/example/leets7th/global/exception/BusinessException.java
@@ -1,0 +1,20 @@
+package com.example.leets7th.global.exception;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/example/leets7th/global/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/example/leets7th/global/exception/CategoryNotFoundException.java
@@ -1,8 +1,8 @@
 package com.example.leets7th.global.exception;
 
-public class CategoryNotFoundException extends RuntimeException {
+public class CategoryNotFoundException extends BusinessException {
 
     public CategoryNotFoundException(Long categoryId) {
-        super("해당 카테고리를 찾을 수 없습니다. id=" + categoryId);
+        super(ErrorCode.CATEGORY_NOT_FOUND, ErrorCode.CATEGORY_NOT_FOUND.getMessage() + " id=" + categoryId);
     }
 }

--- a/src/main/java/com/example/leets7th/global/exception/CommentNotFoundException.java
+++ b/src/main/java/com/example/leets7th/global/exception/CommentNotFoundException.java
@@ -1,8 +1,8 @@
 package com.example.leets7th.global.exception;
 
-public class CommentNotFoundException extends RuntimeException {
+public class CommentNotFoundException extends BusinessException {
 
     public CommentNotFoundException(Long commentId) {
-        super("해당 댓글을 찾을 수 없습니다. id=" + commentId);
+        super(ErrorCode.COMMENT_NOT_FOUND, ErrorCode.COMMENT_NOT_FOUND.getMessage() + " id=" + commentId);
     }
 }

--- a/src/main/java/com/example/leets7th/global/exception/DuplicateEmailException.java
+++ b/src/main/java/com/example/leets7th/global/exception/DuplicateEmailException.java
@@ -1,0 +1,8 @@
+package com.example.leets7th.global.exception;
+
+public class DuplicateEmailException extends BusinessException {
+
+    public DuplicateEmailException() {
+        super(ErrorCode.DUPLICATE_EMAIL);
+    }
+}

--- a/src/main/java/com/example/leets7th/global/exception/DuplicateNicknameException.java
+++ b/src/main/java/com/example/leets7th/global/exception/DuplicateNicknameException.java
@@ -1,0 +1,8 @@
+package com.example.leets7th.global.exception;
+
+public class DuplicateNicknameException extends BusinessException {
+
+    public DuplicateNicknameException() {
+        super(ErrorCode.DUPLICATE_NICKNAME);
+    }
+}

--- a/src/main/java/com/example/leets7th/global/exception/DuplicateReportException.java
+++ b/src/main/java/com/example/leets7th/global/exception/DuplicateReportException.java
@@ -1,8 +1,8 @@
 package com.example.leets7th.global.exception;
 
-public class DuplicateReportException extends RuntimeException {
+public class DuplicateReportException extends BusinessException {
 
     public DuplicateReportException() {
-        super("이미 신고한 대상입니다.");
+        super(ErrorCode.DUPLICATE_REPORT);
     }
 }

--- a/src/main/java/com/example/leets7th/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/leets7th/global/exception/ErrorCode.java
@@ -7,8 +7,17 @@ public enum ErrorCode {
     // 400
     INVALID_COMMENT_POST(HttpStatus.BAD_REQUEST, "INVALID_COMMENT_POST", "해당 게시글에 속한 댓글이 아닙니다."),
 
+    // 401
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다."),
+
     // 403
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근 권한이 없습니다."),
+
+    // 409
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "DUPLICATE_NICKNAME", "이미 사용 중인 닉네임입니다."),
 
     // 404
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_NOT_FOUND", "해당 게시글을 찾을 수 없습니다."),

--- a/src/main/java/com/example/leets7th/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/leets7th/global/exception/ErrorCode.java
@@ -1,0 +1,47 @@
+package com.example.leets7th.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+
+    // 400
+    INVALID_COMMENT_POST(HttpStatus.BAD_REQUEST, "INVALID_COMMENT_POST", "해당 게시글에 속한 댓글이 아닙니다."),
+
+    // 403
+    FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근 권한이 없습니다."),
+
+    // 404
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_NOT_FOUND", "해당 게시글을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_NOT_FOUND", "해당 댓글을 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "해당 사용자를 찾을 수 없습니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY_NOT_FOUND", "해당 카테고리를 찾을 수 없습니다."),
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT_NOT_FOUND", "해당 신고를 찾을 수 없습니다."),
+
+    // 409
+    ALREADY_ADOPTED(HttpStatus.CONFLICT, "ALREADY_ADOPTED", "이미 채택된 댓글이 존재합니다."),
+    ALREADY_HIDDEN(HttpStatus.CONFLICT, "ALREADY_HIDDEN", "이미 숨김 처리된 게시글입니다."),
+    ALREADY_RESOLVED(HttpStatus.CONFLICT, "ALREADY_RESOLVED", "이미 처리된 신고입니다."),
+    DUPLICATE_REPORT(HttpStatus.CONFLICT, "DUPLICATE_REPORT", "이미 신고한 대상입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/example/leets7th/global/exception/ForbiddenException.java
+++ b/src/main/java/com/example/leets7th/global/exception/ForbiddenException.java
@@ -1,8 +1,8 @@
 package com.example.leets7th.global.exception;
 
-public class ForbiddenException extends RuntimeException {
+public class ForbiddenException extends BusinessException {
 
     public ForbiddenException(String message) {
-        super(message);
+        super(ErrorCode.FORBIDDEN, message);
     }
 }

--- a/src/main/java/com/example/leets7th/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/leets7th/global/exception/GlobalExceptionHandler.java
@@ -15,64 +15,11 @@ import java.util.List;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(PostNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handlePostNotFound(PostNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.error("POST_NOT_FOUND", "해당 게시글을 찾을 수 없습니다."));
-    }
-
-    @ExceptionHandler(CommentNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleCommentNotFound(CommentNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.error("COMMENT_NOT_FOUND", e.getMessage()));
-    }
-
-    @ExceptionHandler(ReportNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleReportNotFound(ReportNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.error("REPORT_NOT_FOUND", e.getMessage()));
-    }
-
-    @ExceptionHandler(DuplicateReportException.class)
-    public ResponseEntity<ApiResponse<Void>> handleDuplicateReport(DuplicateReportException e) {
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(ApiResponse.error("DUPLICATE_REPORT", e.getMessage()));
-    }
-
-    @ExceptionHandler(AlreadyAdoptedException.class)
-    public ResponseEntity<ApiResponse<Void>> handleAlreadyAdopted(AlreadyAdoptedException e) {
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(ApiResponse.error("ALREADY_ADOPTED", e.getMessage()));
-    }
-
-    @ExceptionHandler(UserNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleUserNotFound(UserNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.error("USER_NOT_FOUND", e.getMessage()));
-    }
-
-    @ExceptionHandler(CategoryNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleCategoryNotFound(CategoryNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.error("CATEGORY_NOT_FOUND", e.getMessage()));
-    }
-
-    @ExceptionHandler(AlreadyHiddenException.class)
-    public ResponseEntity<ApiResponse<Void>> handleAlreadyHidden(AlreadyHiddenException e) {
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(ApiResponse.error("ALREADY_HIDDEN", e.getMessage()));
-    }
-
-    @ExceptionHandler(AlreadyResolvedException.class)
-    public ResponseEntity<ApiResponse<Void>> handleAlreadyResolved(AlreadyResolvedException e) {
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(ApiResponse.error("ALREADY_RESOLVED", e.getMessage()));
-    }
-
-    @ExceptionHandler(ForbiddenException.class)
-    public ResponseEntity<ApiResponse<Void>> handleForbidden(ForbiddenException e) {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(ApiResponse.error("FORBIDDEN", e.getMessage()));
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.error(errorCode.getCode(), e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -89,7 +36,6 @@ public class GlobalExceptionHandler {
         List<FieldErrorDetail> errors = e.getConstraintViolations().stream()
                 .map(cv -> {
                     String field = cv.getPropertyPath().toString();
-                    // "methodName.paramName" -> "paramName"
                     if (field.contains(".")) {
                         field = field.substring(field.lastIndexOf('.') + 1);
                     }
@@ -107,12 +53,6 @@ public class GlobalExceptionHandler {
         );
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.error("INVALID_PARAMETER", "잘못된 요청입니다.", errors));
-    }
-
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error("INVALID_PARAMETER", e.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/example/leets7th/global/exception/InvalidCommentPostException.java
+++ b/src/main/java/com/example/leets7th/global/exception/InvalidCommentPostException.java
@@ -1,0 +1,8 @@
+package com.example.leets7th.global.exception;
+
+public class InvalidCommentPostException extends BusinessException {
+
+    public InvalidCommentPostException() {
+        super(ErrorCode.INVALID_COMMENT_POST);
+    }
+}

--- a/src/main/java/com/example/leets7th/global/exception/InvalidCredentialsException.java
+++ b/src/main/java/com/example/leets7th/global/exception/InvalidCredentialsException.java
@@ -1,0 +1,8 @@
+package com.example.leets7th.global.exception;
+
+public class InvalidCredentialsException extends BusinessException {
+
+    public InvalidCredentialsException() {
+        super(ErrorCode.INVALID_CREDENTIALS);
+    }
+}

--- a/src/main/java/com/example/leets7th/global/exception/InvalidTokenException.java
+++ b/src/main/java/com/example/leets7th/global/exception/InvalidTokenException.java
@@ -1,0 +1,8 @@
+package com.example.leets7th.global.exception;
+
+public class InvalidTokenException extends BusinessException {
+
+    public InvalidTokenException() {
+        super(ErrorCode.INVALID_TOKEN);
+    }
+}

--- a/src/main/java/com/example/leets7th/global/exception/PostNotFoundException.java
+++ b/src/main/java/com/example/leets7th/global/exception/PostNotFoundException.java
@@ -1,8 +1,8 @@
 package com.example.leets7th.global.exception;
 
-public class PostNotFoundException extends RuntimeException {
+public class PostNotFoundException extends BusinessException {
 
     public PostNotFoundException(Long postId) {
-        super("해당 게시글을 찾을 수 없습니다. id=" + postId);
+        super(ErrorCode.POST_NOT_FOUND, ErrorCode.POST_NOT_FOUND.getMessage() + " id=" + postId);
     }
 }

--- a/src/main/java/com/example/leets7th/global/exception/ReportNotFoundException.java
+++ b/src/main/java/com/example/leets7th/global/exception/ReportNotFoundException.java
@@ -1,8 +1,8 @@
 package com.example.leets7th.global.exception;
 
-public class ReportNotFoundException extends RuntimeException {
+public class ReportNotFoundException extends BusinessException {
 
     public ReportNotFoundException(Long reportId) {
-        super("해당 신고를 찾을 수 없습니다. id=" + reportId);
+        super(ErrorCode.REPORT_NOT_FOUND, ErrorCode.REPORT_NOT_FOUND.getMessage() + " id=" + reportId);
     }
 }

--- a/src/main/java/com/example/leets7th/global/exception/UserNotFoundException.java
+++ b/src/main/java/com/example/leets7th/global/exception/UserNotFoundException.java
@@ -1,8 +1,8 @@
 package com.example.leets7th.global.exception;
 
-public class UserNotFoundException extends RuntimeException {
+public class UserNotFoundException extends BusinessException {
 
     public UserNotFoundException(Long userId) {
-        super("해당 사용자를 찾을 수 없습니다. id=" + userId);
+        super(ErrorCode.USER_NOT_FOUND, ErrorCode.USER_NOT_FOUND.getMessage() + " id=" + userId);
     }
 }

--- a/src/main/java/com/example/leets7th/global/init/DataInitializer.java
+++ b/src/main/java/com/example/leets7th/global/init/DataInitializer.java
@@ -21,7 +21,7 @@ public class DataInitializer implements ApplicationRunner {
     @Override
     public void run(ApplicationArguments args) {
         if (userRepository.count() == 0) {
-            userRepository.save(User.create("Unknown"));
+            userRepository.save(User.create("admin@leets.com", "{noop}admin1234", "admin"));
         }
 
         if (categoryRepository.count() == 0) {

--- a/src/main/java/com/example/leets7th/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/leets7th/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package com.example.leets7th.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            Long userId = jwtProvider.getUserId(token);
+            String role = jwtProvider.getRole(token);
+
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    userId,
+                    null,
+                    List.of(new SimpleGrantedAuthority("ROLE_" + role))
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> "accessToken".equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/example/leets7th/global/jwt/JwtProvider.java
+++ b/src/main/java/com/example/leets7th/global/jwt/JwtProvider.java
@@ -1,0 +1,75 @@
+package com.example.leets7th.global.jwt;
+
+import com.example.leets7th.domain.user.entity.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private final SecretKey key;
+    private final long accessExpiration;
+    private final long refreshExpiration;
+
+    public JwtProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-expiration}") long accessExpiration,
+            @Value("${jwt.refresh-expiration}") long refreshExpiration
+    ) {
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+        this.accessExpiration = accessExpiration;
+        this.refreshExpiration = refreshExpiration;
+    }
+
+    public String generateAccessToken(Long userId, UserRole role) {
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("role", role.name())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + accessExpiration))
+                .signWith(key)
+                .compact();
+    }
+
+    public String generateRefreshToken(Long userId) {
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + refreshExpiration))
+                .signWith(key)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Long getUserId(String token) {
+        return Long.parseLong(getClaims(token).getSubject());
+    }
+
+    public String getRole(String token) {
+        return getClaims(token).get("role", String.class);
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,11 @@ spring:
       ddl-auto: update
     show-sql: true
 
+jwt:
+  secret: ${JWT_SECRET:dGhpcy1pcy1hLXZlcnktbG9uZy1zZWNyZXQta2V5LWZvci1qd3QtaG1hYy1zaGEyNTY=}
+  access-expiration: 3600000       # 1시간 (ms)
+  refresh-expiration: 1209600000   # 14일 (ms)
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

  - 이메일 회원가입 구현 (POST /auth/signup)
  - 이메일 로그인 구현 (POST /auth/login)
  - Spring Security로 인증/인가 로직 구현
  - JWT token 방식 구현 (accessToken, refreshToken)
  - 쿠키 방식으로 토큰 전달


## 2. 핵심 변경 사항

  - User 엔티티에 email, password, role, refreshToken 필드 추가
  - global/jwt/JwtProvider - accessToken(1시간), refreshToken(14일) 생성 및 검증
  - global/jwt/JwtAuthenticationFilter - 요청마다 accessToken 쿠키 파싱 후 SecurityContext    
  세팅
  - global/config/SecurityConfig - /auth/**, Swagger 경로 허용, 나머지 인증 필요, Stateless   
  설정
  - domain/auth - 회원가입/로그인/토큰 재발급/로그아웃 Controller, Service 구현
  - 기존 컨트롤러 X-User-Id 헤더 방식 → @AuthenticationPrincipal로 교체
  - ErrorCode enum 도입으로 예외 관리 일원화


## 3. 실행 및 검증 결과

  ### 회원가입

  |회원가입 성공 (201) |
  | --- |
  |<img width="723" height="694" alt="스크린샷 2026-05-12 210713" src="https://github.com/user-attachments/assets/1283fa81-4c95-415e-9bc6-588e32de80dd" />|

  ---

  ### 로그인

  |로그인 성공 (200) - accessToken, refreshToken HttpOnly 쿠키 발급 확인|
  | --- |
  |<img width="2502" height="920" alt="스크린샷 2026-05-12 211315" src="https://github.com/user-attachments/assets/4edcf747-12f6-448b-9995-4695f33dbcbe" />|

  ---

  ### 인증 후 보호된 API 접근

  |게시글 작성 성공 (201) - 쿠키 자동 전송으로 별도 토큰 입력 없이 인증 처리|
  | --- |
  |<img width="1081" height="1080" alt="스크린샷 2026-05-12 213528" src="https://github.com/user-attachments/assets/e7cb7f73-199b-4af5-9424-bd02d9b58dc5" />|

  ---

  ### 토큰 재발급

  |토큰 재발급 성공 (200) - refreshToken 쿠키로 새 accessToken 발급 확인|
  | --- |
  |<img width="2511" height="1013" alt="스크린샷 2026-05-12 211856" src="https://github.com/user-attachments/assets/4b4b70a8-5850-4b61-a3e7-3904d138eb49" />|

  ---

  ### 로그아웃

  |로그아웃 성공 (200) - DevTools에서 쿠키 Max-Age=0으로 삭제 확인|
  | --- |
  |<img width="2498" height="975" alt="스크린샷 2026-05-12 213624" src="https://github.com/user-attachments/assets/36b9863e-67fc-439e-8e0f-dbfd029d53f1" />|

  ---

  ### 인증 없이 보호된 API 접근

  |로그아웃 후 게시글 작성 시도 실패 (401)|
  | --- |
  |<img width="1082" height="1077" alt="스크린샷 2026-05-12 214044" src="https://github.com/user-attachments/assets/97573086-62f2-4d48-bc10-828f46b1a3f1" />|

  ---

## 4. 완료 사항

  1. Spring Security + JWT 기반 인증/인가 구현
  2. HttpOnly 쿠키로 토큰 전달 (XSS 방어, SameSite=Strict으로 CSRF 방어)
  3. 이메일/닉네임 중복 검증 및 커스텀 예외 처리


## 5. 추가 사항

- 관련 이슈: closed #231 

  - 토큰 전달 방식으로 HttpOnly 쿠키 선택 (이유는 이슈 참고)
  - refreshToken은 User 엔티티 필드에 저장


## 제출 체크리스트

- [X] PR 제목이 규칙에 맞다
- [X] base가 `{이름}/main` 브랜치다
- [X] compare가 `{이름}/{숫자}주차` 브랜치다
- [X] 프로젝트가 정상 실행된다
- [X] 본인을 Assignee로 지정했다
- [X] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고

<!--
BE: rootTiket, soyesenna
FE: One-HyeWon, woneeee
-->
