### PR TITLE
[7주차] 강지훈/[feat] 카카오 OAuth 로그인 구현

### DIFF
--- a/jihoonkang/build.gradle
+++ b/jihoonkang/build.gradle
@@ -35,8 +35,10 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.squareup.okhttp3:mockwebserver'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/jihoonkang/build.gradle
+++ b/jihoonkang/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'com.squareup.okhttp3:mockwebserver'
+	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/jihoonkang/build.gradle
+++ b/jihoonkang/build.gradle
@@ -38,7 +38,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/jihoonkang/src/main/java/com/example/blog/domain/auth/client/KakaoOAuthClient.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/auth/client/KakaoOAuthClient.java
@@ -1,0 +1,73 @@
+package com.example.blog.domain.auth.client;
+
+import com.example.blog.domain.auth.dto.KakaoTokenResponse;
+import com.example.blog.domain.auth.dto.KakaoUserInfo;
+import com.example.blog.global.exception.BusinessException;
+import com.example.blog.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthClient {
+
+    private final WebClient.Builder webClientBuilder;
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.client-secret}")
+    private String clientSecret;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${kakao.token-uri}")
+    private String tokenUri;
+
+    @Value("${kakao.user-info-uri}")
+    private String userInfoUri;
+
+    public KakaoTokenResponse getToken(String code) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("grant_type", "authorization_code");
+        formData.add("client_id", clientId);
+        formData.add("client_secret", clientSecret);
+        formData.add("redirect_uri", redirectUri);
+        formData.add("code", code);
+
+        return webClientBuilder.build()
+            .post()
+            .uri(tokenUri)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(BodyInserters.fromFormData(formData))
+            .retrieve()
+            .onStatus(
+                status -> status.is4xxClientError() || status.is5xxServerError(),
+                response -> Mono.error(new BusinessException(ErrorCode.KAKAO_AUTH_FAILED))
+            )
+            .bodyToMono(KakaoTokenResponse.class)
+            .block();
+    }
+
+    public KakaoUserInfo getUserInfo(String accessToken) {
+        return webClientBuilder.build()
+            .get()
+            .uri(userInfoUri)
+            .header("Authorization", "Bearer " + accessToken)
+            .retrieve()
+            .onStatus(
+                status -> status.is4xxClientError() || status.is5xxServerError(),
+                response -> Mono.error(new BusinessException(ErrorCode.KAKAO_USER_INFO_FAILED))
+            )
+            .bodyToMono(KakaoUserInfo.class)
+            .block();
+    }
+}

--- a/jihoonkang/src/main/java/com/example/blog/domain/auth/client/KakaoOAuthClient.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/auth/client/KakaoOAuthClient.java
@@ -4,7 +4,6 @@ import com.example.blog.domain.auth.dto.KakaoTokenResponse;
 import com.example.blog.domain.auth.dto.KakaoUserInfo;
 import com.example.blog.global.exception.BusinessException;
 import com.example.blog.global.exception.ErrorCode;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -14,11 +13,12 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
+
 @Component
-@RequiredArgsConstructor
 public class KakaoOAuthClient {
 
-    private final WebClient.Builder webClientBuilder;
+    private final WebClient webClient;
 
     @Value("${kakao.client-id}")
     private String clientId;
@@ -35,6 +35,10 @@ public class KakaoOAuthClient {
     @Value("${kakao.user-info-uri}")
     private String userInfoUri;
 
+    public KakaoOAuthClient(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.build();
+    }
+
     public KakaoTokenResponse getToken(String code) {
         MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
         formData.add("grant_type", "authorization_code");
@@ -43,7 +47,7 @@ public class KakaoOAuthClient {
         formData.add("redirect_uri", redirectUri);
         formData.add("code", code);
 
-        return webClientBuilder.build()
+        return webClient
             .post()
             .uri(tokenUri)
             .contentType(MediaType.APPLICATION_FORM_URLENCODED)
@@ -54,11 +58,12 @@ public class KakaoOAuthClient {
                 response -> Mono.error(new BusinessException(ErrorCode.KAKAO_AUTH_FAILED))
             )
             .bodyToMono(KakaoTokenResponse.class)
+            .timeout(Duration.ofSeconds(5))
             .block();
     }
 
     public KakaoUserInfo getUserInfo(String accessToken) {
-        return webClientBuilder.build()
+        return webClient
             .get()
             .uri(userInfoUri)
             .header("Authorization", "Bearer " + accessToken)
@@ -68,6 +73,7 @@ public class KakaoOAuthClient {
                 response -> Mono.error(new BusinessException(ErrorCode.KAKAO_USER_INFO_FAILED))
             )
             .bodyToMono(KakaoUserInfo.class)
+            .timeout(Duration.ofSeconds(5))
             .block();
     }
 }

--- a/jihoonkang/src/main/java/com/example/blog/domain/auth/controller/OAuthController.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/auth/controller/OAuthController.java
@@ -1,0 +1,54 @@
+package com.example.blog.domain.auth.controller;
+
+import com.example.blog.domain.auth.dto.TokenResponse;
+import com.example.blog.domain.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@Tag(name = "소셜 로그인", description = "카카오 OAuth 로그인")
+@RestController
+@RequestMapping("/oauth/kakao")
+@RequiredArgsConstructor
+public class OAuthController {
+
+    private final AuthService authService;
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${kakao.authorize-uri}")
+    private String authorizeUri;
+
+    @Value("${kakao.frontend-redirect-uri}")
+    private String frontendRedirectUri;
+
+    @Operation(summary = "카카오 로그인 시작", description = "카카오 인가 페이지로 리다이렉트합니다.")
+    @GetMapping("/login")
+    public void redirectToKakao(HttpServletResponse response) throws IOException {
+        String authUrl = authorizeUri
+            + "?client_id=" + clientId
+            + "&redirect_uri=" + redirectUri
+            + "&response_type=code";
+        response.sendRedirect(authUrl);
+    }
+
+    @Operation(summary = "카카오 콜백", description = "인가코드로 자체 AT/RT를 발급하고 프론트로 리다이렉트합니다.")
+    @GetMapping("/callback")
+    public void kakaoCallback(@RequestParam String code,
+                              HttpServletResponse response) throws IOException {
+        TokenResponse tokenResponse = authService.kakaoCallback(code, response);
+        response.sendRedirect(frontendRedirectUri + "?accessToken=" + tokenResponse.accessToken());
+    }
+}

--- a/jihoonkang/src/main/java/com/example/blog/domain/auth/controller/OAuthController.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/auth/controller/OAuthController.java
@@ -2,17 +2,19 @@ package com.example.blog.domain.auth.controller;
 
 import com.example.blog.domain.auth.dto.TokenResponse;
 import com.example.blog.domain.auth.service.AuthService;
+import com.example.blog.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.IOException;
 
 @Tag(name = "소셜 로그인", description = "카카오 OAuth 로그인")
 @RestController
@@ -31,12 +33,15 @@ public class OAuthController {
     @Value("${kakao.authorize-uri}")
     private String authorizeUri;
 
-    @Value("${kakao.frontend-redirect-uri}")
-    private String frontendRedirectUri;
+    @Value("${kakao.logout-uri}")
+    private String logoutUri;
+
+    @Value("${kakao.logout-redirect-uri}")
+    private String logoutRedirectUri;
 
     @Operation(summary = "카카오 로그인 시작", description = "카카오 인가 페이지로 리다이렉트합니다.")
     @GetMapping("/login")
-    public void redirectToKakao(HttpServletResponse response) throws IOException {
+    public void redirectToKakao(HttpServletResponse response) throws java.io.IOException {
         String authUrl = authorizeUri
             + "?client_id=" + clientId
             + "&redirect_uri=" + redirectUri
@@ -44,11 +49,28 @@ public class OAuthController {
         response.sendRedirect(authUrl);
     }
 
-    @Operation(summary = "카카오 콜백", description = "인가코드로 자체 AT/RT를 발급하고 프론트로 리다이렉트합니다.")
+    @Operation(summary = "카카오 콜백", description = "인가코드로 자체 AT/RT를 발급합니다. AT는 응답 바디, RT는 HttpOnly 쿠키로 반환합니다.")
     @GetMapping("/callback")
-    public void kakaoCallback(@RequestParam String code,
-                              HttpServletResponse response) throws IOException {
+    public ResponseEntity<ApiResponse<TokenResponse>> kakaoCallback(@RequestParam String code,
+                                                                     HttpServletResponse response) {
         TokenResponse tokenResponse = authService.kakaoCallback(code, response);
-        response.sendRedirect(frontendRedirectUri + "?accessToken=" + tokenResponse.accessToken());
+        return ResponseEntity.ok(ApiResponse.success(tokenResponse));
+    }
+
+    @Operation(summary = "카카오 로그아웃 시작", description = "카카오 로그아웃 페이지로 리다이렉트합니다.")
+    @GetMapping("/logout/start")
+    public void startLogout(HttpServletResponse response) throws java.io.IOException {
+        String kakaoLogoutUrl = logoutUri
+            + "?client_id=" + clientId
+            + "&logout_redirect_uri=" + logoutRedirectUri;
+        response.sendRedirect(kakaoLogoutUrl);
+    }
+
+    @Operation(summary = "카카오 로그아웃 콜백", description = "카카오 로그아웃 후 로컬 RT를 삭제하고 쿠키를 초기화합니다.")
+    @GetMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(HttpServletRequest request,
+                                                    HttpServletResponse response) {
+        authService.logout(request, response);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/jihoonkang/src/main/java/com/example/blog/domain/auth/controller/OAuthController.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/auth/controller/OAuthController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 
 
 @Tag(name = "소셜 로그인", description = "카카오 OAuth 로그인")
@@ -42,10 +43,11 @@ public class OAuthController {
     @Operation(summary = "카카오 로그인 시작", description = "카카오 인가 페이지로 리다이렉트합니다.")
     @GetMapping("/login")
     public void redirectToKakao(HttpServletResponse response) throws java.io.IOException {
-        String authUrl = authorizeUri
-            + "?client_id=" + clientId
-            + "&redirect_uri=" + redirectUri
-            + "&response_type=code";
+        String authUrl = UriComponentsBuilder.fromHttpUrl(authorizeUri)
+            .queryParam("client_id", clientId)
+            .queryParam("redirect_uri", redirectUri)
+            .queryParam("response_type", "code")
+            .toUriString();
         response.sendRedirect(authUrl);
     }
 
@@ -60,9 +62,10 @@ public class OAuthController {
     @Operation(summary = "카카오 로그아웃 시작", description = "카카오 로그아웃 페이지로 리다이렉트합니다.")
     @GetMapping("/logout/start")
     public void startLogout(HttpServletResponse response) throws java.io.IOException {
-        String kakaoLogoutUrl = logoutUri
-            + "?client_id=" + clientId
-            + "&logout_redirect_uri=" + logoutRedirectUri;
+        String kakaoLogoutUrl = UriComponentsBuilder.fromHttpUrl(logoutUri)
+            .queryParam("client_id", clientId)
+            .queryParam("logout_redirect_uri", logoutRedirectUri)
+            .toUriString();
         response.sendRedirect(kakaoLogoutUrl);
     }
 

--- a/jihoonkang/src/main/java/com/example/blog/domain/auth/dto/KakaoTokenResponse.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,8 @@
+package com.example.blog.domain.auth.dto;
+
+public record KakaoTokenResponse(
+    String accessToken,
+    String refreshToken,
+    String tokenType,
+    Long expiresIn
+) {}

--- a/jihoonkang/src/main/java/com/example/blog/domain/auth/dto/KakaoTokenResponse.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/auth/dto/KakaoTokenResponse.java
@@ -1,8 +1,10 @@
 package com.example.blog.domain.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record KakaoTokenResponse(
-    String accessToken,
-    String refreshToken,
-    String tokenType,
-    Long expiresIn
+    @JsonProperty("access_token") String accessToken,
+    @JsonProperty("refresh_token") String refreshToken,
+    @JsonProperty("token_type") String tokenType,
+    @JsonProperty("expires_in") Long expiresIn
 ) {}

--- a/jihoonkang/src/main/java/com/example/blog/domain/auth/dto/KakaoUserInfo.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/auth/dto/KakaoUserInfo.java
@@ -1,8 +1,10 @@
 package com.example.blog.domain.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record KakaoUserInfo(
     Long id,
-    KakaoAccount kakaoAccount
+    @JsonProperty("kakao_account") KakaoAccount kakaoAccount
 ) {
     public record KakaoAccount(
         String email,
@@ -10,7 +12,7 @@ public record KakaoUserInfo(
     ) {
         public record Profile(
             String nickname,
-            String profileImageUrl
+            @JsonProperty("profile_image_url") String profileImageUrl
         ) {}
     }
 

--- a/jihoonkang/src/main/java/com/example/blog/domain/auth/dto/KakaoUserInfo.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/auth/dto/KakaoUserInfo.java
@@ -1,0 +1,34 @@
+package com.example.blog.domain.auth.dto;
+
+public record KakaoUserInfo(
+    Long id,
+    KakaoAccount kakaoAccount
+) {
+    public record KakaoAccount(
+        String email,
+        Profile profile
+    ) {
+        public record Profile(
+            String nickname,
+            String profileImageUrl
+        ) {}
+    }
+
+    public String email() {
+        return kakaoAccount != null ? kakaoAccount.email() : null;
+    }
+
+    public String nickname() {
+        if (kakaoAccount == null || kakaoAccount.profile() == null) {
+            return null;
+        }
+        return kakaoAccount.profile().nickname();
+    }
+
+    public String profileImageUrl() {
+        if (kakaoAccount == null || kakaoAccount.profile() == null) {
+            return null;
+        }
+        return kakaoAccount.profile().profileImageUrl();
+    }
+}

--- a/jihoonkang/src/main/java/com/example/blog/domain/auth/service/AuthService.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/auth/service/AuthService.java
@@ -144,6 +144,26 @@ public class AuthService {
         return candidate + "_" + providerId;
     }
 
+    public void logout(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = extractRefreshTokenFromCookie(request);
+        if (refreshToken != null) {
+            refreshTokenRepository.findByToken(refreshToken)
+                .ifPresent(rt -> refreshTokenRepository.deleteByUserId(rt.getUserId()));
+        }
+        clearRefreshTokenCookie(response);
+    }
+
+    private void clearRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE, "")
+            .httpOnly(true)
+            .secure(cookieSecure)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(0)
+            .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
     private void setRefreshTokenCookie(HttpServletResponse response, String token) {
         ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE, token)
             .httpOnly(true)

--- a/jihoonkang/src/main/java/com/example/blog/domain/auth/service/AuthService.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/auth/service/AuthService.java
@@ -65,7 +65,7 @@ public class AuthService {
 
     @Transactional
     public TokenResponse login(LoginRequest request, HttpServletResponse response) {
-        User user = userRepository.findByEmail(request.email())
+        User user = userRepository.findByEmailAndProvider(request.email(), Provider.LOCAL)
             .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {

--- a/jihoonkang/src/main/java/com/example/blog/domain/auth/service/AuthService.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/auth/service/AuthService.java
@@ -1,5 +1,8 @@
 package com.example.blog.domain.auth.service;
 
+import com.example.blog.domain.auth.client.KakaoOAuthClient;
+import com.example.blog.domain.auth.dto.KakaoTokenResponse;
+import com.example.blog.domain.auth.dto.KakaoUserInfo;
 import com.example.blog.domain.auth.dto.LoginRequest;
 import com.example.blog.domain.auth.dto.SignUpRequest;
 import com.example.blog.domain.auth.dto.TokenResponse;
@@ -37,6 +40,7 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private final KakaoOAuthClient kakaoOAuthClient;
 
     @Value("${jwt.refresh-expiration}")
     private long refreshExpiration;
@@ -100,6 +104,44 @@ public class AuthService {
 
         String newAccessToken = jwtUtil.generateAccessToken(user.getId(), user.getRole().name());
         return new TokenResponse(newAccessToken);
+    }
+
+    public TokenResponse kakaoCallback(String code, HttpServletResponse response) {
+        KakaoTokenResponse kakaoToken = kakaoOAuthClient.getToken(code);
+        KakaoUserInfo userInfo = kakaoOAuthClient.getUserInfo(kakaoToken.accessToken());
+
+        String providerId = String.valueOf(userInfo.id());
+
+        User user = userRepository.findByProviderAndProviderId(Provider.KAKAO, providerId)
+            .orElseGet(() -> registerKakaoUser(userInfo, providerId));
+
+        String accessToken = jwtUtil.generateAccessToken(user.getId(), user.getRole().name());
+        String refreshToken = jwtUtil.generateRefreshToken(user.getId());
+
+        LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(refreshExpiration / 1000);
+        refreshTokenRepository.findByUserId(user.getId())
+            .ifPresentOrElse(
+                rt -> rt.update(refreshToken, expiresAt),
+                () -> refreshTokenRepository.save(RefreshToken.of(user.getId(), refreshToken, expiresAt))
+            );
+
+        setRefreshTokenCookie(response, refreshToken);
+        return new TokenResponse(accessToken);
+    }
+
+    private User registerKakaoUser(KakaoUserInfo userInfo, String providerId) {
+        String username = resolveUniqueUsername(userInfo.nickname(), providerId);
+        String email = userInfo.email() != null ? userInfo.email() : "kakao_" + providerId + "@kakao.local";
+        User newUser = User.ofKakao(username, email, userInfo.profileImageUrl(), providerId);
+        return userRepository.save(newUser);
+    }
+
+    private String resolveUniqueUsername(String nickname, String providerId) {
+        String candidate = nickname != null ? nickname : "kakao_" + providerId;
+        if (!userRepository.existsByUsername(candidate)) {
+            return candidate;
+        }
+        return candidate + "_" + providerId;
     }
 
     private void setRefreshTokenCookie(HttpServletResponse response, String token) {

--- a/jihoonkang/src/main/java/com/example/blog/domain/auth/service/AuthService.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import com.example.blog.domain.auth.dto.TokenResponse;
 import com.example.blog.domain.auth.entity.RefreshToken;
 import com.example.blog.domain.auth.repository.RefreshTokenRepository;
 import com.example.blog.domain.user.dto.UserResponse;
+import com.example.blog.domain.user.entity.Provider;
 import com.example.blog.domain.user.entity.User;
 import com.example.blog.domain.user.repository.UserRepository;
 import com.example.blog.global.exception.BusinessException;
@@ -44,14 +45,14 @@ public class AuthService {
     private boolean cookieSecure;
 
     public UserResponse signUp(SignUpRequest request) {
-        if (userRepository.existsByEmail(request.email())) {
+        if (userRepository.existsByEmailAndProvider(request.email(), Provider.LOCAL)) {
             throw new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS);
         }
         if (userRepository.existsByUsername(request.username())) {
             throw new BusinessException(ErrorCode.USERNAME_ALREADY_EXISTS);
         }
         String hashedPassword = passwordEncoder.encode(request.password());
-        User user = User.of(request.username(), request.email(), hashedPassword, request.profileUrl());
+        User user = User.ofLocal(request.username(), request.email(), hashedPassword, request.profileUrl());
         return UserResponse.from(userRepository.save(user));
     }
 

--- a/jihoonkang/src/main/java/com/example/blog/domain/auth/service/AuthService.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/auth/service/AuthService.java
@@ -24,14 +24,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class AuthService {
 
     private static final String REFRESH_TOKEN_COOKIE = "refreshToken";
@@ -41,6 +42,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     private final KakaoOAuthClient kakaoOAuthClient;
+    private final PlatformTransactionManager transactionManager;
 
     @Value("${jwt.refresh-expiration}")
     private long refreshExpiration;
@@ -48,6 +50,7 @@ public class AuthService {
     @Value("${jwt.cookie.secure}")
     private boolean cookieSecure;
 
+    @Transactional
     public UserResponse signUp(SignUpRequest request) {
         if (userRepository.existsByEmailAndProvider(request.email(), Provider.LOCAL)) {
             throw new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS);
@@ -60,6 +63,7 @@ public class AuthService {
         return UserResponse.from(userRepository.save(user));
     }
 
+    @Transactional
     public TokenResponse login(LoginRequest request, HttpServletResponse response) {
         User user = userRepository.findByEmail(request.email())
             .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
@@ -82,6 +86,7 @@ public class AuthService {
         return new TokenResponse(accessToken);
     }
 
+    @Transactional
     public TokenResponse reissue(HttpServletRequest request) {
         String refreshToken = extractRefreshTokenFromCookie(request);
 
@@ -110,23 +115,25 @@ public class AuthService {
         KakaoTokenResponse kakaoToken = kakaoOAuthClient.getToken(code);
         KakaoUserInfo userInfo = kakaoOAuthClient.getUserInfo(kakaoToken.accessToken());
 
-        String providerId = String.valueOf(userInfo.id());
+        return new TransactionTemplate(transactionManager).execute(status -> {
+            String providerId = String.valueOf(userInfo.id());
 
-        User user = userRepository.findByProviderAndProviderId(Provider.KAKAO, providerId)
-            .orElseGet(() -> registerKakaoUser(userInfo, providerId));
+            User user = userRepository.findByProviderAndProviderId(Provider.KAKAO, providerId)
+                .orElseGet(() -> registerKakaoUser(userInfo, providerId));
 
-        String accessToken = jwtUtil.generateAccessToken(user.getId(), user.getRole().name());
-        String refreshToken = jwtUtil.generateRefreshToken(user.getId());
+            String accessToken = jwtUtil.generateAccessToken(user.getId(), user.getRole().name());
+            String refreshToken = jwtUtil.generateRefreshToken(user.getId());
 
-        LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(refreshExpiration / 1000);
-        refreshTokenRepository.findByUserId(user.getId())
-            .ifPresentOrElse(
-                rt -> rt.update(refreshToken, expiresAt),
-                () -> refreshTokenRepository.save(RefreshToken.of(user.getId(), refreshToken, expiresAt))
-            );
+            LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(refreshExpiration / 1000);
+            refreshTokenRepository.findByUserId(user.getId())
+                .ifPresentOrElse(
+                    rt -> rt.update(refreshToken, expiresAt),
+                    () -> refreshTokenRepository.save(RefreshToken.of(user.getId(), refreshToken, expiresAt))
+                );
 
-        setRefreshTokenCookie(response, refreshToken);
-        return new TokenResponse(accessToken);
+            setRefreshTokenCookie(response, refreshToken);
+            return new TokenResponse(accessToken);
+        });
     }
 
     private User registerKakaoUser(KakaoUserInfo userInfo, String providerId) {
@@ -144,6 +151,7 @@ public class AuthService {
         return candidate + "_" + providerId;
     }
 
+    @Transactional
     public void logout(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = extractRefreshTokenFromCookie(request);
         if (refreshToken != null) {

--- a/jihoonkang/src/main/java/com/example/blog/domain/user/entity/Provider.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/user/entity/Provider.java
@@ -1,0 +1,5 @@
+package com.example.blog.domain.user.entity;
+
+public enum Provider {
+    LOCAL, KAKAO
+}

--- a/jihoonkang/src/main/java/com/example/blog/domain/user/entity/User.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/user/entity/User.java
@@ -12,7 +12,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "users")
+@Table(
+    name = "users",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"email", "provider"}),
+        @UniqueConstraint(columnNames = {"provider", "provider_id"})
+    }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {

--- a/jihoonkang/src/main/java/com/example/blog/domain/user/entity/User.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/user/entity/User.java
@@ -28,15 +28,22 @@ public class User extends BaseEntity {
     @Column(name = "profile_url", length = 200)
     private String profileUrl;
 
-    @Column(nullable = false, unique = true, length = 100)
+    @Column(nullable = false, length = 100)
     private String email;
 
-    @Column(nullable = false, length = 200)
+    @Column(length = 200)
     private String password;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private Role role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Provider provider;
+
+    @Column(name = "provider_id", length = 50)
+    private String providerId;
 
     @OneToMany(mappedBy = "user")
     private List<Post> posts = new ArrayList<>();
@@ -44,13 +51,25 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user")
     private List<Comment> comments = new ArrayList<>();
 
-    public static User of(String username, String email, String password, String profileUrl) {
+    public static User ofLocal(String username, String email, String password, String profileUrl) {
         User user = new User();
         user.username = username;
         user.email = email;
         user.password = password;
         user.profileUrl = profileUrl;
         user.role = Role.USER;
+        user.provider = Provider.LOCAL;
+        return user;
+    }
+
+    public static User ofKakao(String username, String email, String profileUrl, String providerId) {
+        User user = new User();
+        user.username = username;
+        user.email = email;
+        user.profileUrl = profileUrl;
+        user.role = Role.USER;
+        user.provider = Provider.KAKAO;
+        user.providerId = providerId;
         return user;
     }
 

--- a/jihoonkang/src/main/java/com/example/blog/domain/user/repository/UserRepository.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.example.blog.domain.user.repository;
 
+import com.example.blog.domain.user.entity.Provider;
 import com.example.blog.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,7 +10,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
+    boolean existsByEmailAndProvider(String email, Provider provider);
+
     boolean existsByUsername(String username);
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
 }

--- a/jihoonkang/src/main/java/com/example/blog/domain/user/repository/UserRepository.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/user/repository/UserRepository.java
@@ -8,13 +8,11 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    boolean existsByEmail(String email);
-
     boolean existsByEmailAndProvider(String email, Provider provider);
 
     boolean existsByUsername(String username);
 
-    Optional<User> findByEmail(String email);
+    Optional<User> findByEmailAndProvider(String email, Provider provider);
 
     Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
 }

--- a/jihoonkang/src/main/java/com/example/blog/domain/user/service/UserService.java
+++ b/jihoonkang/src/main/java/com/example/blog/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.example.blog.domain.user.service;
 import com.example.blog.domain.user.dto.UserCreateRequest;
 import com.example.blog.domain.user.dto.UserResponse;
 import com.example.blog.domain.user.dto.UserUpdateRequest;
+import com.example.blog.domain.user.entity.Provider;
 import com.example.blog.domain.user.entity.User;
 import com.example.blog.domain.user.repository.UserRepository;
 import com.example.blog.global.exception.BusinessException;
@@ -22,14 +23,14 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     public UserResponse create(UserCreateRequest request) {
-        if (userRepository.existsByEmail(request.email())) {
+        if (userRepository.existsByEmailAndProvider(request.email(), Provider.LOCAL)) {
             throw new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS);
         }
         if (userRepository.existsByUsername(request.username())) {
             throw new BusinessException(ErrorCode.USERNAME_ALREADY_EXISTS);
         }
         String hashedPassword = passwordEncoder.encode(request.password());
-        User user = User.of(request.username(), request.email(), hashedPassword, request.profileUrl());
+        User user = User.ofLocal(request.username(), request.email(), hashedPassword, request.profileUrl());
         return UserResponse.from(userRepository.save(user));
     }
 

--- a/jihoonkang/src/main/java/com/example/blog/global/config/SecurityConfig.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(
                     "/auth", "/login", "/reissue",
+                    "/oauth/kakao/**",
                     "/api/v1/health",
                     "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**",
                     "/h2-console/**", "/error"

--- a/jihoonkang/src/main/java/com/example/blog/global/config/SecurityConfig.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/config/SecurityConfig.java
@@ -58,7 +58,11 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOriginPatterns(List.of("*"));
+        config.setAllowedOriginPatterns(List.of(
+            "http://localhost:3000",
+            "http://localhost:5173",
+            "http://localhost:8080"
+        ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/jihoonkang/src/main/java/com/example/blog/global/config/SecurityConfig.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/config/SecurityConfig.java
@@ -15,6 +15,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -29,6 +34,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
             .csrf(csrf -> csrf.disable())
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(
@@ -47,6 +53,18 @@ public class SecurityConfig {
             .headers(headers -> headers.frameOptions(frame -> frame.disable()))
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOriginPatterns(List.of("*"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 
     @Bean

--- a/jihoonkang/src/main/java/com/example/blog/global/config/WebClientConfig.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.example.blog.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}

--- a/jihoonkang/src/main/java/com/example/blog/global/config/WebClientConfig.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/config/WebClientConfig.java
@@ -1,14 +1,20 @@
 package com.example.blog.global.config;
 
+import io.netty.resolver.DefaultAddressResolverGroup;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
 
 @Configuration
 public class WebClientConfig {
 
     @Bean
     public WebClient.Builder webClientBuilder() {
-        return WebClient.builder();
+        HttpClient httpClient = HttpClient.create()
+            .resolver(DefaultAddressResolverGroup.INSTANCE);
+        return WebClient.builder()
+            .clientConnector(new ReactorClientHttpConnector(httpClient));
     }
 }

--- a/jihoonkang/src/main/java/com/example/blog/global/exception/ErrorCode.java
+++ b/jihoonkang/src/main/java/com/example/blog/global/exception/ErrorCode.java
@@ -33,7 +33,10 @@ public enum ErrorCode {
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_005", "Refresh Token이 존재하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_006", "유효하지 않은 Refresh Token입니다."),
 
-    USERNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "U003", "이미 사용 중인 닉네임입니다.");
+    USERNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "U003", "이미 사용 중인 닉네임입니다."),
+
+    KAKAO_AUTH_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_011", "카카오 인증에 실패했습니다."),
+    KAKAO_USER_INFO_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_012", "카카오 사용자 정보 조회에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/jihoonkang/src/main/resources/application.properties
+++ b/jihoonkang/src/main/resources/application.properties
@@ -27,3 +27,11 @@ jwt.secret=${JWT_SECRET:LeetsBackendKx5!93Jv#1Rz@lQwT9pXe3bD7sUaFzYt}
 jwt.access-expiration=1800000
 jwt.refresh-expiration=1209600000
 jwt.cookie.secure=false
+
+kakao.client-id=${KAKAO_CLIENT_ID:}
+kakao.client-secret=${KAKAO_CLIENT_SECRET:}
+kakao.redirect-uri=${KAKAO_REDIRECT_URI:http://localhost:8080/oauth/kakao/callback}
+kakao.authorize-uri=https://kauth.kakao.com/oauth/authorize
+kakao.token-uri=https://kauth.kakao.com/oauth/token
+kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+kakao.frontend-redirect-uri=${KAKAO_FRONTEND_REDIRECT_URI:http://localhost:3000/oauth/callback}

--- a/jihoonkang/src/main/resources/application.properties
+++ b/jihoonkang/src/main/resources/application.properties
@@ -35,3 +35,5 @@ kakao.authorize-uri=https://kauth.kakao.com/oauth/authorize
 kakao.token-uri=https://kauth.kakao.com/oauth/token
 kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
 kakao.frontend-redirect-uri=${KAKAO_FRONTEND_REDIRECT_URI:http://localhost:3000/oauth/callback}
+kakao.logout-uri=https://kauth.kakao.com/oauth/logout
+kakao.logout-redirect-uri=${KAKAO_LOGOUT_REDIRECT_URI:http://localhost:8080/oauth/kakao/logout}

--- a/jihoonkang/src/test/java/com/example/blog/domain/auth/AuthIntegrationTest.java
+++ b/jihoonkang/src/test/java/com/example/blog/domain/auth/AuthIntegrationTest.java
@@ -47,9 +47,6 @@ class AuthIntegrationTest {
     @Value("${kakao.redirect-uri}")
     private String redirectUri;
 
-    @Value("${kakao.frontend-redirect-uri}")
-    private String frontendRedirectUri;
-
     @Test
     void 회원가입_성공() throws Exception {
         SignUpRequest request = new SignUpRequest("test@example.com", "pass123!", "테스트유저", null);
@@ -162,7 +159,7 @@ class AuthIntegrationTest {
     }
 
     @Test
-    void 카카오_콜백_신규유저_프론트로_리다이렉트() throws Exception {
+    void 카카오_콜백_신규유저_액세스_토큰_반환() throws Exception {
         KakaoTokenResponse kakaoToken = new KakaoTokenResponse("kakao_at", "kakao_rt", "bearer", 21599L);
         KakaoUserInfo userInfo = new KakaoUserInfo(
             55555L,
@@ -174,11 +171,9 @@ class AuthIntegrationTest {
         given(kakaoOAuthClient.getUserInfo(anyString())).willReturn(userInfo);
 
         mockMvc.perform(get("/oauth/kakao/callback").param("code", "testcode"))
-            .andExpect(status().is3xxRedirection())
-            .andExpect(result -> {
-                String location = result.getResponse().getHeader("Location");
-                assertThat(location).startsWith(frontendRedirectUri);
-                assertThat(location).contains("accessToken=");
-            });
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("success"))
+            .andExpect(jsonPath("$.data.access_token").isNotEmpty())
+            .andExpect(cookie().exists("refreshToken"));
     }
 }

--- a/jihoonkang/src/test/java/com/example/blog/domain/auth/AuthIntegrationTest.java
+++ b/jihoonkang/src/test/java/com/example/blog/domain/auth/AuthIntegrationTest.java
@@ -1,17 +1,25 @@
 package com.example.blog.domain.auth;
 
+import com.example.blog.domain.auth.client.KakaoOAuthClient;
+import com.example.blog.domain.auth.dto.KakaoTokenResponse;
+import com.example.blog.domain.auth.dto.KakaoUserInfo;
 import com.example.blog.domain.auth.dto.LoginRequest;
 import com.example.blog.domain.auth.dto.SignUpRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -26,6 +34,21 @@ class AuthIntegrationTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @MockBean
+    private KakaoOAuthClient kakaoOAuthClient;
+
+    @Value("${kakao.authorize-uri}")
+    private String authorizeUri;
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${kakao.frontend-redirect-uri}")
+    private String frontendRedirectUri;
 
     @Test
     void 회원가입_성공() throws Exception {
@@ -124,5 +147,38 @@ class AuthIntegrationTest {
 
         mockMvc.perform(post("/reissue").cookie(fakeCookie))
             .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 카카오_로그인_시작_카카오_인가_URL로_리다이렉트() throws Exception {
+        mockMvc.perform(get("/oauth/kakao/login"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(result -> {
+                String location = result.getResponse().getHeader("Location");
+                assertThat(location).startsWith(authorizeUri);
+                assertThat(location).contains("client_id=" + clientId);
+                assertThat(location).contains("response_type=code");
+            });
+    }
+
+    @Test
+    void 카카오_콜백_신규유저_프론트로_리다이렉트() throws Exception {
+        KakaoTokenResponse kakaoToken = new KakaoTokenResponse("kakao_at", "kakao_rt", "bearer", 21599L);
+        KakaoUserInfo userInfo = new KakaoUserInfo(
+            55555L,
+            new KakaoUserInfo.KakaoAccount("integration@kakao.com",
+                new KakaoUserInfo.KakaoAccount.Profile("통합테스트닉", null))
+        );
+
+        given(kakaoOAuthClient.getToken(anyString())).willReturn(kakaoToken);
+        given(kakaoOAuthClient.getUserInfo(anyString())).willReturn(userInfo);
+
+        mockMvc.perform(get("/oauth/kakao/callback").param("code", "testcode"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(result -> {
+                String location = result.getResponse().getHeader("Location");
+                assertThat(location).startsWith(frontendRedirectUri);
+                assertThat(location).contains("accessToken=");
+            });
     }
 }

--- a/jihoonkang/src/test/java/com/example/blog/domain/auth/AuthServiceTest.java
+++ b/jihoonkang/src/test/java/com/example/blog/domain/auth/AuthServiceTest.java
@@ -24,6 +24,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -33,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
@@ -56,10 +59,14 @@ class AuthServiceTest {
     @Mock
     private KakaoOAuthClient kakaoOAuthClient;
 
+    @Mock
+    private PlatformTransactionManager transactionManager;
+
     @BeforeEach
     void setUp() {
         ReflectionTestUtils.setField(authService, "refreshExpiration", 1209600000L);
         ReflectionTestUtils.setField(authService, "cookieSecure", false);
+        lenient().when(transactionManager.getTransaction(any())).thenReturn(mock(TransactionStatus.class));
     }
 
     @Test
@@ -89,7 +96,7 @@ class AuthServiceTest {
 
     @Test
     void login_사용자_없음_예외() {
-        given(userRepository.findByEmail("no@example.com")).willReturn(Optional.empty());
+        given(userRepository.findByEmailAndProvider("no@example.com", Provider.LOCAL)).willReturn(Optional.empty());
 
         LoginRequest request = new LoginRequest("no@example.com", "pass123");
 
@@ -102,7 +109,7 @@ class AuthServiceTest {
     @Test
     void login_비밀번호_불일치_예외() {
         User user = User.ofLocal("지훈", "jihoon@example.com", "hashedPw", null);
-        given(userRepository.findByEmail("jihoon@example.com")).willReturn(Optional.of(user));
+        given(userRepository.findByEmailAndProvider("jihoon@example.com", Provider.LOCAL)).willReturn(Optional.of(user));
         given(passwordEncoder.matches("wrongPw", "hashedPw")).willReturn(false);
 
         LoginRequest request = new LoginRequest("jihoon@example.com", "wrongPw");

--- a/jihoonkang/src/test/java/com/example/blog/domain/auth/AuthServiceTest.java
+++ b/jihoonkang/src/test/java/com/example/blog/domain/auth/AuthServiceTest.java
@@ -1,18 +1,22 @@
 package com.example.blog.domain.auth;
 
+import com.example.blog.domain.auth.client.KakaoOAuthClient;
+import com.example.blog.domain.auth.dto.KakaoTokenResponse;
+import com.example.blog.domain.auth.dto.KakaoUserInfo;
 import com.example.blog.domain.auth.dto.LoginRequest;
 import com.example.blog.domain.auth.dto.SignUpRequest;
+import com.example.blog.domain.auth.dto.TokenResponse;
 import com.example.blog.domain.auth.entity.RefreshToken;
 import com.example.blog.domain.auth.repository.RefreshTokenRepository;
 import com.example.blog.domain.auth.service.AuthService;
 import com.example.blog.domain.user.entity.Provider;
-import com.example.blog.domain.user.entity.Role;
 import com.example.blog.domain.user.entity.User;
 import com.example.blog.domain.user.repository.UserRepository;
 import com.example.blog.global.exception.BusinessException;
 import com.example.blog.global.exception.ErrorCode;
 import com.example.blog.global.security.JwtUtil;
 import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -48,6 +52,15 @@ class AuthServiceTest {
 
     @Mock
     private JwtUtil jwtUtil;
+
+    @Mock
+    private KakaoOAuthClient kakaoOAuthClient;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(authService, "refreshExpiration", 1209600000L);
+        ReflectionTestUtils.setField(authService, "cookieSecure", false);
+    }
 
     @Test
     void signUp_이메일_중복_예외() {
@@ -143,5 +156,81 @@ class AuthServiceTest {
             .isInstanceOf(BusinessException.class)
             .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN));
+    }
+
+    @Test
+    void kakaoCallback_기존유저_로그인() {
+        KakaoTokenResponse kakaoToken = new KakaoTokenResponse("kakao_at", "kakao_rt", "bearer", 21599L);
+        KakaoUserInfo userInfo = new KakaoUserInfo(
+            12345L,
+            new KakaoUserInfo.KakaoAccount("kakao@test.com",
+                new KakaoUserInfo.KakaoAccount.Profile("테스트닉", null))
+        );
+        User existingUser = User.ofKakao("테스트닉", "kakao@test.com", null, "12345");
+
+        given(kakaoOAuthClient.getToken("code123")).willReturn(kakaoToken);
+        given(kakaoOAuthClient.getUserInfo("kakao_at")).willReturn(userInfo);
+        given(userRepository.findByProviderAndProviderId(Provider.KAKAO, "12345"))
+            .willReturn(Optional.of(existingUser));
+        given(jwtUtil.generateAccessToken(any(), anyString())).willReturn("access_token");
+        given(jwtUtil.generateRefreshToken(any())).willReturn("refresh_token");
+        given(refreshTokenRepository.findByUserId(any())).willReturn(Optional.empty());
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        TokenResponse result = authService.kakaoCallback("code123", response);
+
+        assertThat(result.accessToken()).isEqualTo("access_token");
+    }
+
+    @Test
+    void kakaoCallback_신규유저_자동가입() {
+        KakaoTokenResponse kakaoToken = new KakaoTokenResponse("kakao_at", "kakao_rt", "bearer", 21599L);
+        KakaoUserInfo userInfo = new KakaoUserInfo(
+            99999L,
+            new KakaoUserInfo.KakaoAccount("new@kakao.com",
+                new KakaoUserInfo.KakaoAccount.Profile("뉴유저", null))
+        );
+        User savedUser = User.ofKakao("뉴유저", "new@kakao.com", null, "99999");
+
+        given(kakaoOAuthClient.getToken("newcode")).willReturn(kakaoToken);
+        given(kakaoOAuthClient.getUserInfo("kakao_at")).willReturn(userInfo);
+        given(userRepository.findByProviderAndProviderId(Provider.KAKAO, "99999"))
+            .willReturn(Optional.empty());
+        given(userRepository.existsByUsername("뉴유저")).willReturn(false);
+        given(userRepository.save(any(User.class))).willReturn(savedUser);
+        given(jwtUtil.generateAccessToken(any(), anyString())).willReturn("new_access_token");
+        given(jwtUtil.generateRefreshToken(any())).willReturn("new_refresh_token");
+        given(refreshTokenRepository.findByUserId(any())).willReturn(Optional.empty());
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        TokenResponse result = authService.kakaoCallback("newcode", response);
+
+        assertThat(result.accessToken()).isEqualTo("new_access_token");
+    }
+
+    @Test
+    void kakaoCallback_username_중복시_suffix() {
+        KakaoTokenResponse kakaoToken = new KakaoTokenResponse("kakao_at", "kakao_rt", "bearer", 21599L);
+        KakaoUserInfo userInfo = new KakaoUserInfo(
+            77777L,
+            new KakaoUserInfo.KakaoAccount("dup@kakao.com",
+                new KakaoUserInfo.KakaoAccount.Profile("중복닉", null))
+        );
+        User savedUser = User.ofKakao("중복닉_77777", "dup@kakao.com", null, "77777");
+
+        given(kakaoOAuthClient.getToken("dupcode")).willReturn(kakaoToken);
+        given(kakaoOAuthClient.getUserInfo("kakao_at")).willReturn(userInfo);
+        given(userRepository.findByProviderAndProviderId(Provider.KAKAO, "77777"))
+            .willReturn(Optional.empty());
+        given(userRepository.existsByUsername("중복닉")).willReturn(true);
+        given(userRepository.save(any(User.class))).willReturn(savedUser);
+        given(jwtUtil.generateAccessToken(any(), anyString())).willReturn("at");
+        given(jwtUtil.generateRefreshToken(any())).willReturn("rt");
+        given(refreshTokenRepository.findByUserId(any())).willReturn(Optional.empty());
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        TokenResponse result = authService.kakaoCallback("dupcode", response);
+
+        assertThat(result.accessToken()).isEqualTo("at");
     }
 }

--- a/jihoonkang/src/test/java/com/example/blog/domain/auth/AuthServiceTest.java
+++ b/jihoonkang/src/test/java/com/example/blog/domain/auth/AuthServiceTest.java
@@ -5,6 +5,7 @@ import com.example.blog.domain.auth.dto.SignUpRequest;
 import com.example.blog.domain.auth.entity.RefreshToken;
 import com.example.blog.domain.auth.repository.RefreshTokenRepository;
 import com.example.blog.domain.auth.service.AuthService;
+import com.example.blog.domain.user.entity.Provider;
 import com.example.blog.domain.user.entity.Role;
 import com.example.blog.domain.user.entity.User;
 import com.example.blog.domain.user.repository.UserRepository;
@@ -50,7 +51,7 @@ class AuthServiceTest {
 
     @Test
     void signUp_이메일_중복_예외() {
-        given(userRepository.existsByEmail("dup@example.com")).willReturn(true);
+        given(userRepository.existsByEmailAndProvider("dup@example.com", Provider.LOCAL)).willReturn(true);
 
         SignUpRequest request = new SignUpRequest("dup@example.com", "pass123", "닉네임", null);
 
@@ -62,7 +63,7 @@ class AuthServiceTest {
 
     @Test
     void signUp_닉네임_중복_예외() {
-        given(userRepository.existsByEmail(anyString())).willReturn(false);
+        given(userRepository.existsByEmailAndProvider(anyString(), any(Provider.class))).willReturn(false);
         given(userRepository.existsByUsername("중복닉네임")).willReturn(true);
 
         SignUpRequest request = new SignUpRequest("new@example.com", "pass123", "중복닉네임", null);
@@ -87,7 +88,7 @@ class AuthServiceTest {
 
     @Test
     void login_비밀번호_불일치_예외() {
-        User user = User.of("지훈", "jihoon@example.com", "hashedPw", null);
+        User user = User.ofLocal("지훈", "jihoon@example.com", "hashedPw", null);
         given(userRepository.findByEmail("jihoon@example.com")).willReturn(Optional.of(user));
         given(passwordEncoder.matches("wrongPw", "hashedPw")).willReturn(false);
 


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

- [x] 카카오 OAuth 로그인 (`GET /oauth/kakao/login` → 카카오 인가 페이지 302 리다이렉트)
- [x] 카카오 콜백 처리 (`GET /oauth/kakao/callback` → 자체 AT/RT 발급)
- [x] 신규 유저 자동 가입 (카카오 첫 로그인 시 users 테이블에 자동 생성)
- [x] 기존 유저 로그인 (provider + providerId로 기존 계정 매칭)
- [x] accessToken 응답 바디 반환, refreshToken HttpOnly 쿠키 발급
- [x] 카카오 로그아웃 (`GET /oauth/kakao/logout/start` → 카카오 로그아웃 후 RT 삭제)


## 2. 핵심 변경 사항

**신규 파일**
- `Provider.java` — LOCAL/KAKAO enum
- `KakaoOAuthClient.java` — WebClient로 카카오 토큰 교환 + 사용자 정보 조회
- `KakaoTokenResponse.java`, `KakaoUserInfo.java` — 카카오 API 응답 DTO
- `OAuthController.java` — `/oauth/kakao/**` 엔드포인트
- `WebClientConfig.java` — Reactor Netty HttpClient 설정 (macOS DNS 리졸버)

**수정 파일**
- `User.java` — provider, providerId 필드 추가, password nullable, email unique 제거
- `UserRepository.java` — `findByProviderAndProviderId`, `existsByEmailAndProvider` 추가
- `AuthService.java` — `kakaoCallback`, `logout` 메서드 추가
- `SecurityConfig.java` — `/oauth/kakao/**` permitAll, CORS 설정 추가
- `application.properties` — 카카오 OAuth 프로퍼티 추가

**설계 결정**
- Spring Security OAuth2 Client 미사용 → WebClient 직접 구현 (학습 목적)
- LOCAL/KAKAO 계정 별도 분리 (같은 이메일이어도 독립 계정 허용)
- username 중복 시 `nickname_<providerId>` 폴백


## 3. 실행 및 검증 결과

**환경변수 설정 후 실행**
```bash
KAKAO_CLIENT_ID={REST_API_KEY} KAKAO_CLIENT_SECRET={시크릿키} ./gradlew bootRun
```

**카카오 로그인 흐름**
```
GET /oauth/kakao/login
  → 302 https://kauth.kakao.com/oauth/authorize?...
  → (카카오 로그인 + 동의)
  → GET /oauth/kakao/callback?code=...
  → 200 {"status":"success","data":{"access_token":"eyJ..."}}
    + Set-Cookie: refreshToken=...; HttpOnly; SameSite=Lax
```

**발급된 AT로 보호 API 호출 결과**
```json
GET /api/v1/users/1
Authorization: Bearer eyJ...

200 OK
{"status":"success","data":{"user_id":1,"username":"강지훈","email":"...","role":"USER"}}
```

**카카오 로그아웃 흐름**
```
GET /oauth/kakao/logout/start
  → 302 https://kauth.kakao.com/oauth/logout?...
  → GET /oauth/kakao/logout
  → 200 {"status":"success","data":null} + RT 쿠키 초기화
```

**테스트 결과**: 전체 25개 통과 (`./gradlew test`)

<img width="955" height="964" alt="스크린샷 2026-05-19 오후 9 38 16" src="https://github.com/user-attachments/assets/2054d33b-e282-44b0-afff-8cd8e19d6003" />
<img width="955" height="964" alt="스크린샷 2026-05-19 오후 9 38 22" src="https://github.com/user-attachments/assets/a540e865-e026-4108-95d6-cd433a4bb0e6" />
<img width="955" height="964" alt="스크린샷 2026-05-19 오후 9 38 40" src="https://github.com/user-attachments/assets/c83b2aa9-9f6b-4c22-9b1a-1e305ab851bd" />
<img width="955" height="964" alt="스크린샷 2026-05-19 오후 9 38 42" src="https://github.com/user-attachments/assets/5fe67249-dda5-4783-861a-87c8629a82d3" />

## 4. 완료 사항

1. 카카오 OAuth Authorization Code Grant 구현 (WebClient 직접 호출)
2. 신규/기존 유저 분기 처리 및 자동 가입
3. 기존 JWT 구조(AT 응답 바디 + RT HttpOnly 쿠키) 재사용
4. macOS WebClient DNS 리졸버 오류 수정 및 CORS 설정
5. 카카오 DTO snake_case `@JsonProperty` 역직렬화 수정
6. 카카오 로그아웃 구현 (RT DB 삭제 + 쿠키 초기화)
7. 카카오 OAuth 단위·통합 테스트 추가 (5개)


## 5. 추가 사항

- 카카오 이메일 미동의 시 `kakao_{providerId}@kakao.local` 폴백 이메일 사용
- `spring.jackson.property-naming-strategy=SNAKE_CASE`는 Spring MVC ObjectMapper에만 적용되고 WebClient에는 미적용 → `@JsonProperty`로 명시적 매핑 필요


## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `강지훈/main` 브랜치다
- [x] compare가 `강지훈/6주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [x] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다
