### PR TITLE
[7주차] 시재욱/[feat] 카카오 OAuth 로그인

### DIFF
--- a/src/main/java/com/example/demo/auth/controller/AuthController.java
+++ b/src/main/java/com/example/demo/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.example.demo.auth.controller;
 
+import com.example.demo.auth.dto.KakaoLoginRequest;
 import com.example.demo.auth.dto.LoginRequest;
 import com.example.demo.auth.dto.ReissueRequest;
 import com.example.demo.auth.dto.SignupRequest;
@@ -10,6 +11,7 @@ import com.example.demo.global.exception.BaseCode;
 import com.example.demo.global.exception.ErrorResponse;
 import com.example.demo.global.exception.ResponseUtil;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -87,6 +89,69 @@ public class AuthController {
         return ResponseUtil.success(
                 BaseCode.SUCCESS,
                 authService.login(request)
+        );
+    }
+
+    @Operation(
+            summary = "카카오 로그인 API",
+            description = "카카오 인가 코드를 이용해 로그인하고 accessToken, refreshToken을 발급받습니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "카카오 로그인 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 카카오 로그인 요청 또는 인가 코드 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "카카오 인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping("/kakao/login")
+    public ApiResponse<TokenResponse> kakaoLogin(
+            @RequestBody @Valid KakaoLoginRequest request) {
+
+        return ResponseUtil.success(
+                BaseCode.SUCCESS,
+                authService.kakaoLogin(request)
+        );
+    }
+
+    @Operation(
+            summary = "카카오 로그인 Callback API",
+            description = "카카오에서 전달한 인가 코드를 받아 accessToken, refreshToken을 발급합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "카카오 로그인 Callback 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "인가 코드 누락 또는 잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "카카오 인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @GetMapping("/kakao/callback")
+    public ApiResponse<TokenResponse> kakaoCallback(
+            @Parameter(description = "카카오 인가 코드", example = "A1b2C3d4E5")
+            @RequestParam String code) {
+
+        KakaoLoginRequest request = new KakaoLoginRequest(code);
+
+        return ResponseUtil.success(
+                BaseCode.SUCCESS,
+                authService.kakaoLogin(request)
         );
     }
 

--- a/src/main/java/com/example/demo/auth/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/example/demo/auth/dto/KakaoLoginRequest.java
@@ -1,0 +1,21 @@
+package com.example.demo.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "카카오 로그인 요청 DTO")
+public class KakaoLoginRequest {
+
+    @Schema(
+            description = "카카오 인가 코드",
+            example = "A1b2C3d4E5f6G7h8"
+    )
+    @NotBlank(message = "인가 코드는 필수입니다.")
+    private String code;
+}

--- a/src/main/java/com/example/demo/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/demo/auth/jwt/JwtAuthenticationFilter.java
@@ -30,36 +30,39 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
 
-        String token = resolveToken(request);
+        String authorizationHeader = request.getHeader("Authorization");
 
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            Long userId = jwtTokenProvider.getUserId(token);
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessToken = authorizationHeader.substring(7);
+
+        try {
+            if (!jwtTokenProvider.validateToken(accessToken)) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            Long userId = jwtTokenProvider.getUserId(accessToken);
 
             User user = userRepository.findById(userId)
-                    .orElse(null);
+                    .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
 
-            if (user != null) {
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(
-                                user.getId(),
-                                null,
-                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
-                        );
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            user,
+                            null,
+                            List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                    );
 
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            }
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        } catch (Exception e) {
+            SecurityContextHolder.clearContext();
         }
 
         filterChain.doFilter(request, response);
-    }
-
-    private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-
-        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
-        }
-
-        return null;
     }
 }

--- a/src/main/java/com/example/demo/auth/service/AuthService.java
+++ b/src/main/java/com/example/demo/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.example.demo.auth.service;
 
+import com.example.demo.auth.dto.KakaoLoginRequest;
 import com.example.demo.auth.dto.LoginRequest;
 import com.example.demo.auth.dto.ReissueRequest;
 import com.example.demo.auth.dto.SignupRequest;
@@ -20,6 +21,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final KakaoAuthService kakaoAuthService;
 
     public Long signup(SignupRequest request) {
         if (userRepository.existsByEmail(request.getEmail())) {
@@ -57,6 +59,10 @@ public class AuthService {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
+    }
+
+    public TokenResponse kakaoLogin(KakaoLoginRequest request) {
+        return kakaoAuthService.kakaoLogin(request);
     }
 
     public TokenResponse reissue(ReissueRequest request) {

--- a/src/main/java/com/example/demo/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/example/demo/auth/service/KakaoAuthService.java
@@ -1,0 +1,138 @@
+package com.example.demo.auth.service;
+
+import com.example.demo.auth.dto.KakaoLoginRequest;
+import com.example.demo.auth.dto.TokenResponse;
+import com.example.demo.auth.jwt.JwtTokenProvider;
+import com.example.demo.user.entity.User;
+import com.example.demo.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class KakaoAuthService {
+
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    private final RestClient restClient = RestClient.create();
+
+    @Value("${kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    @Value("${kakao.token-uri}")
+    private String kakaoTokenUri;
+
+    @Value("${kakao.user-info-uri}")
+    private String kakaoUserInfoUri;
+
+    public TokenResponse kakaoLogin(KakaoLoginRequest request) {
+        String kakaoAccessToken = getKakaoAccessToken(request.getCode());
+
+        KakaoUserInfo kakaoUserInfo = getKakaoUserInfo(kakaoAccessToken);
+
+        User user = userRepository.findByKakaoId(kakaoUserInfo.kakaoId())
+                .orElseGet(() -> createKakaoUser(kakaoUserInfo));
+
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId(), user.getEmail());
+
+        user.updateRefreshToken(refreshToken);
+
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    private String getKakaoAccessToken(String code) {
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoClientId);
+        params.add("redirect_uri", kakaoRedirectUri);
+        params.add("code", code);
+
+        Map response = restClient.post()
+                .uri(kakaoTokenUri)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(params)
+                .retrieve()
+                .body(Map.class);
+
+        if (response == null || response.get("access_token") == null) {
+            throw new IllegalArgumentException("카카오 access token 발급에 실패했습니다.");
+        }
+
+        return response.get("access_token").toString();
+    }
+
+    private KakaoUserInfo getKakaoUserInfo(String kakaoAccessToken) {
+
+        Map response = restClient.get()
+                .uri(kakaoUserInfoUri)
+                .header("Authorization", "Bearer " + kakaoAccessToken)
+                .retrieve()
+                .body(Map.class);
+
+        if (response == null || response.get("id") == null) {
+            throw new IllegalArgumentException("카카오 사용자 정보 조회에 실패했습니다.");
+        }
+
+        Long kakaoId = Long.valueOf(response.get("id").toString());
+
+        Map kakaoAccount = (Map) response.get("kakao_account");
+        Map profile = kakaoAccount != null ? (Map) kakaoAccount.get("profile") : null;
+
+        String email = kakaoAccount != null && kakaoAccount.get("email") != null
+                ? kakaoAccount.get("email").toString()
+                : "kakao_" + kakaoId + "@kakao.local";
+
+        String nickname = profile != null && profile.get("nickname") != null
+                ? profile.get("nickname").toString()
+                : "kakao_user_" + kakaoId;
+
+        return new KakaoUserInfo(kakaoId, email, nickname);
+    }
+
+    private User createKakaoUser(KakaoUserInfo kakaoUserInfo) {
+
+        String nickname = kakaoUserInfo.nickname();
+
+        if (userRepository.existsByNickname(nickname)) {
+            nickname = nickname + "_" + kakaoUserInfo.kakaoId();
+        }
+
+        User user = User.builder()
+                .name(nickname)
+                .email(kakaoUserInfo.email())
+                .nickname(nickname)
+                .password(passwordEncoder.encode("KAKAO_USER"))
+                .kakaoId(kakaoUserInfo.kakaoId())
+                .build();
+
+        return userRepository.save(user);
+    }
+
+    private record KakaoUserInfo(
+            Long kakaoId,
+            String email,
+            String nickname
+    ) {
+    }
+}

--- a/src/main/java/com/example/demo/comment/controller/CommentController.java
+++ b/src/main/java/com/example/demo/comment/controller/CommentController.java
@@ -8,6 +8,7 @@ import com.example.demo.global.exception.ApiResponse;
 import com.example.demo.global.exception.BaseCode;
 import com.example.demo.global.exception.ResponseUtil;
 import com.example.demo.global.exception.ErrorResponse;
+import com.example.demo.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,7 +31,6 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    // 댓글 생성
     @Operation(
             summary = "댓글 생성 API",
             description = "로그인한 사용자가 게시글에 댓글을 생성합니다."
@@ -58,10 +58,10 @@ public class CommentController {
     })
     @PostMapping
     public ApiResponse<Map<String, Long>> create(
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal User user,
             @RequestBody @Valid CommentCreateRequest request) {
 
-        Long commentId = commentService.createComment(userId, request);
+        Long commentId = commentService.createComment(user.getId(), request);
 
         return ResponseUtil.success(
                 BaseCode.COMMENT_CREATE_SUCCESS,
@@ -69,7 +69,6 @@ public class CommentController {
         );
     }
 
-    // 특정 게시글 댓글 조회
     @Operation(
             summary = "특정 게시글 댓글 조회 API",
             description = "postId에 해당하는 게시글의 댓글 목록을 조회합니다."
@@ -96,7 +95,6 @@ public class CommentController {
         );
     }
 
-    // 댓글 수정
     @Operation(
             summary = "댓글 수정 API",
             description = "commentId에 해당하는 댓글 내용을 수정합니다."
@@ -136,7 +134,6 @@ public class CommentController {
         );
     }
 
-    // 댓글 삭제
     @Operation(
             summary = "댓글 삭제 API",
             description = "commentId에 해당하는 댓글을 삭제합니다."

--- a/src/main/java/com/example/demo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.example.demo.global.config;
 
 import com.example.demo.auth.jwt.JwtAuthenticationFilter;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,82 +20,33 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-
-        http
-                .csrf(csrf -> csrf.disable())
-
-                .formLogin(form -> form.disable())
-
-                .httpBasic(basic -> basic.disable())
-
-                .sessionManagement(session ->
-                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                )
-
-                .exceptionHandling(exception -> exception
-                        .authenticationEntryPoint((request, response, authException) -> {
-                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                            response.setContentType("application/json;charset=UTF-8");
-
-                            response.getWriter().write("""
-                                    {
-                                      "code": "401",
-                                      "message": "인증이 필요합니다.",
-                                      "success": false
-                                    }
-                                    """);
-                        })
-                        .accessDeniedHandler((request, response, accessDeniedException) -> {
-                            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-                            response.setContentType("application/json;charset=UTF-8");
-
-                            response.getWriter().write("""
-                                    {
-                                      "code": "403",
-                                      "message": "접근 권한이 없습니다.",
-                                      "success": false
-                                    }
-                                    """);
-                        })
-                )
-
-                .authorizeHttpRequests(auth -> auth
-
-                        // 인증 없이 접근 허용
-                        .requestMatchers(
-                                "/auth/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/v3/api-docs/**"
-                        ).permitAll()
-
-                        // 게시글 API → 로그인 필요
-                        .requestMatchers("/posts/**").authenticated()
-
-                        // 댓글 API → 로그인 필요
-                        .requestMatchers("/comments/**").authenticated()
-
-                        // 신고 API → 로그인 필요
-                        .requestMatchers("/reports/**").authenticated()
-
-                        // 미디어 API → 로그인 필요
-                        .requestMatchers("/media/**").authenticated()
-
-                        // 그 외 요청
-                        .anyRequest().permitAll()
-                )
-
-                .addFilterBefore(
-                        jwtAuthenticationFilter,
-                        UsernamePasswordAuthenticationFilter.class
-                );
-
-        return http.build();
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
     @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        return http
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/auth/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(
+                        jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class
+                )
+                .build();
     }
 }

--- a/src/main/java/com/example/demo/post/controller/PostController.java
+++ b/src/main/java/com/example/demo/post/controller/PostController.java
@@ -8,6 +8,7 @@ import com.example.demo.post.dto.PostCreateRequest;
 import com.example.demo.post.dto.PostDetailResponse;
 import com.example.demo.post.dto.PostResponse;
 import com.example.demo.post.service.PostService;
+import com.example.demo.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -29,7 +30,6 @@ public class PostController {
 
     private final PostService postService;
 
-    // 게시글 생성
     @Operation(
             summary = "게시글 생성 API",
             description = "로그인한 사용자가 새로운 게시글을 생성합니다."
@@ -57,16 +57,15 @@ public class PostController {
     })
     @PostMapping
     public ApiResponse<PostResponse> create(
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal User user,
             @RequestBody @Valid PostCreateRequest request) {
 
         return ResponseUtil.success(
                 BaseCode.POST_CREATE_SUCCESS,
-                postService.createPost(userId, request)
+                postService.createPost(user.getId(), request)
         );
     }
 
-    // 게시글 수정
     @Operation(
             summary = "게시글 수정 API",
             description = "로그인한 사용자가 postId에 해당하는 게시글을 수정합니다."
@@ -94,7 +93,7 @@ public class PostController {
     })
     @PutMapping("/{postId}")
     public ApiResponse<PostResponse> update(
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal User user,
 
             @Parameter(description = "게시글 ID", example = "1")
             @PathVariable Long postId,
@@ -103,11 +102,10 @@ public class PostController {
 
         return ResponseUtil.success(
                 BaseCode.POST_UPDATE_SUCCESS,
-                postService.updatePost(userId, postId, request)
+                postService.updatePost(user.getId(), postId, request)
         );
     }
 
-    // 게시글 삭제
     @Operation(
             summary = "게시글 삭제 API",
             description = "로그인한 사용자가 postId에 해당하는 게시글을 삭제합니다."
@@ -130,18 +128,17 @@ public class PostController {
     })
     @DeleteMapping("/{postId}")
     public ApiResponse<Map<String, Long>> delete(
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal User user,
 
             @Parameter(description = "게시글 ID", example = "1")
             @PathVariable Long postId) {
 
         return ResponseUtil.success(
                 BaseCode.POST_DELETE_SUCCESS,
-                Map.of("postId", postService.deletePost(userId, postId))
+                Map.of("postId", postService.deletePost(user.getId(), postId))
         );
     }
 
-    // 게시글 조회
     @Operation(
             summary = "게시글 상세 조회 API",
             description = "postId에 해당하는 게시글 상세 정보를 조회합니다."

--- a/src/main/java/com/example/demo/report/controller/ReportController.java
+++ b/src/main/java/com/example/demo/report/controller/ReportController.java
@@ -7,6 +7,7 @@ import com.example.demo.global.exception.ResponseUtil;
 import com.example.demo.report.dto.ReportCreateRequest;
 import com.example.demo.report.dto.ReportResponse;
 import com.example.demo.report.service.ReportService;
+import com.example.demo.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -25,7 +26,6 @@ public class ReportController {
 
     private final ReportService reportService;
 
-    // 게시글 신고
     @Operation(
             summary = "게시글 신고 API",
             description = "로그인한 사용자가 postId에 해당하는 게시글을 신고합니다."
@@ -53,21 +53,24 @@ public class ReportController {
     })
     @PostMapping("/posts/{postId}/reports")
     public ResponseEntity<ApiResponse<ReportResponse>> reportPost(
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal User user,
 
             @Parameter(description = "신고할 게시글 ID", example = "1")
             @PathVariable Long postId,
 
             @RequestBody ReportCreateRequest request
     ) {
-        ReportResponse response = reportService.reportPost(userId, postId, request);
+        ReportResponse response = reportService.reportPost(
+                user.getId(),
+                postId,
+                request
+        );
 
         return ResponseEntity.ok(
                 ResponseUtil.success(BaseCode.REPORT_POST_SUCCESS, response)
         );
     }
 
-    // 댓글 신고
     @Operation(
             summary = "댓글 신고 API",
             description = "로그인한 사용자가 commentId에 해당하는 댓글을 신고합니다."
@@ -95,21 +98,24 @@ public class ReportController {
     })
     @PostMapping("/comments/{commentId}/reports")
     public ResponseEntity<ApiResponse<ReportResponse>> reportComment(
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal User user,
 
             @Parameter(description = "신고할 댓글 ID", example = "1")
             @PathVariable Long commentId,
 
             @RequestBody ReportCreateRequest request
     ) {
-        ReportResponse response = reportService.reportComment(userId, commentId, request);
+        ReportResponse response = reportService.reportComment(
+                user.getId(),
+                commentId,
+                request
+        );
 
         return ResponseEntity.ok(
                 ResponseUtil.success(BaseCode.REPORT_COMMENT_SUCCESS, response)
         );
     }
 
-    // 신고 처리 완료
     @Operation(
             summary = "신고 처리 완료 API",
             description = "reportId에 해당하는 신고 상태를 처리 완료로 변경합니다."
@@ -132,12 +138,15 @@ public class ReportController {
     })
     @PatchMapping("/reports/{reportId}/resolve")
     public ResponseEntity<ApiResponse<ReportResponse>> resolveReport(
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal User user,
 
             @Parameter(description = "처리할 신고 ID", example = "1")
             @PathVariable Long reportId
     ) {
-        ReportResponse response = reportService.resolveReport(userId, reportId);
+        ReportResponse response = reportService.resolveReport(
+                user.getId(),
+                reportId
+        );
 
         return ResponseEntity.ok(
                 ResponseUtil.success(BaseCode.REPORT_RESOLVE_SUCCESS, response)

--- a/src/main/java/com/example/demo/user/entity/User.java
+++ b/src/main/java/com/example/demo/user/entity/User.java
@@ -13,25 +13,41 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 사용자 이름
     private String name;
 
+    // 이메일 로그인용 이메일
     @Column(nullable = false, unique = true)
     private String email;
 
+    // 사용자 닉네임
     @Column(nullable = false, unique = true)
     private String nickname;
 
+    // 이메일 로그인용 비밀번호
     @Column(nullable = false)
     private String password;
 
+    // 카카오 로그인 사용자 식별 ID
+    @Column(unique = true)
+    private Long kakaoId;
+
+    // Refresh Token 저장
     private String refreshToken;
 
     @Builder
-    public User(String name, String email, String nickname, String password) {
+    public User(
+            String name,
+            String email,
+            String nickname,
+            String password,
+            Long kakaoId
+    ) {
         this.name = name;
         this.email = email;
         this.nickname = nickname;
         this.password = password;
+        this.kakaoId = kakaoId;
     }
 
     public void updateRefreshToken(String refreshToken) {

--- a/src/main/java/com/example/demo/user/repository/UserRepository.java
+++ b/src/main/java/com/example/demo/user/repository/UserRepository.java
@@ -11,7 +11,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByNickname(String nickname);
 
+    boolean existsByKakaoId(Long kakaoId);
+
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByKakaoId(Long kakaoId);
 
     Optional<User> findByRefreshToken(String refreshToken);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,11 @@ spring.jpa.properties.hibernate.highlight_sql=true
 
 # ?? ?? ? ??? ?? ?? ?? ?? ??? ??
 spring.jpa.properties.hibernate.use_sql_comments=tre
+
+jwt.secret=your-secret-key
+
+# Kakao Login
+kakao.client-id=4b137059bfb0c86378fa5b8d03228487
+kakao.redirect-uri=http://localhost:8080/auth/kakao/callback
+kakao.token-uri=https://kauth.kakao.com/oauth/token
+kakao.user-info-uri=https://kapi.kakao.com/v2/user/me


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

- [x] 카카오 로그인
- [x] 카카오 accessToken, refreshToken 발급

## 2. 핵심 변경 사항

6주차에서 구현했던 stateless 인증 방식을 그대로 유지하면서 카카오 인증을 추가했습니다.

카카오 로그인
-> 카카오 accessToken, refreshToken 발급
-> 서버가 사용자 조회
-> 서버 JWT 발급 (accessToken, refreshToken)
-> 클라이언트가 Authorization: Bearer JWT 전송
-> JwtAuthenticationFilter가 매 요청마다 인증


## 3. 실행 및 검증 결과

카카오 토큰 발급
<img width="1770" height="297" alt="카카오 로그인 후 accessToken, refreshToken 발급" src="https://github.com/user-attachments/assets/a4b049b4-c2a1-4309-8575-3990ea92b686" />

토큰 이용해서 api 접근
<img width="1222" height="801" alt="Access토큰으로 api 접근" src="https://github.com/user-attachments/assets/af652d15-84ce-4b36-abc1-5f09735a935f" />


## 4. 완료 사항

<!-- 완료한 작업을 번호 목록으로 작성해주세요. -->

1. 카카오 로그인, 토큰 발급
2. 사용자 조회 후 서버 JWT 발급
3. api 요청마다 필터로 인증


## 5. 추가 사항

#259 

## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다
