### PR TITLE
[7주차] 송유경/[feat] 카카오 OAuth 로그인 구현

### DIFF
--- a/src/main/java/com/leets/blog/comment/service/CommentService.java
+++ b/src/main/java/com/leets/blog/comment/service/CommentService.java
@@ -29,8 +29,7 @@ public class CommentService {
 
     @Transactional
     public CommentResponse create(AuthUser authUser, Long postId, CommentRequest.Create request) {
-        User user = userRepository.findById(authUser.getUserId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository.getReferenceById(authUser.getUserId());
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
 

--- a/src/main/java/com/leets/blog/global/config/WebConfig.java
+++ b/src/main/java/com/leets/blog/global/config/WebConfig.java
@@ -2,7 +2,9 @@ package com.leets.blog.global.config;
 
 import com.leets.blog.user.auth.CurrentUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -17,5 +19,10 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(currentUserArgumentResolver);
+    }
+
+    @Bean
+    public RestClient restClient() {
+        return RestClient.create();
     }
 }

--- a/src/main/java/com/leets/blog/global/exception/ErrorCode.java
+++ b/src/main/java/com/leets/blog/global/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    KAKAO_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "카카오 로그인에 실패했습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "해당 작업에 대한 권한이 없습니다."),
     INVALID_STATE_TRANSITION(HttpStatus.CONFLICT, "허용되지 않는 상태 전이입니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),

--- a/src/main/java/com/leets/blog/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/leets/blog/global/exception/GlobalExceptionHandler.java
@@ -1,12 +1,14 @@
 package com.leets.blog.global.exception;
 
 import com.leets.blog.global.common.BaseResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -43,6 +45,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<BaseResponse<Void>> handleException(Exception e) {
+        log.error("Unhandled exception", e);
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(BaseResponse.<Void>builder()

--- a/src/main/java/com/leets/blog/post/domain/Post.java
+++ b/src/main/java/com/leets/blog/post/domain/Post.java
@@ -42,21 +42,12 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
-    public void confirmUser(User user) {
-        this.user = user;
-        if (user != null && !user.getPosts().contains(this)) {
-            user.getPosts().add(this);
-        }
-    }
-
     @Builder
     public Post(String title, String content, PostStatus status, User user) {
         this.title = title;
         this.content = content;
         this.status = status;
-        if (user != null && !user.getPosts().contains(this)) {
-            confirmUser(user);
-        }
+        this.user = user;
     }
 
     public void update(String title, String content) {

--- a/src/main/java/com/leets/blog/post/domain/Post.java
+++ b/src/main/java/com/leets/blog/post/domain/Post.java
@@ -33,7 +33,7 @@ public class Post extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private PostStatus status;          // PUBLISHED, DRAFT
+    private PostStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)      // 필요시만 가져오는 LAZY 지연로딩 사용
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/leets/blog/post/service/PostService.java
+++ b/src/main/java/com/leets/blog/post/service/PostService.java
@@ -4,7 +4,7 @@ import com.leets.blog.global.exception.BusinessException;
 import com.leets.blog.global.exception.ErrorCode;
 import com.leets.blog.user.auth.AuthUser;
 import com.leets.blog.post.domain.Post;
-import com.leets.blog.post.domain.PostStatus; // 추가
+import com.leets.blog.post.domain.PostStatus;
 import com.leets.blog.post.repository.PostRepository;
 import com.leets.blog.post.dto.PostRequest;
 import com.leets.blog.post.dto.PostResponse;
@@ -27,8 +27,7 @@ public class PostService {
 
     @Transactional
     public PostResponse create(AuthUser authUser, PostRequest.Create request) {
-        User user = userRepository.findById(authUser.getUserId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository.getReferenceById(authUser.getUserId());
 
         Post post = Post.builder()
                 .title(request.getTitle())

--- a/src/main/java/com/leets/blog/report/service/ReportService.java
+++ b/src/main/java/com/leets/blog/report/service/ReportService.java
@@ -31,46 +31,29 @@ public class ReportService {
 
     @Transactional
     public ReportResponse reportComment(AuthUser authUser, Long commentId, ReportRequest.Create request) {
-        User reporter = userRepository.findById(authUser.getUserId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
         if (!commentRepository.existsById(commentId)) {
             throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND);
         }
-
-        if (reportRepository.existsByReporterIdAndTargetTypeAndTargetId(
-                reporter.getId(),
-                ReportTargetType.COMMENT,
-                commentId
-        )) {
-            throw new BusinessException(ErrorCode.DUPLICATE_REPORT);
-        }
-
-        Report report = new Report(ReportTargetType.COMMENT, commentId, request.getReason(), reporter);
-        Report savedReport = reportRepository.save(report);
-        return new ReportResponse(savedReport);
+        return createReport(authUser, commentId, ReportTargetType.COMMENT, request);
     }
 
     @Transactional
     public ReportResponse reportPost(AuthUser authUser, Long postId, ReportRequest.Create request) {
-        User reporter = userRepository.findById(authUser.getUserId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
         if (!postRepository.existsById(postId)) {
             throw new BusinessException(ErrorCode.POST_NOT_FOUND);
         }
+        return createReport(authUser, postId, ReportTargetType.POST, request);
+    }
 
-        if (reportRepository.existsByReporterIdAndTargetTypeAndTargetId(
-                reporter.getId(),
-                ReportTargetType.POST,
-                postId
-        )) {
+    private ReportResponse createReport(AuthUser authUser, Long targetId, ReportTargetType targetType, ReportRequest.Create request) {
+        User reporter = userRepository.findById(authUser.getUserId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (reportRepository.existsByReporterIdAndTargetTypeAndTargetId(reporter.getId(), targetType, targetId)) {
             throw new BusinessException(ErrorCode.DUPLICATE_REPORT);
         }
 
-        Report report = new Report(ReportTargetType.POST, postId, request.getReason(), reporter);
-        Report savedReport = reportRepository.save(report);
-        return new ReportResponse(savedReport);
+        return new ReportResponse(reportRepository.save(new Report(targetType, targetId, request.getReason(), reporter)));
     }
 
     @Transactional

--- a/src/main/java/com/leets/blog/security/KakaoOAuthProperties.java
+++ b/src/main/java/com/leets/blog/security/KakaoOAuthProperties.java
@@ -1,0 +1,19 @@
+package com.leets.blog.security;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "oauth.kakao")
+public class KakaoOAuthProperties {
+
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+    private String tokenUri = "https://kauth.kakao.com/oauth/token";
+    private String userInfoUri = "https://kapi.kakao.com/v2/user/me";
+}

--- a/src/main/java/com/leets/blog/security/SecurityConfig.java
+++ b/src/main/java/com/leets/blog/security/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/auth/signup", "/api/auth/login", "/api/auth/refresh", "/api/auth/logout").permitAll()
+                        .requestMatchers("/api/auth/signup", "/api/auth/login", "/api/auth/kakao/login", "/api/auth/kakao/callback", "/api/auth/refresh", "/api/auth/logout").permitAll()
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/webjars/**").permitAll()
                         .requestMatchers("/static/**", "/css/**", "/js/**", "/images/**").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/leets/blog/user/controller/AuthController.java
+++ b/src/main/java/com/leets/blog/user/controller/AuthController.java
@@ -49,22 +49,33 @@ public class AuthController {
             HttpServletResponse response
     ) {
         AuthResponse.Login loginResponse = authService.login(request);
+        addLoginCookies(response, loginResponse);
 
-        response.addHeader(HttpHeaders.SET_COOKIE,
-                CookieUtils.createCookie(
-                        jwtProperties.getAccessCookieName(),
-                        loginResponse.getAccessToken(),
-                        jwtProperties.getAccessTokenExpirationSeconds(),
-                        jwtProperties
-                ).toString());
-        response.addHeader(HttpHeaders.SET_COOKIE,
-                CookieUtils.createCookie(
-                        jwtProperties.getRefreshCookieName(),
-                        loginResponse.getRefreshToken(),
-                        jwtProperties.getRefreshTokenExpirationSeconds(),
-                        jwtProperties
-                ).toString());
+        return ResponseEntity.ok(BaseResponse.ok(loginResponse));
+    }
 
+    @PostMapping("/kakao/login")
+    @Operation(
+            summary = "카카오 로그인",
+            description = "카카오 인가 코드로 로그인하고 access/refresh 토큰을 쿠키로 발급합니다."
+    )
+    public ResponseEntity<BaseResponse<AuthResponse.Login>> kakaoLogin(
+            @Valid @RequestBody AuthRequest.KakaoLogin request,
+            HttpServletResponse response
+    ) {
+        AuthResponse.Login loginResponse = authService.kakaoLogin(request);
+        addLoginCookies(response, loginResponse);
+        return ResponseEntity.ok(BaseResponse.ok(loginResponse));
+    }
+
+    @GetMapping("/kakao/callback")
+    @Operation(summary = "카카오 로그인 콜백 (테스트용)", description = "카카오 인가 코드를 받아 로그인 처리합니다.")
+    public ResponseEntity<BaseResponse<AuthResponse.Login>> kakaoCallback(
+            @RequestParam String code,
+            HttpServletResponse response
+    ) {
+        AuthResponse.Login loginResponse = authService.kakaoLogin(new AuthRequest.KakaoLogin(code));
+        addLoginCookies(response, loginResponse);
         return ResponseEntity.ok(BaseResponse.ok(loginResponse));
     }
 
@@ -127,5 +138,22 @@ public class AuthController {
                 authUser.getRole()
         );
         return ResponseEntity.ok(BaseResponse.ok(response));
+    }
+
+    private void addLoginCookies(HttpServletResponse response, AuthResponse.Login loginResponse) {
+        response.addHeader(HttpHeaders.SET_COOKIE,
+                CookieUtils.createCookie(
+                        jwtProperties.getAccessCookieName(),
+                        loginResponse.getAccessToken(),
+                        jwtProperties.getAccessTokenExpirationSeconds(),
+                        jwtProperties
+                ).toString());
+        response.addHeader(HttpHeaders.SET_COOKIE,
+                CookieUtils.createCookie(
+                        jwtProperties.getRefreshCookieName(),
+                        loginResponse.getRefreshToken(),
+                        jwtProperties.getRefreshTokenExpirationSeconds(),
+                        jwtProperties
+                ).toString());
     }
 }

--- a/src/main/java/com/leets/blog/user/controller/AuthController.java
+++ b/src/main/java/com/leets/blog/user/controller/AuthController.java
@@ -68,17 +68,6 @@ public class AuthController {
         return ResponseEntity.ok(BaseResponse.ok(loginResponse));
     }
 
-    @GetMapping("/kakao/callback")
-    @Operation(summary = "카카오 로그인 콜백 (테스트용)", description = "카카오 인가 코드를 받아 로그인 처리합니다.")
-    public ResponseEntity<BaseResponse<AuthResponse.Login>> kakaoCallback(
-            @RequestParam String code,
-            HttpServletResponse response
-    ) {
-        AuthResponse.Login loginResponse = authService.kakaoLogin(new AuthRequest.KakaoLogin(code));
-        addLoginCookies(response, loginResponse);
-        return ResponseEntity.ok(BaseResponse.ok(loginResponse));
-    }
-
     @PostMapping("/refresh")
     @Operation(
             summary = "토큰 재발급",

--- a/src/main/java/com/leets/blog/user/controller/DevAuthController.java
+++ b/src/main/java/com/leets/blog/user/controller/DevAuthController.java
@@ -1,0 +1,54 @@
+package com.leets.blog.user.controller;
+
+import com.leets.blog.global.common.BaseResponse;
+import com.leets.blog.security.CookieUtils;
+import com.leets.blog.security.JwtProperties;
+import com.leets.blog.user.dto.AuthRequest;
+import com.leets.blog.user.dto.AuthResponse;
+import com.leets.blog.user.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("dev")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Tag(name = "Auth (Dev)", description = "개발 환경 전용 인증 API")
+public class DevAuthController {
+
+    private final AuthService authService;
+    private final JwtProperties jwtProperties;
+
+    @GetMapping("/kakao/callback")
+    @Operation(summary = "카카오 로그인 콜백 (테스트용)", description = "카카오 인가 코드를 받아 로그인 처리합니다.")
+    public ResponseEntity<BaseResponse<AuthResponse.Login>> kakaoCallback(
+            @RequestParam String code,
+            HttpServletResponse response
+    ) {
+        AuthResponse.Login loginResponse = authService.kakaoLogin(new AuthRequest.KakaoLogin(code));
+        response.addHeader(HttpHeaders.SET_COOKIE,
+                CookieUtils.createCookie(
+                        jwtProperties.getAccessCookieName(),
+                        loginResponse.getAccessToken(),
+                        jwtProperties.getAccessTokenExpirationSeconds(),
+                        jwtProperties
+                ).toString());
+        response.addHeader(HttpHeaders.SET_COOKIE,
+                CookieUtils.createCookie(
+                        jwtProperties.getRefreshCookieName(),
+                        loginResponse.getRefreshToken(),
+                        jwtProperties.getRefreshTokenExpirationSeconds(),
+                        jwtProperties
+                ).toString());
+        return ResponseEntity.ok(BaseResponse.ok(loginResponse));
+    }
+}

--- a/src/main/java/com/leets/blog/user/domain/User.java
+++ b/src/main/java/com/leets/blog/user/domain/User.java
@@ -15,7 +15,9 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)  // 기본 생성자 생성, 외부 접근 PROTECTED 제한
-@Table(name = "users")
+@Table(name = "users", indexes = {
+    @Index(name = "idx_oauth_provider_id", columnList = "oauthProvider, oauthId")
+})
 public class User extends BaseTimeEntity {
 
     @Id
@@ -31,6 +33,12 @@ public class User extends BaseTimeEntity {
 
     @Column(nullable = false, length = 100)
     private String nickname;
+
+    @Column(length = 30)
+    private String oauthProvider;
+
+    @Column(length = 100)
+    private String oauthId;
 
     // role (권한) 설정
     @Enumerated(EnumType.STRING)
@@ -50,5 +58,8 @@ public class User extends BaseTimeEntity {
         this.role = role;
     }
 
-
+    public void linkOAuth(String oauthProvider, String oauthId) {
+        this.oauthProvider = oauthProvider;
+        this.oauthId = oauthId;
+    }
 }

--- a/src/main/java/com/leets/blog/user/dto/AuthRequest.java
+++ b/src/main/java/com/leets/blog/user/dto/AuthRequest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -39,5 +40,14 @@ public class AuthRequest {
         @NotBlank(message = "비밀번호는 필수입니다.")
         @Schema(description = "비밀번호", example = "password1234")
         private String password;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KakaoLogin {
+        @NotBlank(message = "카카오 인가 코드는 필수입니다.")
+        @Schema(description = "카카오 인가 코드", example = "authorization-code-from-kakao")
+        private String code;
     }
 }

--- a/src/main/java/com/leets/blog/user/dto/KakaoOAuthResponse.java
+++ b/src/main/java/com/leets/blog/user/dto/KakaoOAuthResponse.java
@@ -1,0 +1,43 @@
+package com.leets.blog.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+public class KakaoOAuthResponse {
+
+    @Getter
+    public static class Token {
+        @JsonProperty("access_token")
+        private String accessToken;
+    }
+
+    @Getter
+    public static class UserInfo {
+        private Long id;
+
+        @JsonProperty("kakao_account")
+        private KakaoAccount kakaoAccount;
+
+        public String getEmail() {
+            return kakaoAccount == null ? null : kakaoAccount.getEmail();
+        }
+
+        public String getNickname() {
+            if (kakaoAccount == null || kakaoAccount.getProfile() == null) {
+                return null;
+            }
+            return kakaoAccount.getProfile().getNickname();
+        }
+    }
+
+    @Getter
+    public static class KakaoAccount {
+        private String email;
+        private Profile profile;
+    }
+
+    @Getter
+    public static class Profile {
+        private String nickname;
+    }
+}

--- a/src/main/java/com/leets/blog/user/oauth/KakaoOAuthClient.java
+++ b/src/main/java/com/leets/blog/user/oauth/KakaoOAuthClient.java
@@ -1,0 +1,70 @@
+package com.leets.blog.user.oauth;
+
+import com.leets.blog.global.exception.BusinessException;
+import com.leets.blog.global.exception.ErrorCode;
+import com.leets.blog.security.KakaoOAuthProperties;
+import com.leets.blog.user.dto.KakaoOAuthResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthClient {
+
+    private final KakaoOAuthProperties kakaoOAuthProperties;
+    private final RestClient restClient;
+
+    public KakaoOAuthResponse.UserInfo getUserInfo(String code) {
+        try {
+            KakaoOAuthResponse.Token token = requestToken(code);
+            return requestUserInfo(token.getAccessToken());
+        } catch (RestClientException | IllegalArgumentException ex) {
+            throw new BusinessException(ErrorCode.KAKAO_LOGIN_FAILED);
+        }
+    }
+
+    private KakaoOAuthResponse.Token requestToken(String code) {
+        LinkedMultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", kakaoOAuthProperties.getClientId());
+        body.add("redirect_uri", kakaoOAuthProperties.getRedirectUri());
+        body.add("code", code);
+
+        if (StringUtils.hasText(kakaoOAuthProperties.getClientSecret())) {
+            body.add("client_secret", kakaoOAuthProperties.getClientSecret());
+        }
+
+        KakaoOAuthResponse.Token token = restClient.post()
+                .uri(kakaoOAuthProperties.getTokenUri())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .body(KakaoOAuthResponse.Token.class);
+
+        if (token == null || !StringUtils.hasText(token.getAccessToken())) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+
+        return token;
+    }
+
+    private KakaoOAuthResponse.UserInfo requestUserInfo(String accessToken) {
+        KakaoOAuthResponse.UserInfo userInfo = restClient.get()
+                .uri(kakaoOAuthProperties.getUserInfoUri())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .body(KakaoOAuthResponse.UserInfo.class);
+
+        if (userInfo == null || userInfo.getId() == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+
+        return userInfo;
+    }
+}

--- a/src/main/java/com/leets/blog/user/oauth/KakaoOAuthClient.java
+++ b/src/main/java/com/leets/blog/user/oauth/KakaoOAuthClient.java
@@ -48,7 +48,7 @@ public class KakaoOAuthClient {
                 .body(KakaoOAuthResponse.Token.class);
 
         if (token == null || !StringUtils.hasText(token.getAccessToken())) {
-            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+            throw new BusinessException(ErrorCode.KAKAO_LOGIN_FAILED);
         }
 
         return token;
@@ -62,7 +62,7 @@ public class KakaoOAuthClient {
                 .body(KakaoOAuthResponse.UserInfo.class);
 
         if (userInfo == null || userInfo.getId() == null) {
-            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+            throw new BusinessException(ErrorCode.KAKAO_LOGIN_FAILED);
         }
 
         return userInfo;

--- a/src/main/java/com/leets/blog/user/repository/UserRepository.java
+++ b/src/main/java/com/leets/blog/user/repository/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
+    Optional<User> findByOauthProviderAndOauthId(String oauthProvider, String oauthId);
 }

--- a/src/main/java/com/leets/blog/user/service/AuthService.java
+++ b/src/main/java/com/leets/blog/user/service/AuthService.java
@@ -7,20 +7,28 @@ import com.leets.blog.user.domain.User;
 import com.leets.blog.user.domain.UserRole;
 import com.leets.blog.user.dto.AuthRequest;
 import com.leets.blog.user.dto.AuthResponse;
+import com.leets.blog.user.dto.KakaoOAuthResponse;
+import com.leets.blog.user.oauth.KakaoOAuthClient;
 import com.leets.blog.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AuthService {
 
+    private static final String KAKAO_PROVIDER = "KAKAO";
+
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final KakaoOAuthClient kakaoOAuthClient;
 
     @Transactional
     public AuthResponse.UserInfo signUp(AuthRequest.SignUp request) {
@@ -47,15 +55,18 @@ public class AuthService {
             throw new BusinessException(ErrorCode.LOGIN_FAILED);
         }
 
-        String accessToken = jwtTokenProvider.createAccessToken(
-                user.getId(),
-                user.getEmail(),
-                user.getNickname(),
-                user.getRole().name()
-        );
-        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+        return createLoginResponse(user);
+    }
 
-        return new AuthResponse.Login(user, accessToken, refreshToken);
+    @Transactional
+    public AuthResponse.Login kakaoLogin(AuthRequest.KakaoLogin request) {
+        KakaoOAuthResponse.UserInfo kakaoUserInfo = kakaoOAuthClient.getUserInfo(request.getCode());
+        String kakaoId = kakaoUserInfo.getId().toString();
+
+        User user = userRepository.findByOauthProviderAndOauthId(KAKAO_PROVIDER, kakaoId)
+                .orElseGet(() -> findOrCreateKakaoUser(kakaoUserInfo, kakaoId));
+
+        return createLoginResponse(user);
     }
 
     public String reissueAccessToken(String refreshToken) {
@@ -67,6 +78,42 @@ public class AuthService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
+        return createAccessToken(user);
+    }
+
+    public AuthResponse.UserInfo findUserById(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        return new AuthResponse.UserInfo(user);
+    }
+
+    private User findOrCreateKakaoUser(KakaoOAuthResponse.UserInfo kakaoUserInfo, String kakaoId) {
+        String email = resolveKakaoEmail(kakaoUserInfo, kakaoId);
+        return userRepository.findByEmail(email)
+                .map(user -> {
+                    user.linkOAuth(KAKAO_PROVIDER, kakaoId);
+                    return user;
+                })
+                .orElseGet(() -> {
+                    User user = new User(
+                            email,
+                            passwordEncoder.encode(UUID.randomUUID().toString()),
+                            resolveKakaoNickname(kakaoUserInfo, kakaoId),
+                            UserRole.USER
+                    );
+                    user.linkOAuth(KAKAO_PROVIDER, kakaoId);
+                    return userRepository.save(user);
+                });
+    }
+
+    private AuthResponse.Login createLoginResponse(User user) {
+        String accessToken = createAccessToken(user);
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+
+        return new AuthResponse.Login(user, accessToken, refreshToken);
+    }
+
+    private String createAccessToken(User user) {
         return jwtTokenProvider.createAccessToken(
                 user.getId(),
                 user.getEmail(),
@@ -75,9 +122,17 @@ public class AuthService {
         );
     }
 
-    public AuthResponse.UserInfo findUserById(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        return new AuthResponse.UserInfo(user);
+    private String resolveKakaoEmail(KakaoOAuthResponse.UserInfo kakaoUserInfo, String kakaoId) {
+        if (StringUtils.hasText(kakaoUserInfo.getEmail())) {
+            return kakaoUserInfo.getEmail();
+        }
+        return "kakao_" + kakaoId + "@kakao.local";
+    }
+
+    private String resolveKakaoNickname(KakaoOAuthResponse.UserInfo kakaoUserInfo, String kakaoId) {
+        if (StringUtils.hasText(kakaoUserInfo.getNickname())) {
+            return kakaoUserInfo.getNickname();
+        }
+        return "kakao_" + kakaoId;
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,3 +18,11 @@ jwt:
   secure: false
   httpOnly: true
   sameSite: Lax
+
+oauth:
+  kakao:
+    clientId: ${KAKAO_CLIENT_ID:}
+    clientSecret: ${KAKAO_CLIENT_SECRET:}
+    redirectUri: ${KAKAO_REDIRECT_URI:}
+    tokenUri: https://kauth.kakao.com/oauth/token
+    userInfoUri: https://kapi.kakao.com/v2/user/me


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

- [x] 카카오 OAuth 로그인 구현 (`POST /api/auth/kakao/login`)
- [x] 신규 유저 자동 회원가입 처리
- [x] 기존 이메일 계정과 카카오 계정 연동 처리
- [x] JWT 토큰 쿠키 발급


## 2. 핵심 변경 사항

- `KakaoOAuthProperties` - 카카오 OAuth 설정값 바인딩 (`client_id`, `client_secret`, `redirect_uri`)
- `KakaoOAuthClient` - 카카오 인가 코드 → 토큰 교환 → 유저 정보 조회
- `KakaoOAuthResponse` - 카카오 API 응답 DTO (Token, UserInfo)
- `User` - `oauthProvider`, `oauthId` 필드 추가 및 `linkOAuth()` 메서드 추가
- `UserRepository` - `findByOauthProviderAndOauthId()` 추가
- `AuthService` - `kakaoLogin()` 추가 (신규/기존 유저 분기 처리)
- `AuthController` - `POST /api/auth/kakao/login`, `GET /api/auth/kakao/callback` (테스트용) 추가
- `ErrorCode` - `KAKAO_LOGIN_FAILED` 추가
- `WebConfig` - `RestClient` 빈 등록
- `application.yaml` - `oauth.kakao.*` 환경변수 설정 추가


## 3. 실행 및 검증 결과

브라우저에서 카카오 인가 URL 접속 후 로그인 완료 시 정상 응답 확인

<img width="1104" height="873" alt="스크린샷 2026-05-19 오후 5 58 11" src="https://github.com/user-attachments/assets/b17328b9-bd29-4750-8f72-389e1558a7b2" />

<img width="1104" height="126" alt="스크린샷 2026-05-19 오후 5 54 33" src="https://github.com/user-attachments/assets/a7161054-1633-4dc3-911e-0fd6e6e75d6e" />



## 4. 완료 사항
카카오 인가 코드로 액세스 토큰 발급 및 유저 정보 조회
신규 유저 자동 가입 / 기존 유저 로그인 처리
카카오 이메일 미제공 시 더미 이메일(kakao_{id}@kakao.local)로 폴백 처리
JWT 액세스/리프레시 토큰 쿠키 발급



## 5. 추가 사항

- 관련 이슈: closed #266 
- 카카오 이메일은 비즈니스 인증 없이는 수집 불가하여 미제공 시 더미 이메일로 처리
- 환경변수 필요: KAKAO_CLIENT_ID, KAKAO_CLIENT_SECRET, KAKAO_REDIRECT_URI
- GET /api/auth/kakao/callback 엔드포인트는 테스트용으로 추가된 콜백 핸들러


## 제출 체크리스트

- [x]  PR 제목이 규칙에 맞다
- [x]  base가 {이름}/main 브랜치다
- [x]  compare가 {이름}/{숫자}주차 브랜치다
- [x]  프로젝트가 정상 실행된다
- [x]  본인을 Assignee로 지정했다
- [x]  파트 담당 Reviewer를 지정했다
- [ ]  리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다


