### PR TITLE
[7주차] 김다인/[feat] 카카오 OAuth 로그인

### DIFF
--- a/kimdain/.gitignore
+++ b/kimdain/.gitignore
@@ -1,4 +1,5 @@
 HELP.md
+.env
 
 ### Gradle ###
 .gradle/

--- a/kimdain/build.gradle
+++ b/kimdain/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
@@ -43,6 +44,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/kimdain/src/main/java/com/leets/blog/auth/controller/AuthController.java
+++ b/kimdain/src/main/java/com/leets/blog/auth/controller/AuthController.java
@@ -30,4 +30,11 @@ public class AuthController {
 
         return ResponseEntity.ok(tokenResponse);
     }
+
+    // 카카오 로그인
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<TokenResponse> kakaoLogin(@RequestParam String code) {
+        TokenResponse tokenResponse = authService.kakaoLogin(code);
+        return ResponseEntity.ok(tokenResponse);
+    }
 }

--- a/kimdain/src/main/java/com/leets/blog/auth/dto/KakaoTokenResponse.java
+++ b/kimdain/src/main/java/com/leets/blog/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,8 @@
+package com.leets.blog.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoTokenResponse(
+        @JsonProperty("access_token")
+        String accessToken
+) {}

--- a/kimdain/src/main/java/com/leets/blog/auth/dto/KakaoUserResponse.java
+++ b/kimdain/src/main/java/com/leets/blog/auth/dto/KakaoUserResponse.java
@@ -1,0 +1,10 @@
+package com.leets.blog.auth.dto;
+
+public record KakaoUserResponse(
+        Long id,
+        KakaoProperties properties
+) {
+    public record KakaoProperties(
+            String nickname
+    ) {}
+}

--- a/kimdain/src/main/java/com/leets/blog/auth/service/AuthService.java
+++ b/kimdain/src/main/java/com/leets/blog/auth/service/AuthService.java
@@ -18,6 +18,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final KakaoService kakaoService;
 
     @Transactional
     public void signup(SignupRequest request) {
@@ -37,5 +38,28 @@ public class AuthService {
         if (!passwordEncoder.matches(request.password(), user.getPassword())) throw new RuntimeException("비번틀림");
 
         return TokenResponse.of(jwtProvider.createAccessToken(user.getEmail()), jwtProvider.createRefreshToken(user.getEmail()));
+    }
+
+    // 카카오 로그인
+    @Transactional
+    public TokenResponse kakaoLogin(String code) {
+        String kakaoAccessToken = kakaoService.getAccessToken(code);
+        KakaoUserResponse userInfo = kakaoService.getUserInfo(kakaoAccessToken);
+
+        String kakaoId = userInfo.id().toString();
+        String nickname = userInfo.properties().nickname();
+
+        User user = userRepository.findByEmail(kakaoId)
+                .orElseGet(() -> userRepository.save(User.builder()
+                        .email(kakaoId)
+                        .nickname(nickname)
+                        .name(nickname)
+                        .password(passwordEncoder.encode(kakaoId))
+                        .build()));
+
+        return TokenResponse.of(
+                jwtProvider.createAccessToken(user.getEmail()),
+                jwtProvider.createRefreshToken(user.getEmail())
+        );
     }
 }

--- a/kimdain/src/main/java/com/leets/blog/auth/service/KakaoService.java
+++ b/kimdain/src/main/java/com/leets/blog/auth/service/KakaoService.java
@@ -1,0 +1,49 @@
+package com.leets.blog.auth.service;
+
+import com.leets.blog.auth.dto.KakaoTokenResponse;
+import com.leets.blog.auth.dto.KakaoUserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${kakao.client-secret}")
+    private String clientSecret;
+
+    public String getAccessToken(String code) {
+        return WebClient.create("https://kauth.kakao.com")
+                .post()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/oauth/token")
+                        .queryParam("grant_type", "authorization_code")
+                        .queryParam("client_id", clientId)
+                        .queryParam("client_secret", clientSecret)
+                        .queryParam("redirect_uri", redirectUri)
+                        .queryParam("code", code)
+                        .build())
+                .retrieve()
+                .bodyToMono(KakaoTokenResponse.class)
+                .block()
+                .accessToken();
+    }
+
+    public KakaoUserResponse getUserInfo(String accessToken) {
+        return WebClient.create("https://kapi.kakao.com")
+                .get()
+                .uri("/v2/user/me")
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .bodyToMono(KakaoUserResponse.class)
+                .block();
+    }
+}

--- a/kimdain/src/main/resources/application.properties
+++ b/kimdain/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
-# Swagger ??
+# Swagger
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.display-request-duration=true


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용
카카오 OAuth 로그인 구현


## 2. 핵심 변경 사항
- `KakaoService` : 인가코드 → 카카오 액세스토큰 교환, 유저정보 조회
- `AuthController` : `/auth/kakao/callback` 엔드포인트 추가
- `AuthService` : 카카오 유저 자동 회원가입 및 JWT 발급 로직 추가
- `application.properties` : 카카오 client-id, redirect-uri 환경변수 설정


## 3. 실행 및 검증 결과
<img width="2560" height="1499" alt="스크린샷(80)" src="https://github.com/user-attachments/assets/3b795c0e-d3f2-4da4-ace4-c316bb95f285" />

<img width="2560" height="1454" alt="스크린샷(81)" src="https://github.com/user-attachments/assets/0385d66d-ec01-4954-923c-f99cecf0eb31" />


## 4. 완료 사항
1. 카카오 OAuth 인가코드 방식 로그인 구현
2. 신규 유저 자동 회원가입 처리
3. JWT accessToken / refreshToken 발급


## 5. 추가 사항
- 관련 이슈: closed #253 


## 제출 체크리스트
- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고

<!--
BE: rootTiket, soyesenna
FE: One-HyeWon, woneeee
-->
