### PR TITLE
[6주차] 한하람/[feat] Spring Security + JWT 인증/인가

### DIFF
--- a/hanharam/build.gradle.kts
+++ b/hanharam/build.gradle.kts
@@ -28,10 +28,16 @@ dependencies {
     // 기본 의존성
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-security")
 
     // DB
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     runtimeOnly("com.mysql:mysql-connector-j")
+
+    // JWT
+    implementation("io.jsonwebtoken:jjwt-api:0.12.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.5")
 
     // Lombok
     compileOnly("org.projectlombok:lombok")

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/AuthenticationController.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/AuthenticationController.java
@@ -1,0 +1,35 @@
+package com.leets.blog.authentication.adapter.in.web;
+
+import com.leets.blog.authentication.adapter.in.web.dto.request.LoginRequest;
+import com.leets.blog.authentication.adapter.in.web.dto.request.SignUpRequest;
+import com.leets.blog.authentication.adapter.in.web.dto.response.AuthResponse;
+import com.leets.blog.authentication.application.port.in.command.AuthenticateMemberUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+@Tag(name = "Authentication | 인증", description = "회원가입 및 로그인 API")
+public class AuthenticationController {
+
+    private final AuthenticateMemberUseCase authenticateMemberUseCase;
+
+    @PostMapping("/signup")
+    @Operation(summary = "회원가입", description = "이메일과 비밀번호로 회원가입을 진행합니다.")
+    public AuthResponse signUp(@Valid @RequestBody SignUpRequest request) {
+        return AuthResponse.from(authenticateMemberUseCase.signUp(request.toCommand()));
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하고 JWT를 발급합니다.")
+    public AuthResponse login(@Valid @RequestBody LoginRequest request) {
+        return AuthResponse.from(authenticateMemberUseCase.login(request.toCommand()));
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/AuthenticationController.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/AuthenticationController.java
@@ -5,6 +5,7 @@ import com.leets.blog.authentication.adapter.in.web.dto.request.SignUpRequest;
 import com.leets.blog.authentication.adapter.in.web.dto.response.AuthResponse;
 import com.leets.blog.authentication.application.port.in.command.AuthenticateMemberUseCase;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
 @Tag(name = "Authentication | 인증", description = "회원가입 및 로그인 API")
+@SecurityRequirements
 public class AuthenticationController {
 
     private final AuthenticateMemberUseCase authenticateMemberUseCase;

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/dto/request/LoginRequest.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/dto/request/LoginRequest.java
@@ -1,0 +1,22 @@
+package com.leets.blog.authentication.adapter.in.web.dto.request;
+
+import com.leets.blog.authentication.application.port.in.command.dto.LoginCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "로그인 요청")
+public record LoginRequest(
+        @Schema(description = "로그인 이메일", example = "test@example.com")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @Schema(description = "비밀번호", example = "test1234")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+    public LoginCommand toCommand() {
+        return new LoginCommand(email, password);
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/dto/request/SignUpRequest.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/dto/request/SignUpRequest.java
@@ -1,0 +1,35 @@
+package com.leets.blog.authentication.adapter.in.web.dto.request;
+
+import com.leets.blog.authentication.application.port.in.command.dto.SignUpCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "회원가입 요청")
+public record SignUpRequest(
+        @Schema(description = "이름", example = "홍길동")
+        @NotBlank(message = "이름은 필수입니다.")
+        String name,
+
+        @Schema(description = "닉네임", example = "길동이")
+        @NotBlank(message = "닉네임은 필수입니다.")
+        String nickname,
+
+        @Schema(description = "로그인 이메일", example = "test@example.com")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @Schema(description = "비밀번호", example = "test1234")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d).{8,64}$",
+                message = "비밀번호는 8자 이상 64자 이하이며 영문과 숫자를 포함해야 합니다."
+        )
+        String password
+) {
+    public SignUpCommand toCommand() {
+        return new SignUpCommand(name, nickname, email, password);
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/dto/response/AuthResponse.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/dto/response/AuthResponse.java
@@ -1,0 +1,23 @@
+package com.leets.blog.authentication.adapter.in.web.dto.response;
+
+import com.leets.blog.authentication.application.port.in.command.dto.LoginResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "인증 응답")
+public record AuthResponse(
+        Long memberId,
+        String email,
+        String nickname,
+        String accessToken,
+        String refreshToken
+) {
+    public static AuthResponse from(LoginResult result) {
+        return new AuthResponse(
+                result.memberId(),
+                result.email(),
+                result.nickname(),
+                result.accessToken(),
+                result.refreshToken()
+        );
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/port/in/command/AuthenticateMemberUseCase.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/port/in/command/AuthenticateMemberUseCase.java
@@ -1,0 +1,11 @@
+package com.leets.blog.authentication.application.port.in.command;
+
+import com.leets.blog.authentication.application.port.in.command.dto.LoginCommand;
+import com.leets.blog.authentication.application.port.in.command.dto.LoginResult;
+import com.leets.blog.authentication.application.port.in.command.dto.SignUpCommand;
+
+public interface AuthenticateMemberUseCase {
+    LoginResult signUp(SignUpCommand command);
+
+    LoginResult login(LoginCommand command);
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/port/in/command/dto/LoginCommand.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/port/in/command/dto/LoginCommand.java
@@ -1,0 +1,13 @@
+package com.leets.blog.authentication.application.port.in.command.dto;
+
+import java.util.Objects;
+
+public record LoginCommand(
+        String email,
+        String password
+) {
+    public LoginCommand {
+        Objects.requireNonNull(email, "이메일은 필수입니다.");
+        Objects.requireNonNull(password, "비밀번호는 필수입니다.");
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/port/in/command/dto/LoginResult.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/port/in/command/dto/LoginResult.java
@@ -1,0 +1,13 @@
+package com.leets.blog.authentication.application.port.in.command.dto;
+
+import lombok.Builder;
+
+@Builder
+public record LoginResult(
+        Long memberId,
+        String email,
+        String nickname,
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/port/in/command/dto/SignUpCommand.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/port/in/command/dto/SignUpCommand.java
@@ -1,0 +1,17 @@
+package com.leets.blog.authentication.application.port.in.command.dto;
+
+import java.util.Objects;
+
+public record SignUpCommand(
+        String name,
+        String nickname,
+        String email,
+        String password
+) {
+    public SignUpCommand {
+        Objects.requireNonNull(name, "이름은 필수입니다.");
+        Objects.requireNonNull(nickname, "닉네임은 필수입니다.");
+        Objects.requireNonNull(email, "이메일은 필수입니다.");
+        Objects.requireNonNull(password, "비밀번호는 필수입니다.");
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/service/AuthenticationService.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/service/AuthenticationService.java
@@ -1,0 +1,115 @@
+package com.leets.blog.authentication.application.service;
+
+import com.leets.blog.authentication.application.port.in.command.AuthenticateMemberUseCase;
+import com.leets.blog.authentication.application.port.in.command.dto.LoginCommand;
+import com.leets.blog.authentication.application.port.in.command.dto.LoginResult;
+import com.leets.blog.authentication.application.port.in.command.dto.SignUpCommand;
+import com.leets.blog.authentication.domain.exception.AuthenticationDomainException;
+import com.leets.blog.authentication.domain.exception.AuthenticationErrorCode;
+import com.leets.blog.global.security.JwtTokenProvider;
+import com.leets.blog.member.application.port.out.LoadMemberAuthPort;
+import com.leets.blog.member.application.port.out.SaveMemberAuthPort;
+import com.leets.blog.member.domain.Member;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthenticationService implements AuthenticateMemberUseCase {
+
+    private static final Pattern EMAIL_PATTERN =
+            Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+    private static final Pattern PASSWORD_PATTERN =
+            Pattern.compile("^(?=.*[A-Za-z])(?=.*\\d).{8,64}$");
+
+    private final LoadMemberAuthPort loadMemberAuthPort;
+    private final SaveMemberAuthPort saveMemberAuthPort;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public LoginResult signUp(SignUpCommand command) {
+        String email = normalizeEmail(command.email());
+        validateSignUpInput(command.name(), command.nickname(), email, command.password());
+
+        if (loadMemberAuthPort.existsByEmail(email)) {
+            throw new AuthenticationDomainException(AuthenticationErrorCode.DUPLICATE_EMAIL);
+        }
+
+        Member savedMember = saveMemberAuthPort.save(
+                Member.create(
+                        command.name().trim(),
+                        command.nickname().trim(),
+                        email,
+                        passwordEncoder.encode(command.password())
+                )
+        );
+
+        return issueTokens(savedMember);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public LoginResult login(LoginCommand command) {
+        String email = normalizeEmail(command.email());
+        validateLoginInput(email, command.password());
+
+        Member member = loadMemberAuthPort.findByEmail(email)
+                .orElseThrow(() -> new AuthenticationDomainException(AuthenticationErrorCode.INVALID_CREDENTIALS));
+
+        if (!passwordEncoder.matches(command.password(), member.getPassword())) {
+            throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_CREDENTIALS);
+        }
+
+        return issueTokens(member);
+    }
+
+    private LoginResult issueTokens(Member member) {
+        List<String> roles = List.of(member.getRole().name());
+
+        return LoginResult.builder()
+                .memberId(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .accessToken(jwtTokenProvider.createAccessToken(member.getId(), roles))
+                .refreshToken(jwtTokenProvider.createRefreshToken(member.getId()))
+                .build();
+    }
+
+    private void validateSignUpInput(String name, String nickname, String email, String password) {
+        if (name.isBlank() || nickname.isBlank()) {
+            throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_PROFILE_INPUT);
+        }
+        validateEmail(email);
+        validatePassword(password);
+    }
+
+    private void validateLoginInput(String email, String password) {
+        validateEmail(email);
+        if (password == null || password.isBlank()) {
+            throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_CREDENTIALS);
+        }
+    }
+
+    private void validateEmail(String email) {
+        if (!EMAIL_PATTERN.matcher(email).matches()) {
+            throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_EMAIL_FORMAT);
+        }
+    }
+
+    private void validatePassword(String password) {
+        if (!PASSWORD_PATTERN.matcher(password).matches()) {
+            throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_PASSWORD_FORMAT);
+        }
+    }
+
+    private String normalizeEmail(String email) {
+        return email.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/domain/exception/AuthenticationDomainException.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/domain/exception/AuthenticationDomainException.java
@@ -1,0 +1,15 @@
+package com.leets.blog.authentication.domain.exception;
+
+import com.leets.blog.global.exception.BusinessException;
+import com.leets.blog.global.exception.constant.Domain;
+
+public class AuthenticationDomainException extends BusinessException {
+
+    public AuthenticationDomainException(AuthenticationErrorCode errorCode) {
+        super(Domain.AUTHENTICATION, errorCode);
+    }
+
+    public AuthenticationDomainException(AuthenticationErrorCode errorCode, String message) {
+        super(Domain.AUTHENTICATION, errorCode, message);
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/domain/exception/AuthenticationErrorCode.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/domain/exception/AuthenticationErrorCode.java
@@ -1,0 +1,27 @@
+package com.leets.blog.authentication.domain.exception;
+
+import com.leets.blog.global.response.code.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthenticationErrorCode implements BaseCode {
+
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "AUTH-001", "이미 사용 중인 이메일입니다."),
+    INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "AUTH-002", "올바른 이메일 형식이 아닙니다."),
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "AUTH-003", "비밀번호는 8자 이상 64자 이하이며 영문과 숫자를 포함해야 합니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH-004", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    INVALID_PROFILE_INPUT(HttpStatus.BAD_REQUEST, "AUTH-011", "이름과 닉네임은 필수입니다."),
+    WRONG_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "AUTH-005", "잘못된 JWT 서명입니다."),
+    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-006", "만료된 JWT 토큰입니다."),
+    UNSUPPORTED_JWT(HttpStatus.UNAUTHORIZED, "AUTH-007", "지원되지 않는 JWT 토큰입니다."),
+    INVALID_JWT(HttpStatus.UNAUTHORIZED, "AUTH-008", "유효하지 않은 JWT 토큰입니다."),
+    INVALID_AUTH_HEADER(HttpStatus.UNAUTHORIZED, "AUTH-009", "Authorization 헤더 형식이 올바르지 않습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH-010", "회원을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/hanharam/src/main/java/com/leets/blog/global/config/JacksonConfig.java
+++ b/hanharam/src/main/java/com/leets/blog/global/config/JacksonConfig.java
@@ -1,0 +1,18 @@
+package com.leets.blog.global.config;
+
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
+        return builder -> builder
+                .featuresToEnable(JsonWriteFeature.WRITE_NUMBERS_AS_STRINGS.mappedFeature())
+                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO 8601 형식
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/global/config/OpenApiConfig.java
+++ b/hanharam/src/main/java/com/leets/blog/global/config/OpenApiConfig.java
@@ -1,0 +1,31 @@
+package com.leets.blog.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        String schemeName = "bearerAuth";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Leets Blog API")
+                        .version("v1")
+                        .description("블로그 API"))
+                .addSecurityItem(new SecurityRequirement().addList(schemeName))
+                .components(new Components()
+                        .addSecuritySchemes(schemeName, new SecurityScheme()
+                                .name("Authorization")
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/global/config/SecurityConfig.java
+++ b/hanharam/src/main/java/com/leets/blog/global/config/SecurityConfig.java
@@ -1,0 +1,55 @@
+package com.leets.blog.global.config;
+
+import com.leets.blog.global.security.ApiAuthenticationEntryPoint;
+import com.leets.blog.global.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private static final String[] SWAGGER_PATHS = {
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/swagger-resources/**",
+            "/webjars/**"
+    };
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ApiAuthenticationEntryPoint apiAuthenticationEntryPoint;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(SWAGGER_PATHS).permitAll()
+                        .requestMatchers("/error", "/test/**", "/api/v1/auth/**").permitAll()
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/v1/posts/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex.authenticationEntryPoint(apiAuthenticationEntryPoint))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/global/config/WebMvcConfig.java
+++ b/hanharam/src/main/java/com/leets/blog/global/config/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package com.leets.blog.global.config;
+
+import com.leets.blog.global.security.resolver.CurrentMemberArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final CurrentMemberArgumentResolver currentMemberArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentMemberArgumentResolver);
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/global/security/ApiAuthenticationEntryPoint.java
+++ b/hanharam/src/main/java/com/leets/blog/global/security/ApiAuthenticationEntryPoint.java
@@ -1,0 +1,62 @@
+package com.leets.blog.global.security;
+
+import static com.leets.blog.global.security.JwtAuthenticationFilter.JWT_ERROR_ATTRIBUTE;
+import static com.leets.blog.global.security.JwtAuthenticationFilter.JWT_UNKNOWN_ERROR_ATTRIBUTE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.leets.blog.authentication.domain.exception.AuthenticationDomainException;
+import com.leets.blog.global.exception.constant.CommonErrorCode;
+import com.leets.blog.global.response.ApiResponse;
+import com.leets.blog.global.response.code.BaseCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException {
+        BaseCode errorCode = resolveErrorCode(request, authException);
+
+        ApiResponse<Object> body = ApiResponse.onFailure(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                null
+        );
+
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+
+    private BaseCode resolveErrorCode(HttpServletRequest request, AuthenticationException authException) {
+        Object jwtError = request.getAttribute(JWT_ERROR_ATTRIBUTE);
+        if (jwtError instanceof AuthenticationDomainException domainException) {
+            return domainException.getBaseCode();
+        }
+
+        Object unknownError = request.getAttribute(JWT_UNKNOWN_ERROR_ATTRIBUTE);
+        if (unknownError != null) {
+            return CommonErrorCode.INTERNAL_SERVER_ERROR;
+        }
+
+        Throwable cause = authException.getCause();
+        if (cause instanceof AuthenticationDomainException domainException) {
+            return domainException.getBaseCode();
+        }
+
+        return CommonErrorCode.UNAUTHORIZED;
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/global/security/JwtAuthenticationFilter.java
+++ b/hanharam/src/main/java/com/leets/blog/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,70 @@
+package com.leets.blog.global.security;
+
+import com.leets.blog.authentication.domain.exception.AuthenticationDomainException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String JWT_ERROR_ATTRIBUTE = "jwt.error";
+    public static final String JWT_UNKNOWN_ERROR_ATTRIBUTE = "jwt.error.unknown";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token != null) {
+            try {
+                if (jwtTokenProvider.validateAccessToken(token)) {
+                    Long memberId = jwtTokenProvider.parseAccessToken(token);
+                    List<String> roles = jwtTokenProvider.getRolesFromAccessToken(token);
+
+                    MemberPrincipal principal = MemberPrincipal.builder()
+                            .memberId(memberId)
+                            .build();
+
+                    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                            principal,
+                            null,
+                            roles.stream()
+                                    .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+                                    .toList()
+                    );
+
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            } catch (AuthenticationDomainException e) {
+                request.setAttribute(JWT_ERROR_ATTRIBUTE, e);
+            } catch (Exception e) {
+                request.setAttribute(JWT_UNKNOWN_ERROR_ATTRIBUTE, e);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/global/security/JwtTokenProvider.java
+++ b/hanharam/src/main/java/com/leets/blog/global/security/JwtTokenProvider.java
@@ -1,0 +1,112 @@
+package com.leets.blog.global.security;
+
+import com.leets.blog.authentication.domain.exception.AuthenticationDomainException;
+import com.leets.blog.authentication.domain.exception.AuthenticationErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private final SecretKey accessTokenSecret;
+    private final SecretKey refreshTokenSecret;
+    private final long accessTokenValidityInMilliseconds;
+    private final long refreshTokenValidityInMilliseconds;
+
+    public JwtTokenProvider(
+            @Value("${jwt.access-token-secret}") String accessTokenSecret,
+            @Value("${jwt.refresh-token-secret}") String refreshTokenSecret,
+            @Value("${jwt.access-token-validity-in-seconds}") long accessTokenValidityInSeconds,
+            @Value("${jwt.refresh-token-validity-in-seconds}") long refreshTokenValidityInSeconds
+    ) {
+        this.accessTokenSecret = Keys.hmacShaKeyFor(accessTokenSecret.getBytes(StandardCharsets.UTF_8));
+        this.refreshTokenSecret = Keys.hmacShaKeyFor(refreshTokenSecret.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenValidityInMilliseconds = accessTokenValidityInSeconds * 1000;
+        this.refreshTokenValidityInMilliseconds = refreshTokenValidityInSeconds * 1000;
+    }
+
+    public String createAccessToken(Long memberId, List<String> roles) {
+        Date now = new Date();
+        Date validityDate = new Date(now.getTime() + accessTokenValidityInMilliseconds);
+
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .claim(AUTHORITIES_KEY, roles)
+                .issuedAt(now)
+                .expiration(validityDate)
+                .signWith(accessTokenSecret)
+                .compact();
+    }
+
+    public String createRefreshToken(Long memberId) {
+        Date now = new Date();
+        Date validityDate = new Date(now.getTime() + refreshTokenValidityInMilliseconds);
+
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .issuedAt(now)
+                .expiration(validityDate)
+                .signWith(refreshTokenSecret)
+                .compact();
+    }
+
+    public boolean validateAccessToken(String token) {
+        return validateToken(token, accessTokenSecret);
+    }
+
+    public Long parseAccessToken(String token) {
+        return Long.parseLong(parseClaims(token, accessTokenSecret).getSubject());
+    }
+
+    public List<String> getRolesFromAccessToken(String token) {
+        Claims claims = parseClaims(token, accessTokenSecret);
+        Object roles = claims.get(AUTHORITIES_KEY);
+        if (roles instanceof List<?> roleList) {
+            return roleList.stream()
+                    .map(String::valueOf)
+                    .toList();
+        }
+        return Collections.emptyList();
+    }
+
+    private boolean validateToken(String token, SecretKey secretKey) {
+        try {
+            parseClaims(token, secretKey);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명입니다.");
+            throw new AuthenticationDomainException(AuthenticationErrorCode.WRONG_JWT_SIGNATURE);
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.");
+            throw new AuthenticationDomainException(AuthenticationErrorCode.EXPIRED_JWT_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰입니다.");
+            throw new AuthenticationDomainException(AuthenticationErrorCode.UNSUPPORTED_JWT);
+        } catch (IllegalArgumentException e) {
+            log.info("유효하지 않은 JWT 토큰입니다.");
+            throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_JWT);
+        }
+    }
+
+    private Claims parseClaims(String token, SecretKey secretKey) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/global/security/MemberPrincipal.java
+++ b/hanharam/src/main/java/com/leets/blog/global/security/MemberPrincipal.java
@@ -1,0 +1,15 @@
+package com.leets.blog.global.security;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberPrincipal {
+
+    private final Long memberId;
+
+    @Builder
+    public MemberPrincipal(Long memberId) {
+        this.memberId = memberId;
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/global/security/annotation/CurrentMember.java
+++ b/hanharam/src/main/java/com/leets/blog/global/security/annotation/CurrentMember.java
@@ -1,0 +1,11 @@
+package com.leets.blog.global.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentMember {
+}

--- a/hanharam/src/main/java/com/leets/blog/global/security/resolver/CurrentMemberArgumentResolver.java
+++ b/hanharam/src/main/java/com/leets/blog/global/security/resolver/CurrentMemberArgumentResolver.java
@@ -1,0 +1,43 @@
+package com.leets.blog.global.security.resolver;
+
+import com.leets.blog.global.security.MemberPrincipal;
+import com.leets.blog.global.security.annotation.CurrentMember;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentMember.class)
+                && MemberPrincipal.class.isAssignableFrom(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return null;
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof MemberPrincipal memberPrincipal) {
+            return memberPrincipal;
+        }
+
+        return null;
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/member/adapter/out/persistence/MemberPersistenceAdapter.java
+++ b/hanharam/src/main/java/com/leets/blog/member/adapter/out/persistence/MemberPersistenceAdapter.java
@@ -1,17 +1,21 @@
 package com.leets.blog.member.adapter.out.persistence;
 
+import com.leets.blog.member.adapter.out.persistence.entity.MemberJpaEntity;
+import com.leets.blog.member.application.port.out.LoadMemberAuthPort;
+import com.leets.blog.member.application.port.out.SaveMemberAuthPort;
 import com.leets.blog.member.application.port.out.out.LoadMemberPort;
-import com.leets.blog.member.domain.MemberJpaEntity;
+import com.leets.blog.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
-public class MemberPersistenceAdapter implements LoadMemberPort {
+public class MemberPersistenceAdapter implements LoadMemberPort, LoadMemberAuthPort, SaveMemberAuthPort {
 
     private final MemberRepository memberRepository;
 
@@ -36,5 +40,22 @@ public class MemberPersistenceAdapter implements LoadMemberPort {
     @Override
     public boolean existsById(Long memberId) {
         return memberRepository.existsById(memberId);
+    }
+
+    @Override
+    public Optional<Member> findByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .map(MemberJpaEntity::toDomain);
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return memberRepository.existsByEmail(email);
+    }
+
+    @Override
+    public Member save(Member member) {
+        MemberJpaEntity saved = memberRepository.save(MemberJpaEntity.from(member));
+        return saved.toDomain();
     }
 }

--- a/hanharam/src/main/java/com/leets/blog/member/adapter/out/persistence/MemberRepository.java
+++ b/hanharam/src/main/java/com/leets/blog/member/adapter/out/persistence/MemberRepository.java
@@ -1,12 +1,17 @@
 package com.leets.blog.member.adapter.out.persistence;
 
-import com.leets.blog.member.domain.MemberJpaEntity;
+import com.leets.blog.member.adapter.out.persistence.entity.MemberJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public interface MemberRepository extends JpaRepository<MemberJpaEntity, Long> {
     // SELECT * FROM members WHERE id IN (...)
     List<MemberJpaEntity> findAllByIdIn(Set<Long> ids);
+
+    Optional<MemberJpaEntity> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/hanharam/src/main/java/com/leets/blog/member/adapter/out/persistence/entity/MemberJpaEntity.java
+++ b/hanharam/src/main/java/com/leets/blog/member/adapter/out/persistence/entity/MemberJpaEntity.java
@@ -1,7 +1,8 @@
-package com.leets.blog.member.domain;
+package com.leets.blog.member.adapter.out.persistence.entity;
 
 import com.leets.blog.common.BaseEntity;
 import com.leets.blog.common.enums.Role;
+import com.leets.blog.member.domain.Member;
 import com.leets.blog.member.domain.enums.Gender;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -40,10 +41,37 @@ public class MemberJpaEntity extends BaseEntity {
     private Role role = Role.USER;
 
     @Builder
-    private MemberJpaEntity(String name, String nickname, String email, String password) {
+    private MemberJpaEntity(String name, String nickname, String email, String password, Role role, Gender gender) {
         this.name = name;
         this.nickname = nickname;
         this.email = email;
         this.password = password;
+        this.role = role;
+        this.gender = gender;
+    }
+
+    public static MemberJpaEntity from(Member member) {
+        return MemberJpaEntity.builder()
+                .name(member.getName())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .password(member.getPassword())
+                .role(member.getRole())
+                .gender(member.getGender())
+                .build();
+    }
+
+    public Member toDomain() {
+        return Member.reconstruct(
+                this.id,
+                this.name,
+                this.nickname,
+                this.email,
+                this.password,
+                this.role,
+                this.gender,
+                this.getCreatedAt(),
+                this.getUpdatedAt()
+        );
     }
 }

--- a/hanharam/src/main/java/com/leets/blog/member/application/port/out/LoadMemberAuthPort.java
+++ b/hanharam/src/main/java/com/leets/blog/member/application/port/out/LoadMemberAuthPort.java
@@ -1,0 +1,10 @@
+package com.leets.blog.member.application.port.out;
+
+import com.leets.blog.member.domain.Member;
+import java.util.Optional;
+
+public interface LoadMemberAuthPort {
+    Optional<Member> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/hanharam/src/main/java/com/leets/blog/member/application/port/out/SaveMemberAuthPort.java
+++ b/hanharam/src/main/java/com/leets/blog/member/application/port/out/SaveMemberAuthPort.java
@@ -1,0 +1,7 @@
+package com.leets.blog.member.application.port.out;
+
+import com.leets.blog.member.domain.Member;
+
+public interface SaveMemberAuthPort {
+    Member save(Member member);
+}

--- a/hanharam/src/main/java/com/leets/blog/member/domain/Member.java
+++ b/hanharam/src/main/java/com/leets/blog/member/domain/Member.java
@@ -1,0 +1,60 @@
+package com.leets.blog.member.domain;
+
+import com.leets.blog.common.enums.Role;
+import com.leets.blog.member.domain.enums.Gender;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Member {
+
+    private final Long id;
+    private final String name;
+    private final String nickname;
+    private final String email;
+    private final String password;
+    private final Role role;
+    private final Gender gender;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static Member create(String name, String nickname, String email, String password) {
+        return Member.builder()
+                .name(name)
+                .nickname(nickname)
+                .email(email)
+                .password(password)
+                .role(Role.USER)
+                .gender(Gender.NONE)
+                .build();
+    }
+
+    public static Member reconstruct(
+            Long id,
+            String name,
+            String nickname,
+            String email,
+            String password,
+            Role role,
+            Gender gender,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        return Member.builder()
+                .id(id)
+                .name(name)
+                .nickname(nickname)
+                .email(email)
+                .password(password)
+                .role(role)
+                .gender(gender)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/post/adapter/in/web/PostController.java
+++ b/hanharam/src/main/java/com/leets/blog/post/adapter/in/web/PostController.java
@@ -1,5 +1,7 @@
 package com.leets.blog.post.adapter.in.web;
 
+import com.leets.blog.global.security.MemberPrincipal;
+import com.leets.blog.global.security.annotation.CurrentMember;
 import com.leets.blog.post.adapter.in.web.dto.request.CreatePostRequest;
 import com.leets.blog.post.adapter.in.web.dto.request.UpdatePostRequest;
 import com.leets.blog.post.application.port.in.commad.CreatePostUseCase;
@@ -27,9 +29,9 @@ public class PostController {
     @Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
     public PostId createPost(
             @Valid @RequestBody CreatePostRequest request,
-            Long memberId
+            @CurrentMember MemberPrincipal memberPrincipal
     ) {
-        return createPostUseCase.createPost(request.toCommand(memberId));
+        return createPostUseCase.createPost(request.toCommand(memberPrincipal.getMemberId()));
     }
 
     @PatchMapping("/{postId}")
@@ -37,19 +39,19 @@ public class PostController {
     public PostId updatePost(
             @PathVariable Long postId,
             @Valid @RequestBody UpdatePostRequest request,
-            Long memberId
+            @CurrentMember MemberPrincipal memberPrincipal
     ) {
 
-        return updatePostUseCase.updatePost(request.toCommand(postId, memberId));
+        return updatePostUseCase.updatePost(request.toCommand(postId, memberPrincipal.getMemberId()));
     }
 
     @DeleteMapping("/{postId}")
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
     public void deletePost(
             @PathVariable Long postId,
-            Long requesterId
+            @CurrentMember MemberPrincipal memberPrincipal
     ) {
-        DeletePostCommand command = new DeletePostCommand(postId,requesterId);
+        DeletePostCommand command = new DeletePostCommand(postId, memberPrincipal.getMemberId());
         deletePostUseCase.deletePost(command);
     }
 }

--- a/hanharam/src/main/java/com/leets/blog/post/adapter/in/web/PostController.java
+++ b/hanharam/src/main/java/com/leets/blog/post/adapter/in/web/PostController.java
@@ -10,6 +10,8 @@ import com.leets.blog.post.application.port.in.commad.UpdatePostUseCase;
 import com.leets.blog.post.application.port.in.commad.dto.DeletePostCommand;
 import com.leets.blog.post.domain.Post.PostId;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/posts")
 @RequiredArgsConstructor
 @Tag(name = "Post | 게시글 command", description = "게시글 관련 API")
+@SecurityRequirement(name = "bearerAuth")
 public class PostController {
 
     private final CreatePostUseCase createPostUseCase;
@@ -29,6 +32,7 @@ public class PostController {
     @Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
     public PostId createPost(
             @Valid @RequestBody CreatePostRequest request,
+            @Parameter(hidden = true)
             @CurrentMember MemberPrincipal memberPrincipal
     ) {
         return createPostUseCase.createPost(request.toCommand(memberPrincipal.getMemberId()));
@@ -39,6 +43,7 @@ public class PostController {
     public PostId updatePost(
             @PathVariable Long postId,
             @Valid @RequestBody UpdatePostRequest request,
+            @Parameter(hidden = true)
             @CurrentMember MemberPrincipal memberPrincipal
     ) {
 
@@ -49,6 +54,7 @@ public class PostController {
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
     public void deletePost(
             @PathVariable Long postId,
+            @Parameter(hidden = true)
             @CurrentMember MemberPrincipal memberPrincipal
     ) {
         DeletePostCommand command = new DeletePostCommand(postId, memberPrincipal.getMemberId());

--- a/hanharam/src/main/java/com/leets/blog/report/adapter/in/web/ReportController.java
+++ b/hanharam/src/main/java/com/leets/blog/report/adapter/in/web/ReportController.java
@@ -8,6 +8,8 @@ import com.leets.blog.report.application.port.in.command.ReportPostUseCase;
 import com.leets.blog.report.application.port.in.command.ReviewReportUseCase;
 import com.leets.blog.report.application.port.in.command.dto.ReviewReportCommand;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/reports")
 @RequiredArgsConstructor
 @Tag(name = "Report | 신고 command", description = "신고 관련 API")
+@SecurityRequirement(name = "bearerAuth")
 public class ReportController {
 
     private final ReportCommentUseCase reportCommentUseCase;
@@ -28,6 +31,7 @@ public class ReportController {
     public void reportPost(
             @PathVariable Long postId,
             @Valid @RequestBody CreateReportRequest request,
+            @Parameter(hidden = true)
             @CurrentMember MemberPrincipal memberPrincipal
     ) {
         reportPostUseCase.report(request.toPostCommand(postId, memberPrincipal.getMemberId()));
@@ -38,6 +42,7 @@ public class ReportController {
     public void reportComment(
             @PathVariable Long commentId,
             @Valid @RequestBody CreateReportRequest request,
+            @Parameter(hidden = true)
             @CurrentMember MemberPrincipal memberPrincipal
     ) {
         reportCommentUseCase.report(request.toCommentCommand(commentId, memberPrincipal.getMemberId()));

--- a/hanharam/src/main/java/com/leets/blog/report/adapter/in/web/ReportController.java
+++ b/hanharam/src/main/java/com/leets/blog/report/adapter/in/web/ReportController.java
@@ -1,5 +1,7 @@
 package com.leets.blog.report.adapter.in.web;
 
+import com.leets.blog.global.security.MemberPrincipal;
+import com.leets.blog.global.security.annotation.CurrentMember;
 import com.leets.blog.report.adapter.in.web.dto.request.CreateReportRequest;
 import com.leets.blog.report.application.port.in.command.ReportCommentUseCase;
 import com.leets.blog.report.application.port.in.command.ReportPostUseCase;
@@ -26,9 +28,9 @@ public class ReportController {
     public void reportPost(
             @PathVariable Long postId,
             @Valid @RequestBody CreateReportRequest request,
-            Long reporterId
+            @CurrentMember MemberPrincipal memberPrincipal
     ) {
-        reportPostUseCase.report(request.toPostCommand(postId, reporterId));
+        reportPostUseCase.report(request.toPostCommand(postId, memberPrincipal.getMemberId()));
     }
 
     @PostMapping("/comments/{commentId}")
@@ -36,9 +38,9 @@ public class ReportController {
     public void reportComment(
             @PathVariable Long commentId,
             @Valid @RequestBody CreateReportRequest request,
-            Long reporterId
+            @CurrentMember MemberPrincipal memberPrincipal
     ) {
-        reportCommentUseCase.report(request.toCommentCommand(commentId, reporterId));
+        reportCommentUseCase.report(request.toCommentCommand(commentId, memberPrincipal.getMemberId()));
     }
 
     @PatchMapping("/{reportId}/reviewing")

--- a/hanharam/src/main/resources/application.yml
+++ b/hanharam/src/main/resources/application.yml
@@ -3,3 +3,9 @@ spring:
     name: blog
   profiles:
     active: local
+
+jwt:
+  access-token-secret: "local-access-token-secret-key-for-blog-project-2026"
+  refresh-token-secret: "local-refresh-token-secret-key-for-blog-project-2026"
+  access-token-validity-in-seconds: 3600
+  refresh-token-validity-in-seconds: 1209600


### PR DESCRIPTION
<!--
제목: [주차] {이름}/[타입] {작업 내용}
예시: [1주차] 조혜원/[feat] 초기 프로젝트 설정
-->

## 1. 과제 요구사항 중 구현한 내용

- 이메일/비밀번호 기반 회원가입 API 추가
- 이메일/비밀번호 기반 로그인 API 추가
- 로그인/회원가입 성공 시 Access Token과 Refresh Token을 함께 발급
- 기존 게시글/신고 command API가 요청 파라미터의 memberId를 직접 받지 않고 JWT 기반 현재 사용자 정보를 사용하도록 변경

## 2. 핵심 변경 사항

### 1. Authentication
- `POST /api/v1/auth/signup`
- `POST /api/v1/auth/login`

### 2. JWT 발급 
- Access Token / Refresh Token 발급
- Access Token에는 회원 ID와 역할 정보를 담습니다.
- 기본 만료 시간
  - Access Token: 1시간
  - Refresh Token: 14일

### 3. 비밀번호 정책
- 비밀번호는 8자 이상 64자 이하
- 영문과 숫자를 최소 1개 이상 포함해야 함
- 저장 시 `BCryptPasswordEncoder`로 해시 처리

### 4. 이메일 정책
- 로그인 아이디는 `email`을 사용합
- 회원가입/로그인 시 이메일은 trim 후 소문자로 정규화
- 애플리케이션 레벨에서 중복 이메일 가입을 차단

### 5. 인증 방식 변경
- 기존 게시글/신고 command 컨트롤러에서 `Long memberId`, `Long reporterId` 같은 raw 파라미터 입력 대신
  `Authorization: Bearer <accessToken>` 기반 인증을 사용
- 현재 사용자 ID는 `@CurrentMember MemberPrincipal`로 주입받음

### 공개 엔드포인트
- `/api/v1/auth/**`
- `GET /api/v1/posts/**`
- `/test/**`
- Swagger 관련 경로

### 인증 필요 엔드포인트
- 게시글 생성/수정/삭제
- 신고 생성/검토중 처리

회원가입 흐름:

POST /api/v1/auth/signup 호출
SignUpRequest.java에서 기본 validation 수행
AuthenticationService.java에서 이메일 소문자 정규화, 중복 이메일 체크, 비밀번호 정책 체크
비밀번호를 PasswordEncoder로 암호화
MemberPersistenceAdapter.java로 회원 저장
저장된 회원 ID 기준으로 JwtTokenProvider.java에서 access/refresh token 발급
응답으로 회원 정보 + 토큰 반환

로그인 흐름:

POST /api/v1/auth/login 호출
LoginRequest.java에서 형식 검증
AuthenticationService.java에서 이메일 정규화
findByEmail로 회원 조회
저장된 해시 비밀번호와 입력 비밀번호를 passwordEncoder.matches()로 비교
맞으면 JWT 발급
AuthResponse.java로 반환

## 3. 실행 및 검증 결과

### 회원가입
<img width="1208" height="1297" alt="image" src="https://github.com/user-attachments/assets/24ad7f18-7c11-4261-b76c-d215f8b83f9b" />

### 로그인
<img width="1225" height="1280" alt="image" src="https://github.com/user-attachments/assets/374c4c10-8474-4ac1-9927-69d1774e5934" />

### 발급받은 토큰으로 API 실행 검증
<img width="1414" height="467" alt="image" src="https://github.com/user-attachments/assets/4e1ac4c8-f366-422c-a13a-4d3eef12fc85" />


## 4. 완료 사항

<!-- 완료한 작업을 번호 목록으로 작성해주세요. -->

- 이메일/비밀번호 기반 회원가입 API 추가
- 이메일/비밀번호 기반 로그인 API 추가


## 5. 추가 사항

- 관련 이슈: closed #244 


## 제출 체크리스트

- [ ] PR 제목이 규칙에 맞다
- [ ] base가 `{이름}/main` 브랜치다
- [ ] compare가 `{이름}/{숫자}주차` 브랜치다
- [ ] 프로젝트가 정상 실행된다
- [ ] 본인을 Assignee로 지정했다
- [ ] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고

<!--
BE: rootTiket, soyesenna
FE: One-HyeWon, woneeee
-->
