### PR TITLE
[7주차] 김동빈/[feat] 카카오 OAuth 로그인

### DIFF
--- a/7th-be-blog/src/main/java/com/leets/blog/common/config/DataInitializer.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/config/DataInitializer.java
@@ -26,6 +26,7 @@ public class DataInitializer {
 
             User user = User.builder()
                     .name("tester")
+                    .nickname("tester")
                     .email("tester@test.com")
                     .password(passwordEncoder.encode("1234"))
                     .build();

--- a/7th-be-blog/src/main/java/com/leets/blog/common/exception/BaseErrorCode.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/exception/BaseErrorCode.java
@@ -15,6 +15,7 @@ public enum BaseErrorCode {
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "USER4003", "이미 등록된 닉네임입니다."),
     INVALID_LOGIN(HttpStatus.UNAUTHORIZED, "AUTH4001", "이메일 또는 비밀번호가 올바르지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4002", "유효하지 않은 리프레시 토큰입니다."),
+    KAKAO_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH4003", "카카오 로그인에 실패했습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4001", "게시글을 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT4001", "댓글을 찾을 수 없습니다."),
     DUPLICATE_REPORT(HttpStatus.CONFLICT, "REPORT4001", "이미 신고를 완료했습니다."),

--- a/7th-be-blog/src/main/java/com/leets/blog/common/security/JwtTokenProvider.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/security/JwtTokenProvider.java
@@ -81,15 +81,18 @@ public class JwtTokenProvider {
         Date now = new Date();
         Date expiration = new Date(now.getTime() + expirationMillis);
 
-        return Jwts.builder()
+        var builder = Jwts.builder()
                 .subject(String.valueOf(user.getId()))
-                .claim("email", user.getEmail())
                 .claim("role", user.getRole().name())
                 .claim(TOKEN_TYPE_CLAIM, tokenType)
                 .issuedAt(now)
-                .expiration(expiration)
-                .signWith(secretKey, Jwts.SIG.HS256)
-                .compact();
+                .expiration(expiration);
+
+        if (user.getEmail() != null) {
+            builder.claim("email", user.getEmail());
+        }
+
+        return builder.signWith(secretKey, Jwts.SIG.HS256).compact();
     }
 
     private String getTokenType(String token) {

--- a/7th-be-blog/src/main/java/com/leets/blog/common/security/SecurityConfig.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/common/security/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
             "/auth",
             "/login",
             "/auth/refresh",
+            "/oauth/kakao/**",
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/v3/api-docs/**",

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/client/KakaoOAuthClient.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/client/KakaoOAuthClient.java
@@ -1,0 +1,95 @@
+package com.leets.blog.domain.auth.client;
+
+import com.leets.blog.common.exception.BaseErrorCode;
+import com.leets.blog.common.exception.GeneralException;
+import com.leets.blog.domain.auth.dto.KakaoTokenResponse;
+import com.leets.blog.domain.auth.dto.KakaoUserResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class KakaoOAuthClient {
+
+    private static final String AUTHORIZATION_URL = "https://kauth.kakao.com/oauth/authorize";
+    private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+    private static final String AUTHORIZATION_CODE_GRANT_TYPE = "authorization_code";
+    private static final String CODE_RESPONSE_TYPE = "code";
+
+    private final RestClient restClient = RestClient.create();
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.client-secret}")
+    private String clientSecret;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    public String getAuthorizationUrl() {
+        return UriComponentsBuilder.fromUriString(AUTHORIZATION_URL)
+                .queryParam("response_type", CODE_RESPONSE_TYPE)
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .build()
+                .encode()
+                .toUriString();
+    }
+
+    public KakaoTokenResponse requestToken(String code) {
+        try {
+            KakaoTokenResponse response = restClient.post()
+                    .uri(TOKEN_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(createTokenRequestBody(code))
+                    .retrieve()
+                    .body(KakaoTokenResponse.class);
+
+            if (response == null || !StringUtils.hasText(response.accessToken())) {
+                throw new GeneralException(BaseErrorCode.KAKAO_LOGIN_FAILED);
+            }
+            return response;
+        } catch (RestClientException exception) {
+            throw new GeneralException(BaseErrorCode.KAKAO_LOGIN_FAILED);
+        }
+    }
+
+    public KakaoUserResponse requestUserInfo(String accessToken) {
+        try {
+            KakaoUserResponse response = restClient.get()
+                    .uri(USER_INFO_URL)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .body(KakaoUserResponse.class);
+
+            if (response == null || response.id() == null) {
+                throw new GeneralException(BaseErrorCode.KAKAO_LOGIN_FAILED);
+            }
+            return response;
+        } catch (RestClientException exception) {
+            throw new GeneralException(BaseErrorCode.KAKAO_LOGIN_FAILED);
+        }
+    }
+
+    private LinkedMultiValueMap<String, String> createTokenRequestBody(String code) {
+        LinkedMultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", AUTHORIZATION_CODE_GRANT_TYPE);
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        if (StringUtils.hasText(clientSecret)) {
+            body.add("client_secret", clientSecret);
+        }
+
+        return body;
+    }
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/controller/AuthController.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/controller/AuthController.java
@@ -12,9 +12,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,5 +45,19 @@ public class AuthController {
     @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰으로 새 액세스 토큰을 발급받습니다.")
     public ApiResponse<TokenReissueResponse> reissueAccessToken(@RequestBody @Valid TokenReissueRequest request) {
         return ApiResponse.onSuccess(authService.reissueAccessToken(request));
+    }
+
+    @GetMapping("/oauth/kakao/login")
+    @Operation(summary = "카카오 로그인 페이지 이동", description = "카카오 인가 코드 발급 페이지로 리다이렉트합니다.")
+    public ResponseEntity<Void> redirectToKakaoLogin() {
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .location(URI.create(authService.getKakaoAuthorizationUrl()))
+                .build();
+    }
+
+    @GetMapping("/oauth/kakao/callback")
+    @Operation(summary = "카카오 로그인 콜백", description = "카카오 인가 코드로 로그인하고 서비스 토큰을 발급받습니다.")
+    public ApiResponse<LoginResponse> kakaoCallback(@RequestParam String code) {
+        return ApiResponse.onSuccess(authService.kakaoLogin(code));
     }
 }

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/KakaoTokenResponse.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,21 @@
+package com.leets.blog.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoTokenResponse(
+        @JsonProperty("token_type")
+        String tokenType,
+
+        @JsonProperty("access_token")
+        String accessToken,
+
+        @JsonProperty("expires_in")
+        Integer expiresIn,
+
+        @JsonProperty("refresh_token")
+        String refreshToken,
+
+        @JsonProperty("refresh_token_expires_in")
+        Integer refreshTokenExpiresIn
+) {
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/KakaoUserResponse.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/KakaoUserResponse.java
@@ -1,0 +1,32 @@
+package com.leets.blog.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserResponse(
+        Long id,
+
+        @JsonProperty("kakao_account")
+        KakaoAccount kakaoAccount
+) {
+
+    public String providerId() {
+        return String.valueOf(id);
+    }
+
+    public String nickname() {
+        if (kakaoAccount == null || kakaoAccount.profile() == null) {
+            return null;
+        }
+        return kakaoAccount.profile().nickname();
+    }
+
+    public record KakaoAccount(
+            Profile profile
+    ) {
+    }
+
+    public record Profile(
+            String nickname
+    ) {
+    }
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/SignupRequest.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/SignupRequest.java
@@ -1,6 +1,5 @@
 package com.leets.blog.domain.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -17,10 +16,14 @@ public record SignupRequest(
         @Size(max = 100, message = "비밀번호는 100자 이내여야 합니다.")
         String password,
 
-        @JsonAlias("nickname")
-        @Schema(description = "닉네임", example = "tester")
+        @Schema(description = "이름", example = "김동빈")
+        @NotBlank(message = "이름은 필수입니다.")
+        @Size(max = 30, message = "이름은 30자 이내여야 합니다.")
+        String name,
+
+        @Schema(description = "닉네임", example = "dongbin807")
         @NotBlank(message = "닉네임은 필수입니다.")
         @Size(max = 30, message = "닉네임은 30자 이내여야 합니다.")
-        String name
+        String nickname
 ) {
 }

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/SignupResponse.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/dto/SignupResponse.java
@@ -10,11 +10,14 @@ public record SignupResponse(
         @Schema(description = "이메일", example = "user@example.com")
         String email,
 
-        @Schema(description = "닉네임", example = "tester")
-        String name
+        @Schema(description = "이름", example = "김동빈")
+        String name,
+
+        @Schema(description = "닉네임", example = "dongbin807")
+        String nickname
 ) {
 
     public static SignupResponse from(User user) {
-        return new SignupResponse(user.getId(), user.getEmail(), user.getName());
+        return new SignupResponse(user.getId(), user.getEmail(), user.getName(), user.getNickname());
     }
 }

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/service/AuthService.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/service/AuthService.java
@@ -3,6 +3,9 @@ package com.leets.blog.domain.auth.service;
 import com.leets.blog.common.exception.BaseErrorCode;
 import com.leets.blog.common.exception.GeneralException;
 import com.leets.blog.common.security.JwtTokenProvider;
+import com.leets.blog.domain.auth.client.KakaoOAuthClient;
+import com.leets.blog.domain.auth.dto.KakaoTokenResponse;
+import com.leets.blog.domain.auth.dto.KakaoUserResponse;
 import com.leets.blog.domain.auth.dto.LoginRequest;
 import com.leets.blog.domain.auth.dto.LoginResponse;
 import com.leets.blog.domain.auth.dto.SignupRequest;
@@ -11,12 +14,14 @@ import com.leets.blog.domain.auth.dto.TokenReissueRequest;
 import com.leets.blog.domain.auth.dto.TokenReissueResponse;
 import com.leets.blog.domain.auth.entity.RefreshToken;
 import com.leets.blog.domain.auth.repository.RefreshTokenRepository;
+import com.leets.blog.domain.user.entity.AuthProvider;
 import com.leets.blog.domain.user.entity.User;
 import com.leets.blog.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -30,6 +35,7 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
+    private final KakaoOAuthClient kakaoOAuthClient;
 
     @Transactional
     public SignupResponse signup(SignupRequest request) {
@@ -39,6 +45,7 @@ public class AuthService {
                 .email(request.email())
                 .password(passwordEncoder.encode(request.password()))
                 .name(request.name())
+                .provider(AuthProvider.LOCAL)
                 .build();
 
         return SignupResponse.from(userRepository.save(user));
@@ -46,7 +53,7 @@ public class AuthService {
 
     @Transactional
     public LoginResponse login(LoginRequest request) {
-        User user = userRepository.findByEmail(request.email())
+        User user = userRepository.findByEmailAndProvider(request.email(), AuthProvider.LOCAL)
                 .filter(foundUser -> !foundUser.isDeleted())
                 .orElseThrow(() -> new GeneralException(BaseErrorCode.INVALID_LOGIN));
 
@@ -54,6 +61,48 @@ public class AuthService {
             throw new GeneralException(BaseErrorCode.INVALID_LOGIN);
         }
 
+        return issueToken(user);
+    }
+
+    public String getKakaoAuthorizationUrl() {
+        return kakaoOAuthClient.getAuthorizationUrl();
+    }
+
+    @Transactional
+    public LoginResponse kakaoLogin(String code) {
+        KakaoTokenResponse tokenResponse = kakaoOAuthClient.requestToken(code);
+        KakaoUserResponse kakaoUser = kakaoOAuthClient.requestUserInfo(tokenResponse.accessToken());
+
+        User user = userRepository.findByProviderAndProviderId(AuthProvider.KAKAO, kakaoUser.providerId())
+                .map(this::validateKakaoUser)
+                .orElseGet(() -> userRepository.save(createKakaoUser(kakaoUser)));
+
+        return issueToken(user);
+    }
+
+    private User validateKakaoUser(User user) {
+        if (user.isDeleted()) {
+            throw new GeneralException(BaseErrorCode.INVALID_LOGIN);
+        }
+        return user;
+    }
+
+    private User createKakaoUser(KakaoUserResponse kakaoUser) {
+        return User.builder()
+                .name(resolveKakaoNickname(kakaoUser))
+                .provider(AuthProvider.KAKAO)
+                .providerId(kakaoUser.providerId())
+                .build();
+    }
+
+    private String resolveKakaoNickname(KakaoUserResponse kakaoUser) {
+        if (StringUtils.hasText(kakaoUser.nickname())) {
+            return kakaoUser.nickname();
+        }
+        return "kakao_" + kakaoUser.providerId();
+    }
+
+    private LoginResponse issueToken(User user) {
         String accessToken = jwtTokenProvider.createAccessToken(user);
         String refreshToken = jwtTokenProvider.createRefreshToken(user);
         saveRefreshToken(user, refreshToken);

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/auth/service/AuthService.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/auth/service/AuthService.java
@@ -45,6 +45,7 @@ public class AuthService {
                 .email(request.email())
                 .password(passwordEncoder.encode(request.password()))
                 .name(request.name())
+                .nickname(request.nickname())
                 .provider(AuthProvider.LOCAL)
                 .build();
 
@@ -90,6 +91,7 @@ public class AuthService {
     private User createKakaoUser(KakaoUserResponse kakaoUser) {
         return User.builder()
                 .name(resolveKakaoNickname(kakaoUser))
+                .nickname(createKakaoServiceNickname(kakaoUser.providerId()))
                 .provider(AuthProvider.KAKAO)
                 .providerId(kakaoUser.providerId())
                 .build();
@@ -100,6 +102,19 @@ public class AuthService {
             return kakaoUser.nickname();
         }
         return "kakao_" + kakaoUser.providerId();
+    }
+
+    private String createKakaoServiceNickname(String providerId) {
+        String baseNickname = "kakao_" + providerId;
+        String nickname = baseNickname;
+        int suffix = 1;
+
+        while (userRepository.existsByNickname(nickname)) {
+            nickname = baseNickname + "_" + suffix;
+            suffix++;
+        }
+
+        return nickname;
     }
 
     private LoginResponse issueToken(User user) {
@@ -135,7 +150,7 @@ public class AuthService {
         if (userRepository.existsByEmail(request.email())) {
             throw new GeneralException(BaseErrorCode.DUPLICATE_EMAIL);
         }
-        if (userRepository.existsByName(request.name())) {
+        if (userRepository.existsByNickname(request.nickname())) {
             throw new GeneralException(BaseErrorCode.DUPLICATE_NICKNAME);
         }
     }

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/post/converter/PostConverter.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/post/converter/PostConverter.java
@@ -13,7 +13,7 @@ public class PostConverter {
                 .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
-                .authorName(post.getUser().getName())
+                .authorName(post.getUser().getNickname())
                 .createdAt(post.getCreatedAt())
                 .build();
     }

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/post/dto/PostResponse.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/post/dto/PostResponse.java
@@ -19,7 +19,7 @@ public class PostResponse {
     private String title;
     @Schema(description = "게시글 본문", example = "Swagger UI를 프로젝트에 적용한 과정을 정리합니다.")
     private String content;
-    @Schema(description = "작성자 이름", example = "dongbin")
+    @Schema(description = "작성자 닉네임", example = "dongbin")
     private String authorName;
     @Schema(description = "생성 시각", example = "2026-05-05T14:30:00")
     private LocalDateTime createdAt;

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/user/entity/AuthProvider.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/user/entity/AuthProvider.java
@@ -1,0 +1,6 @@
+package com.leets.blog.domain.user.entity;
+
+public enum AuthProvider {
+    LOCAL,
+    KAKAO
+}

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/user/entity/User.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/user/entity/User.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,7 +25,12 @@ import java.util.List;
 @Entity
 @Getter
 @Builder
-@Table(name = "users")
+@Table(
+        name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_users_provider_provider_id", columnNames = {"provider", "provider_id"})
+        }
+)
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
@@ -33,14 +39,22 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false, unique = true)
+    @Column(unique = true)
     private String email;
 
-    @Column(nullable = false)
+    @Column
     private String password;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AuthProvider provider = AuthProvider.LOCAL;
+
+    @Column(name = "provider_id")
+    private String providerId;
 
     @Builder.Default
     @Enumerated(EnumType.STRING)

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/user/entity/User.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/user/entity/User.java
@@ -42,6 +42,9 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
     @Column(unique = true)
     private String email;
 

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/user/repository/UserRepository.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/user/repository/UserRepository.java
@@ -10,7 +10,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
-    boolean existsByName(String name);
+    boolean existsByNickname(String nickname);
 
     Optional<User> findByEmail(String email);
 

--- a/7th-be-blog/src/main/java/com/leets/blog/domain/user/repository/UserRepository.java
+++ b/7th-be-blog/src/main/java/com/leets/blog/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.leets.blog.domain.user.repository;
 
+import com.leets.blog.domain.user.entity.AuthProvider;
 import com.leets.blog.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,4 +13,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByName(String name);
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByEmailAndProvider(String email, AuthProvider provider);
+
+    Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
 }

--- a/7th-be-blog/src/main/resources/application.properties
+++ b/7th-be-blog/src/main/resources/application.properties
@@ -15,3 +15,7 @@ spring.h2.console.path=/h2-console
 jwt.secret=leets-7th-be-blog-email-auth-secret-key-for-jwt-token-signing
 jwt.access-token-expiration=1800000
 jwt.refresh-token-expiration=1209600000
+
+kakao.client-id=${KAKAO_REST_API_KEY:}
+kakao.client-secret=${KAKAO_CLIENT_SECRET:}
+kakao.redirect-uri=${KAKAO_REDIRECT_URI:http://localhost:8080/oauth/kakao/callback}

--- a/7th-be-blog/src/test/java/com/leets/blog/domain/post/service/PostServiceTest.java
+++ b/7th-be-blog/src/test/java/com/leets/blog/domain/post/service/PostServiceTest.java
@@ -44,6 +44,7 @@ class PostServiceTest {
     void setUp() {
         user = User.builder()
                 .name("tester")
+                .nickname("tester")
                 .email("tester@example.com")
                 .password("password")
                 .build();


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

- [x] 카카오 OAuth 로그인
- [x] 카카오 사용자 정보 조회
- [x] 서버 JWT accessToken, refreshToken 발급

## 2. 핵심 변경 사항

6주차 JWT 인증 방식을 유지하면서 카카오 로그인을 추가했습니다.

카카오 로그인  
-> 카카오 access token 발급  
-> 카카오 사용자 정보 조회  
-> 사용자 조회/생성  
-> 서버 JWT 발급  
-> `Authorization: Bearer JWT`로 인증

주요 변경 사항은 다음과 같습니다.

1. 카카오 로그인 API 추가
   - `GET /oauth/kakao/login`
   - `GET /oauth/kakao/callback`

2. User 엔티티 확장
   - `provider`: `LOCAL`, `KAKAO`
   - `providerId`: 카카오 회원번호
   - `name`: 이름/표시 이름
   - `nickname`: 서비스 고유 닉네임

3. 로그인 방식 분리
   - 이메일 로그인: `LOCAL + email`
   - 카카오 로그인: `KAKAO + providerId`

## 3. 실행 및 검증 결과
### 로그인 화면
<img width="1167" height="733" alt="스크린샷 2026-05-19 오후 12 51 29" src="https://github.com/user-attachments/assets/33d26e63-1a2b-448e-a439-e3caab0ea05e" />

### 로그인 응답
<img width="1062" height="178" alt="스크린샷 2026-05-19 오후 1 10 47" src="https://github.com/user-attachments/assets/2d9aa38e-55d0-482b-9686-95e0025595de" />

### 로그인 응답 확인 302
<img width="1352" height="878" alt="스크린샷 2026-05-19 오후 1 01 18" src="https://github.com/user-attachments/assets/67e3437b-162e-4c98-9084-a83ce80592aa" />


## 4. 완료 사항

1. 카카오 OAuth 로그인 구현
2. 카카오 사용자 조회/생성
3. 서버 JWT 발급
4. JWT 필터 인증 확인

#261 

## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

## 5. 리뷰어 참고 

- 로그아웃은 별도로 구현하지 않았습니다.