### PR TITLE
[6주차] 김동빈/[Feat] Spring Security + JWT 인증/인가

### DIFF
--- a/7th-be-blog/build.gradle
+++ b/7th-be-blog/build.gradle
@@ -20,8 +20,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 
     runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/7th-be-blog/src/main/java/com/leets/blog/common/config/DataInitializer.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/config/DataInitializer.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Slf4j
 @Configuration
@@ -14,6 +15,7 @@ import org.springframework.context.annotation.Configuration;
 public class DataInitializer {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Bean
     public CommandLineRunner initData() {
@@ -25,7 +27,7 @@ public class DataInitializer {
             User user = User.builder()
                     .name("tester")
                     .email("tester@test.com")
-                    .password("1234")
+                    .password(passwordEncoder.encode("1234"))
                     .build();
 
             userRepository.save(user);

--- a/7th-be-blog/src/main/java/com/leets/blog/common/exception/BaseErrorCode.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/exception/BaseErrorCode.java
@@ -13,6 +13,7 @@ public enum BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4001", "사용자를 찾을 수 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "USER4002", "이미 등록된 이메일입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "USER4003", "이미 등록된 닉네임입니다."),
+    INVALID_LOGIN(HttpStatus.UNAUTHORIZED, "AUTH4001", "이메일 또는 비밀번호가 올바르지 않습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4001", "게시글을 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT4001", "댓글을 찾을 수 없습니다."),
     DUPLICATE_REPORT(HttpStatus.CONFLICT, "REPORT4001", "이미 신고를 완료했습니다."),

--- a/7th-be-blog/src/main/java/com/leets/blog/common/exception/BaseErrorCode.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/exception/BaseErrorCode.java
@@ -14,6 +14,7 @@ public enum BaseErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "USER4002", "이미 등록된 이메일입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "USER4003", "이미 등록된 닉네임입니다."),
     INVALID_LOGIN(HttpStatus.UNAUTHORIZED, "AUTH4001", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4002", "유효하지 않은 리프레시 토큰입니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4001", "게시글을 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT4001", "댓글을 찾을 수 없습니다."),
     DUPLICATE_REPORT(HttpStatus.CONFLICT, "REPORT4001", "이미 신고를 완료했습니다."),

--- a/7th-be-blog/src/main/java/com/leets/blog/common/exception/BaseErrorCode.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/exception/BaseErrorCode.java
@@ -11,6 +11,8 @@ public enum BaseErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 내부 오류가 발생했습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4001", "사용자를 찾을 수 없습니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "USER4002", "이미 등록된 이메일입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "USER4003", "이미 등록된 닉네임입니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4001", "게시글을 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT4001", "댓글을 찾을 수 없습니다."),
     DUPLICATE_REPORT(HttpStatus.CONFLICT, "REPORT4001", "이미 신고를 완료했습니다."),

--- a/7th-be-blog/src/main/java/com/leets/blog/common/exception/GeneralException.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/exception/GeneralException.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 public class GeneralException extends RuntimeException {
 
     private final BaseErrorCode errorCode;
-
+    
     public GeneralException(BaseErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;

--- a/7th-be-blog/src/main/java/com/leets/blog/common/security/JwtAuthenticationFilter.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/security/JwtAuthenticationFilter.java
@@ -1,7 +1,5 @@
 package com.leets.blog.common.security;
 
-import com.leets.blog.domain.user.entity.User;
-import com.leets.blog.domain.user.repository.UserRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,7 +24,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String BEARER_PREFIX = "Bearer ";
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final UserRepository userRepository;
 
     @Override
     protected void doFilterInternal(
@@ -52,19 +49,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void authenticate(HttpServletRequest request, String token) {
-        Long userId = jwtTokenProvider.getUserId(token);
+        JwtPrincipal principal = new JwtPrincipal(
+                jwtTokenProvider.getUserId(token),
+                jwtTokenProvider.getEmail(token),
+                jwtTokenProvider.getRole(token)
+        );
 
-        userRepository.findById(userId)
-                .filter(user -> !user.isDeleted())
-                .ifPresent(user -> setAuthentication(request, user));
+        setAuthentication(request, principal);
     }
 
-    private void setAuthentication(HttpServletRequest request, User user) {
+    private void setAuthentication(HttpServletRequest request, JwtPrincipal principal) {
         List<SimpleGrantedAuthority> authorities = List.of(
-                new SimpleGrantedAuthority("ROLE_" + user.getRole().name())
+                new SimpleGrantedAuthority("ROLE_" + principal.role())
         );
         UsernamePasswordAuthenticationToken authentication =
-                new UsernamePasswordAuthenticationToken(user, null, authorities);
+                new UsernamePasswordAuthenticationToken(principal, null, authorities);
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
         SecurityContext context = SecurityContextHolder.createEmptyContext();

--- a/7th-be-blog/src/main/java/com/leets/blog/common/security/JwtAuthenticationFilter.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/security/JwtAuthenticationFilter.java
@@ -1,0 +1,74 @@
+package com.leets.blog.common.security;
+
+import com.leets.blog.domain.user.entity.User;
+import com.leets.blog.domain.user.repository.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token) && jwtTokenProvider.isAccessToken(token)) {
+            authenticate(request, token);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String authorization = request.getHeader(AUTHORIZATION_HEADER);
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+        return authorization.substring(BEARER_PREFIX.length());
+    }
+
+    private void authenticate(HttpServletRequest request, String token) {
+        Long userId = jwtTokenProvider.getUserId(token);
+
+        userRepository.findById(userId)
+                .filter(user -> !user.isDeleted())
+                .ifPresent(user -> setAuthentication(request, user));
+    }
+
+    private void setAuthentication(HttpServletRequest request, User user) {
+        List<SimpleGrantedAuthority> authorities = List.of(
+                new SimpleGrantedAuthority("ROLE_" + user.getRole().name())
+        );
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(user, null, authorities);
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+    }
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/common/security/JwtPrincipal.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/security/JwtPrincipal.java
@@ -1,0 +1,8 @@
+package com.leets.blog.common.security;
+
+public record JwtPrincipal(
+        Long userId,
+        String email,
+        String role
+) {
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/common/security/JwtTokenProvider.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/security/JwtTokenProvider.java
@@ -1,0 +1,102 @@
+package com.leets.blog.common.security;
+
+import com.leets.blog.domain.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private static final String TOKEN_TYPE_CLAIM = "tokenType";
+    private static final String ACCESS_TOKEN_TYPE = "ACCESS";
+    private static final String REFRESH_TOKEN_TYPE = "REFRESH";
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void init() {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createAccessToken(User user) {
+        return createToken(user, ACCESS_TOKEN_TYPE, accessTokenExpiration);
+    }
+
+    public String createRefreshToken(User user) {
+        return createToken(user, REFRESH_TOKEN_TYPE, refreshTokenExpiration);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException exception) {
+            return false;
+        }
+    }
+
+    public boolean isRefreshToken(String token) {
+        return REFRESH_TOKEN_TYPE.equals(getTokenType(token));
+    }
+
+    public Long getUserId(String token) {
+        return Long.valueOf(parseClaims(token).getSubject());
+    }
+
+    public String getEmail(String token) {
+        return parseClaims(token).get("email", String.class);
+    }
+
+    public String getRole(String token) {
+        return parseClaims(token).get("role", String.class);
+    }
+
+    public Date getExpiration(String token) {
+        return parseClaims(token).getExpiration();
+    }
+
+    private String createToken(User user, String tokenType, long expirationMillis) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + expirationMillis);
+
+        return Jwts.builder()
+                .subject(String.valueOf(user.getId()))
+                .claim("email", user.getEmail())
+                .claim("role", user.getRole().name())
+                .claim(TOKEN_TYPE_CLAIM, tokenType)
+                .issuedAt(now)
+                .expiration(expiration)
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    private String getTokenType(String token) {
+        return parseClaims(token).get(TOKEN_TYPE_CLAIM, String.class);
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/common/security/JwtTokenProvider.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/security/JwtTokenProvider.java
@@ -57,6 +57,10 @@ public class JwtTokenProvider {
         return REFRESH_TOKEN_TYPE.equals(getTokenType(token));
     }
 
+    public boolean isAccessToken(String token) {
+        return ACCESS_TOKEN_TYPE.equals(getTokenType(token));
+    }
+
     public Long getUserId(String token) {
         return Long.valueOf(parseClaims(token).getSubject());
     }

--- a/7th-be-blog/src/main/java/com/leets/blog/common/security/SecurityConfig.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/security/SecurityConfig.java
@@ -1,0 +1,53 @@
+package com.leets.blog.common.security;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private static final String[] PERMIT_URLS = {
+            "/auth",
+            "/login",
+            "/auth/refresh",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/v3/api-docs/**",
+            "/h2-console/**",
+            "/error"
+    };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                        .accessDeniedHandler((request, response, accessDeniedException) ->
+                                response.sendError(HttpServletResponse.SC_FORBIDDEN)))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(PERMIT_URLS).permitAll()
+                        .anyRequest().authenticated())
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/common/security/SecurityConfig.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.leets.blog.common.security;
 
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
@@ -12,10 +13,14 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     private static final String[] PERMIT_URLS = {
             "/auth",
@@ -43,6 +48,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(PERMIT_URLS).permitAll()
                         .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/controller/AuthController.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.leets.blog.domain.auth.controller;
 
 import com.leets.blog.common.response.ApiResponse;
+import com.leets.blog.domain.auth.dto.LoginRequest;
+import com.leets.blog.domain.auth.dto.LoginResponse;
 import com.leets.blog.domain.auth.dto.SignupRequest;
 import com.leets.blog.domain.auth.dto.SignupResponse;
 import com.leets.blog.domain.auth.service.AuthService;
@@ -23,5 +25,11 @@ public class AuthController {
     @Operation(summary = "이메일 회원가입", description = "이메일, 비밀번호, 닉네임으로 회원가입합니다.")
     public ApiResponse<SignupResponse> signup(@RequestBody @Valid SignupRequest request) {
         return ApiResponse.onSuccess(authService.signup(request));
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "이메일 로그인", description = "이메일과 비밀번호로 로그인하고 토큰을 발급받습니다.")
+    public ApiResponse<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
+        return ApiResponse.onSuccess(authService.login(request));
     }
 }

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/controller/AuthController.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/controller/AuthController.java
@@ -1,0 +1,27 @@
+package com.leets.blog.domain.auth.controller;
+
+import com.leets.blog.common.response.ApiResponse;
+import com.leets.blog.domain.auth.dto.SignupRequest;
+import com.leets.blog.domain.auth.dto.SignupResponse;
+import com.leets.blog.domain.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Auth", description = "인증 API")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/auth")
+    @Operation(summary = "이메일 회원가입", description = "이메일, 비밀번호, 닉네임으로 회원가입합니다.")
+    public ApiResponse<SignupResponse> signup(@RequestBody @Valid SignupRequest request) {
+        return ApiResponse.onSuccess(authService.signup(request));
+    }
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/controller/AuthController.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/controller/AuthController.java
@@ -5,6 +5,8 @@ import com.leets.blog.domain.auth.dto.LoginRequest;
 import com.leets.blog.domain.auth.dto.LoginResponse;
 import com.leets.blog.domain.auth.dto.SignupRequest;
 import com.leets.blog.domain.auth.dto.SignupResponse;
+import com.leets.blog.domain.auth.dto.TokenReissueRequest;
+import com.leets.blog.domain.auth.dto.TokenReissueResponse;
 import com.leets.blog.domain.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -31,5 +33,11 @@ public class AuthController {
     @Operation(summary = "이메일 로그인", description = "이메일과 비밀번호로 로그인하고 토큰을 발급받습니다.")
     public ApiResponse<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
         return ApiResponse.onSuccess(authService.login(request));
+    }
+
+    @PostMapping("/auth/refresh")
+    @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰으로 새 액세스 토큰을 발급받습니다.")
+    public ApiResponse<TokenReissueResponse> reissueAccessToken(@RequestBody @Valid TokenReissueRequest request) {
+        return ApiResponse.onSuccess(authService.reissueAccessToken(request));
     }
 }

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/LoginRequest.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,17 @@
+package com.leets.blog.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @Schema(description = "이메일", example = "user@example.com")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @Schema(description = "비밀번호", example = "password1234")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/LoginResponse.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/LoginResponse.java
@@ -1,0 +1,12 @@
+package com.leets.blog.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LoginResponse(
+        @Schema(description = "액세스 토큰")
+        String accessToken,
+
+        @Schema(description = "리프레시 토큰")
+        String refreshToken
+) {
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/SignupRequest.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/SignupRequest.java
@@ -1,0 +1,26 @@
+package com.leets.blog.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequest(
+        @Schema(description = "이메일", example = "user@example.com")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @Schema(description = "비밀번호", example = "password1234")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(max = 100, message = "비밀번호는 100자 이내여야 합니다.")
+        String password,
+
+        @JsonAlias("nickname")
+        @Schema(description = "닉네임", example = "tester")
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 30, message = "닉네임은 30자 이내여야 합니다.")
+        String name
+) {
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/SignupResponse.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/SignupResponse.java
@@ -1,0 +1,20 @@
+package com.leets.blog.domain.auth.dto;
+
+import com.leets.blog.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SignupResponse(
+        @Schema(description = "사용자 ID", example = "1")
+        Long id,
+
+        @Schema(description = "이메일", example = "user@example.com")
+        String email,
+
+        @Schema(description = "닉네임", example = "tester")
+        String name
+) {
+
+    public static SignupResponse from(User user) {
+        return new SignupResponse(user.getId(), user.getEmail(), user.getName());
+    }
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/TokenReissueRequest.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/TokenReissueRequest.java
@@ -1,0 +1,11 @@
+package com.leets.blog.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenReissueRequest(
+        @Schema(description = "리프레시 토큰")
+        @NotBlank(message = "리프레시 토큰은 필수입니다.")
+        String refreshToken
+) {
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/TokenReissueResponse.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/TokenReissueResponse.java
@@ -1,0 +1,9 @@
+package com.leets.blog.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TokenReissueResponse(
+        @Schema(description = "새 액세스 토큰")
+        String accessToken
+) {
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/entity/RefreshToken.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/entity/RefreshToken.java
@@ -55,6 +55,6 @@ public class RefreshToken extends BaseEntity {
     }
 
     public boolean isExpired(LocalDateTime now) {
-        return expiresAt.isBefore(now);
+        return !expiresAt.isAfter(now);
     }
 }

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/entity/RefreshToken.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,60 @@
+package com.leets.blog.domain.auth.entity;
+
+import com.leets.blog.common.entity.BaseEntity;
+import com.leets.blog.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "refresh_tokens")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(nullable = false, unique = true, length = 1000)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    public static RefreshToken create(User user, String token, LocalDateTime expiresAt) {
+        return RefreshToken.builder()
+                .user(user)
+                .token(token)
+                .expiresAt(expiresAt)
+                .build();
+    }
+
+    public void update(String token, LocalDateTime expiresAt) {
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    public boolean isExpired(LocalDateTime now) {
+        return expiresAt.isBefore(now);
+    }
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/repository/RefreshTokenRepository.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,15 @@
+package com.leets.blog.domain.auth.repository;
+
+import com.leets.blog.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByUserId(Long userId);
+
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteByUserId(Long userId);
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/service/AuthService.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/service/AuthService.java
@@ -2,8 +2,13 @@ package com.leets.blog.domain.auth.service;
 
 import com.leets.blog.common.exception.BaseErrorCode;
 import com.leets.blog.common.exception.GeneralException;
+import com.leets.blog.common.security.JwtTokenProvider;
+import com.leets.blog.domain.auth.dto.LoginRequest;
+import com.leets.blog.domain.auth.dto.LoginResponse;
 import com.leets.blog.domain.auth.dto.SignupRequest;
 import com.leets.blog.domain.auth.dto.SignupResponse;
+import com.leets.blog.domain.auth.entity.RefreshToken;
+import com.leets.blog.domain.auth.repository.RefreshTokenRepository;
 import com.leets.blog.domain.user.entity.User;
 import com.leets.blog.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,12 +16,17 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AuthService {
 
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -32,6 +42,23 @@ public class AuthService {
         return SignupResponse.from(userRepository.save(user));
     }
 
+    @Transactional
+    public LoginResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.email())
+                .filter(foundUser -> !foundUser.isDeleted())
+                .orElseThrow(() -> new GeneralException(BaseErrorCode.INVALID_LOGIN));
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new GeneralException(BaseErrorCode.INVALID_LOGIN);
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(user);
+        String refreshToken = jwtTokenProvider.createRefreshToken(user);
+        saveRefreshToken(user, refreshToken);
+
+        return new LoginResponse(accessToken, refreshToken);
+    }
+
     private void validateSignupRequest(SignupRequest request) {
         if (userRepository.existsByEmail(request.email())) {
             throw new GeneralException(BaseErrorCode.DUPLICATE_EMAIL);
@@ -39,5 +66,18 @@ public class AuthService {
         if (userRepository.existsByName(request.name())) {
             throw new GeneralException(BaseErrorCode.DUPLICATE_NICKNAME);
         }
+    }
+
+    private void saveRefreshToken(User user, String refreshToken) {
+        LocalDateTime expiresAt = LocalDateTime.ofInstant(
+                jwtTokenProvider.getExpiration(refreshToken).toInstant(),
+                ZoneId.systemDefault()
+        );
+
+        refreshTokenRepository.findByUserId(user.getId())
+                .ifPresentOrElse(
+                        savedToken -> savedToken.update(refreshToken, expiresAt),
+                        () -> refreshTokenRepository.save(RefreshToken.create(user, refreshToken, expiresAt))
+                );
     }
 }

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/service/AuthService.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/service/AuthService.java
@@ -7,6 +7,8 @@ import com.leets.blog.domain.auth.dto.LoginRequest;
 import com.leets.blog.domain.auth.dto.LoginResponse;
 import com.leets.blog.domain.auth.dto.SignupRequest;
 import com.leets.blog.domain.auth.dto.SignupResponse;
+import com.leets.blog.domain.auth.dto.TokenReissueRequest;
+import com.leets.blog.domain.auth.dto.TokenReissueResponse;
 import com.leets.blog.domain.auth.entity.RefreshToken;
 import com.leets.blog.domain.auth.repository.RefreshTokenRepository;
 import com.leets.blog.domain.user.entity.User;
@@ -57,6 +59,27 @@ public class AuthService {
         saveRefreshToken(user, refreshToken);
 
         return new LoginResponse(accessToken, refreshToken);
+    }
+
+    public TokenReissueResponse reissueAccessToken(TokenReissueRequest request) {
+        String requestRefreshToken = request.refreshToken();
+        if (!jwtTokenProvider.validateToken(requestRefreshToken) || !jwtTokenProvider.isRefreshToken(requestRefreshToken)) {
+            throw new GeneralException(BaseErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(requestRefreshToken)
+                .orElseThrow(() -> new GeneralException(BaseErrorCode.INVALID_REFRESH_TOKEN));
+
+        if (refreshToken.isExpired(LocalDateTime.now())) {
+            throw new GeneralException(BaseErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        User user = refreshToken.getUser();
+        if (user.isDeleted()) {
+            throw new GeneralException(BaseErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        return new TokenReissueResponse(jwtTokenProvider.createAccessToken(user));
     }
 
     private void validateSignupRequest(SignupRequest request) {

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/service/AuthService.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/service/AuthService.java
@@ -1,0 +1,43 @@
+package com.leets.blog.domain.auth.service;
+
+import com.leets.blog.common.exception.BaseErrorCode;
+import com.leets.blog.common.exception.GeneralException;
+import com.leets.blog.domain.auth.dto.SignupRequest;
+import com.leets.blog.domain.auth.dto.SignupResponse;
+import com.leets.blog.domain.user.entity.User;
+import com.leets.blog.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public SignupResponse signup(SignupRequest request) {
+        validateSignupRequest(request);
+
+        User user = User.builder()
+                .email(request.email())
+                .password(passwordEncoder.encode(request.password()))
+                .name(request.name())
+                .build();
+
+        return SignupResponse.from(userRepository.save(user));
+    }
+
+    private void validateSignupRequest(SignupRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new GeneralException(BaseErrorCode.DUPLICATE_EMAIL);
+        }
+        if (userRepository.existsByName(request.name())) {
+            throw new GeneralException(BaseErrorCode.DUPLICATE_NICKNAME);
+        }
+    }
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/user/entity/Role.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/user/entity/Role.java
@@ -1,0 +1,5 @@
+package com.leets.blog.domain.user.entity;
+
+public enum Role {
+    USER
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/user/entity/User.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/user/entity/User.java
@@ -5,6 +5,8 @@ import com.leets.blog.domain.comment.entity.Comment;
 import com.leets.blog.domain.post.entity.Post;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,7 +33,7 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String name;
 
     @Column(nullable = false, unique = true)
@@ -39,6 +41,11 @@ public class User extends BaseEntity {
 
     @Column(nullable = false)
     private String password;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role = Role.USER;
 
     @Builder.Default
     @OneToMany(mappedBy = "user")

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/user/repository/UserRepository.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/user/repository/UserRepository.java
@@ -3,5 +3,13 @@ package com.leets.blog.domain.user.repository;
 import com.leets.blog.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByEmail(String email);
+
+    boolean existsByName(String name);
+
+    Optional<User> findByEmail(String email);
 }

--- a/7th-be-blog/src/main/resources/application.properties
+++ b/7th-be-blog/src/main/resources/application.properties
@@ -13,5 +13,5 @@ spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
 
 jwt.secret=leets-7th-be-blog-email-auth-secret-key-for-jwt-token-signing
-jwt.access-token-expiration=3600000
+jwt.access-token-expiration=1800000
 jwt.refresh-token-expiration=1209600000

--- a/7th-be-blog/src/main/resources/application.properties
+++ b/7th-be-blog/src/main/resources/application.properties
@@ -11,3 +11,7 @@ spring.jpa.properties.hibernate.format_sql=true
 
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
+
+jwt.secret=leets-7th-be-blog-email-auth-secret-key-for-jwt-token-signing
+jwt.access-token-expiration=3600000
+jwt.refresh-token-expiration=1209600000


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

- [x] Spring Security 기반 인증/인가 구현
- [x] JWT AccessToken / RefreshToken 발급 구현
- [x] 이메일 회원가입, 로그인 API 구현
- [x] 이메일, 닉네임 중복 방지
- [x] RefreshToken 기반 AccessToken 재발급 구현

## 2. 핵심 변경 사항

1. JWT 인증 기능 추가
- AccessToken / RefreshToken 발급
- JWT 검증 로직 구현
- JwtAuthenticationFilter 적용

2. Spring Security 설정
- Stateless 인증 방식 적용
- 인증이 필요한 API 접근 제어
- 인증 실패 시 401 응답 처리

3. 인증 API 구현
- 회원가입 API 구현
- 로그인 API 구현
- RefreshToken 재발급 API 구현
- 비밀번호 암호화 저장

## 3. 실행 및 검증 결과

회원가입
<img width="936" height="678" alt="스크린샷 2026-05-12 오후 11 04 24" src="https://github.com/user-attachments/assets/13bf0f68-7f62-447e-a2fd-51c517599076" />


로그인
<img width="960" height="680" alt="스크린샷 2026-05-12 오후 11 04 51" src="https://github.com/user-attachments/assets/f0f7245c-7472-4774-8540-c7f71e0fdd3e" />

토큰 재발급
<img width="964" height="673" alt="스크린샷 2026-05-12 오후 11 10 41" src="https://github.com/user-attachments/assets/e266aa6a-eaab-4bf8-8062-52823399fac8" />


토큰 기반 인증 요청
<img width="962" height="594" alt="스크린샷 2026-05-12 오후 11 20 21" src="https://github.com/user-attachments/assets/c0a794e9-d090-4982-9620-31e6a7a2b571" />

토큰 없이 요청한 경우
<img width="1003" height="512" alt="스크린샷 2026-05-12 오후 11 22 29" src="https://github.com/user-attachments/assets/6c001767-f9f3-494c-960e-e69a6374ae40" />


## 4. 완료 사항

1. Spring Security 기반 인증/인가 구현
2. JWT AccessToken / RefreshToken 발급 구현
3. 이메일 회원가입, 로그인 API 구현
4. 이메일, 닉네임 중복 방지
5. RefreshToken 기반 AccessToken 재발급 구현

## 5. 추가 사항

#221 

## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고

