### PR TITLE
[7주차] 한하람/[feat] 카카오 OAuth 로그인

### DIFF
--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/AuthenticationController.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/AuthenticationController.java
@@ -1,6 +1,8 @@
 package com.leets.blog.authentication.adapter.in.web;
 
+import com.leets.blog.authentication.adapter.in.web.dto.request.KakaoLoginRequest;
 import com.leets.blog.authentication.adapter.in.web.dto.request.LoginRequest;
+import com.leets.blog.authentication.adapter.in.web.dto.request.RefreshTokenRequest;
 import com.leets.blog.authentication.adapter.in.web.dto.request.SignUpRequest;
 import com.leets.blog.authentication.adapter.in.web.dto.response.AuthResponse;
 import com.leets.blog.authentication.application.port.in.command.AuthenticateMemberUseCase;
@@ -33,5 +35,17 @@ public class AuthenticationController {
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하고 JWT를 발급합니다.")
     public AuthResponse login(@Valid @RequestBody LoginRequest request) {
         return AuthResponse.from(authenticateMemberUseCase.login(request.toCommand()));
+    }
+
+    @PostMapping("/login/kakao")
+    @Operation(summary = "카카오 로그인", description = "카카오 authorization code를 받아 로그인 또는 자동 회원가입을 진행합니다.")
+    public AuthResponse kakaoLogin(@Valid @RequestBody KakaoLoginRequest request) {
+        return AuthResponse.from(authenticateMemberUseCase.loginWithKakao(request.toCommand()));
+    }
+
+    @PostMapping("/refresh")
+    @Operation(summary = "토큰 재발급", description = "리프레시 토큰으로 access token과 refresh token을 모두 재발급합니다.")
+    public AuthResponse refresh(@Valid @RequestBody RefreshTokenRequest request) {
+        return AuthResponse.from(authenticateMemberUseCase.refreshTokens(request.toCommand()));
     }
 }

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/dto/request/KakaoLoginRequest.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,16 @@
+package com.leets.blog.authentication.adapter.in.web.dto.request;
+
+import com.leets.blog.authentication.application.port.in.command.dto.KakaoLoginCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "카카오 로그인 요청")
+public record KakaoLoginRequest(
+        @Schema(description = "카카오 authorization code", example = "SplxlOBeZQQYbYS6WxSbIA")
+        @NotBlank(message = "카카오 인가 코드는 필수입니다.")
+        String authorizationCode
+) {
+    public KakaoLoginCommand toCommand() {
+        return new KakaoLoginCommand(authorizationCode);
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/dto/request/RefreshTokenRequest.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/in/web/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,16 @@
+package com.leets.blog.authentication.adapter.in.web.dto.request;
+
+import com.leets.blog.authentication.application.port.in.command.dto.RefreshTokenCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "리프레시 토큰 재발급 요청")
+public record RefreshTokenRequest(
+        @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
+        @NotBlank(message = "리프레시 토큰은 필수입니다.")
+        String refreshToken
+) {
+    public RefreshTokenCommand toCommand() {
+        return new RefreshTokenCommand(refreshToken);
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/external/KakaoOAuthAdapter.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/external/KakaoOAuthAdapter.java
@@ -5,11 +5,14 @@ import com.leets.blog.authentication.application.port.out.VerifyKakaoOAuthPort;
 import com.leets.blog.authentication.application.port.out.dto.KakaoOAuthUserInfo;
 import com.leets.blog.authentication.domain.exception.AuthenticationDomainException;
 import com.leets.blog.authentication.domain.exception.AuthenticationErrorCode;
-import java.util.Objects;
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -39,10 +42,18 @@ public class KakaoOAuthAdapter implements VerifyKakaoOAuthPort {
         this.redirectUri = redirectUri;
     }
 
+    @PostConstruct
+    public void validateKakaoConfig() {
+        if (clientId == null || clientId.isBlank() || redirectUri == null || redirectUri.isBlank()) {
+            throw new AuthenticationDomainException(
+                    AuthenticationErrorCode.OAUTH_CONFIGURATION_MISSING,
+                    "카카오 OAuth 설정이 누락되었습니다."
+            );
+        }
+    }
+
     @Override
     public KakaoOAuthUserInfo verifyAuthorizationCode(String authorizationCode) {
-        validateKakaoConfig();
-
         String accessToken = exchangeAuthorizationCode(authorizationCode);
         KakaoUserResponse userResponse = getUserInfo(accessToken);
 
@@ -86,7 +97,8 @@ public class KakaoOAuthAdapter implements VerifyKakaoOAuthPort {
                     .body(formData)
                     .retrieve()
                     .onStatus(HttpStatusCode::isError, (req, res) -> {
-                        log.error("Kakao 토큰 교환 실패: status={}", res.getStatusCode());
+                        String responseBody = readResponseBody(res);
+                        log.error("Kakao 토큰 교환 실패: status={}, body={}", res.getStatusCode(), responseBody);
                         throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
                     })
                     .body(KakaoTokenResponse.class);
@@ -96,8 +108,6 @@ public class KakaoOAuthAdapter implements VerifyKakaoOAuthPort {
             }
 
             return response.accessToken();
-        } catch (AuthenticationDomainException e) {
-            throw e;
         } catch (Exception e) {
             log.error("Kakao 토큰 교환 중 오류 발생", e);
             throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
@@ -111,24 +121,23 @@ public class KakaoOAuthAdapter implements VerifyKakaoOAuthPort {
                     .header("Authorization", "Bearer " + accessToken)
                     .retrieve()
                     .onStatus(HttpStatusCode::isError, (req, res) -> {
-                        log.error("Kakao 사용자 정보 조회 실패: status={}", res.getStatusCode());
+                        String responseBody = readResponseBody(res);
+                        log.error("Kakao 사용자 정보 조회 실패: status={}, body={}", res.getStatusCode(), responseBody);
                         throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
                     })
                     .body(KakaoUserResponse.class);
-        } catch (AuthenticationDomainException e) {
-            throw e;
         } catch (Exception e) {
             log.error("Kakao 사용자 정보 조회 중 오류 발생", e);
             throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
         }
     }
 
-    private void validateKakaoConfig() {
-        if (clientId == null || clientId.isBlank() || redirectUri == null || redirectUri.isBlank()) {
-            throw new AuthenticationDomainException(
-                    AuthenticationErrorCode.OAUTH_CONFIGURATION_MISSING,
-                    "카카오 OAuth 설정이 누락되었습니다."
-            );
+    private String readResponseBody(ClientHttpResponse response) {
+        try {
+            return new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            log.error("Kakao 응답 body 읽기 실패", e);
+            return "<unreadable>";
         }
     }
 

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/external/KakaoOAuthAdapter.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/external/KakaoOAuthAdapter.java
@@ -1,0 +1,158 @@
+package com.leets.blog.authentication.adapter.out.external;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.leets.blog.authentication.application.port.out.VerifyKakaoOAuthPort;
+import com.leets.blog.authentication.application.port.out.dto.KakaoOAuthUserInfo;
+import com.leets.blog.authentication.domain.exception.AuthenticationDomainException;
+import com.leets.blog.authentication.domain.exception.AuthenticationErrorCode;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class KakaoOAuthAdapter implements VerifyKakaoOAuthPort {
+
+    private static final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    private final RestClient restClient;
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
+
+    public KakaoOAuthAdapter(
+            RestClient.Builder restClientBuilder,
+            @Value("${app.oauth.kakao.client-id:}") String clientId,
+            @Value("${app.oauth.kakao.client-secret:}") String clientSecret,
+            @Value("${app.oauth.kakao.redirect-uri:}") String redirectUri
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+    }
+
+    @Override
+    public KakaoOAuthUserInfo verifyAuthorizationCode(String authorizationCode) {
+        validateKakaoConfig();
+
+        String accessToken = exchangeAuthorizationCode(authorizationCode);
+        KakaoUserResponse userResponse = getUserInfo(accessToken);
+
+        if (userResponse == null || userResponse.id() == null) {
+            throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
+        }
+
+        String email = null;
+        String nickname = null;
+
+        if (userResponse.kakaoAccount() != null) {
+            email = userResponse.kakaoAccount().email();
+
+            if (userResponse.kakaoAccount().profile() != null) {
+                nickname = userResponse.kakaoAccount().profile().nickname();
+            }
+        }
+
+        return new KakaoOAuthUserInfo(
+                String.valueOf(userResponse.id()),
+                email,
+                nickname
+        );
+    }
+
+    private String exchangeAuthorizationCode(String authorizationCode) {
+        try {
+            MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+            formData.add("grant_type", "authorization_code");
+            formData.add("client_id", clientId);
+            formData.add("redirect_uri", redirectUri);
+            formData.add("code", authorizationCode);
+
+            if (clientSecret != null && !clientSecret.isBlank()) {
+                formData.add("client_secret", clientSecret);
+            }
+
+            KakaoTokenResponse response = restClient.post()
+                    .uri(KAKAO_TOKEN_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(formData)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, res) -> {
+                        log.error("Kakao 토큰 교환 실패: status={}", res.getStatusCode());
+                        throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
+                    })
+                    .body(KakaoTokenResponse.class);
+
+            if (response == null || response.accessToken() == null || response.accessToken().isBlank()) {
+                throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
+            }
+
+            return response.accessToken();
+        } catch (AuthenticationDomainException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Kakao 토큰 교환 중 오류 발생", e);
+            throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+
+    private KakaoUserResponse getUserInfo(String accessToken) {
+        try {
+            return restClient.get()
+                    .uri(KAKAO_USER_INFO_URL)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, res) -> {
+                        log.error("Kakao 사용자 정보 조회 실패: status={}", res.getStatusCode());
+                        throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
+                    })
+                    .body(KakaoUserResponse.class);
+        } catch (AuthenticationDomainException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Kakao 사용자 정보 조회 중 오류 발생", e);
+            throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+
+    private void validateKakaoConfig() {
+        if (clientId == null || clientId.isBlank() || redirectUri == null || redirectUri.isBlank()) {
+            throw new AuthenticationDomainException(
+                    AuthenticationErrorCode.OAUTH_CONFIGURATION_MISSING,
+                    "카카오 OAuth 설정이 누락되었습니다."
+            );
+        }
+    }
+
+    private record KakaoTokenResponse(
+            @JsonProperty("access_token")
+            String accessToken
+    ) {
+    }
+
+    private record KakaoUserResponse(
+            Long id,
+            @JsonProperty("kakao_account")
+            KakaoAccount kakaoAccount
+    ) {
+    }
+
+    private record KakaoAccount(
+            String email,
+            Profile profile
+    ) {
+    }
+
+    private record Profile(
+            String nickname
+    ) {
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/external/KakaoOAuthAdapter.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/external/KakaoOAuthAdapter.java
@@ -9,6 +9,7 @@ import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -31,12 +32,12 @@ public class KakaoOAuthAdapter implements VerifyKakaoOAuthPort {
     private final String redirectUri;
 
     public KakaoOAuthAdapter(
-            RestClient.Builder restClientBuilder,
+            @Qualifier("kakaoRestClient") RestClient restClient,
             @Value("${app.oauth.kakao.client-id:}") String clientId,
             @Value("${app.oauth.kakao.client-secret:}") String clientSecret,
             @Value("${app.oauth.kakao.redirect-uri:}") String redirectUri
     ) {
-        this.restClient = restClientBuilder.build();
+        this.restClient = restClient;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.redirectUri = redirectUri;

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/MemberOAuthPersistenceAdapter.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/MemberOAuthPersistenceAdapter.java
@@ -1,0 +1,29 @@
+package com.leets.blog.authentication.adapter.out.persistence;
+
+import com.leets.blog.authentication.adapter.out.persistence.entity.MemberOAuthJpaEntity;
+import com.leets.blog.authentication.application.port.out.LoadMemberOAuthPort;
+import com.leets.blog.authentication.application.port.out.SaveMemberOAuthPort;
+import com.leets.blog.authentication.domain.MemberOAuth;
+import com.leets.blog.authentication.domain.enums.OAuthProvider;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberOAuthPersistenceAdapter implements LoadMemberOAuthPort, SaveMemberOAuthPort {
+
+    private final MemberOAuthRepository memberOAuthRepository;
+
+    @Override
+    public Optional<MemberOAuth> findByProviderAndProviderId(OAuthProvider provider, String providerId) {
+        return memberOAuthRepository.findByProviderAndProviderId(provider, providerId)
+                .map(MemberOAuthJpaEntity::toDomain);
+    }
+
+    @Override
+    public MemberOAuth save(MemberOAuth memberOAuth) {
+        MemberOAuthJpaEntity saved = memberOAuthRepository.save(MemberOAuthJpaEntity.from(memberOAuth));
+        return saved.toDomain();
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/MemberOAuthRepository.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/MemberOAuthRepository.java
@@ -1,0 +1,10 @@
+package com.leets.blog.authentication.adapter.out.persistence;
+
+import com.leets.blog.authentication.adapter.out.persistence.entity.MemberOAuthJpaEntity;
+import com.leets.blog.authentication.domain.enums.OAuthProvider;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberOAuthRepository extends JpaRepository<MemberOAuthJpaEntity, Long> {
+    Optional<MemberOAuthJpaEntity> findByProviderAndProviderId(OAuthProvider provider, String providerId);
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/MemberRefreshTokenPersistenceAdapter.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/MemberRefreshTokenPersistenceAdapter.java
@@ -1,0 +1,28 @@
+package com.leets.blog.authentication.adapter.out.persistence;
+
+import com.leets.blog.authentication.adapter.out.persistence.entity.MemberRefreshTokenJpaEntity;
+import com.leets.blog.authentication.application.port.out.ConsumeMemberRefreshTokenPort;
+import com.leets.blog.authentication.application.port.out.SaveMemberRefreshTokenPort;
+import com.leets.blog.authentication.domain.MemberRefreshToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberRefreshTokenPersistenceAdapter implements SaveMemberRefreshTokenPort, ConsumeMemberRefreshTokenPort {
+
+    private final MemberRefreshTokenRepository memberRefreshTokenRepository;
+
+    @Override
+    public MemberRefreshToken save(MemberRefreshToken memberRefreshToken) {
+        MemberRefreshTokenJpaEntity saved = memberRefreshTokenRepository.save(
+                MemberRefreshTokenJpaEntity.from(memberRefreshToken)
+        );
+        return saved.toDomain();
+    }
+
+    @Override
+    public boolean consume(String tokenId, Long memberId) {
+        return memberRefreshTokenRepository.deleteByTokenIdAndMemberId(tokenId, memberId) > 0;
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/MemberRefreshTokenRepository.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/MemberRefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.leets.blog.authentication.adapter.out.persistence;
+
+import com.leets.blog.authentication.adapter.out.persistence.entity.MemberRefreshTokenJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRefreshTokenRepository extends JpaRepository<MemberRefreshTokenJpaEntity, Long> {
+    long deleteByTokenIdAndMemberId(String tokenId, Long memberId);
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/entity/MemberOAuthJpaEntity.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/entity/MemberOAuthJpaEntity.java
@@ -1,0 +1,62 @@
+package com.leets.blog.authentication.adapter.out.persistence.entity;
+
+import com.leets.blog.authentication.domain.MemberOAuth;
+import com.leets.blog.authentication.domain.enums.OAuthProvider;
+import com.leets.blog.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member_oauth")
+public class MemberOAuthJpaEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false)
+    private OAuthProvider provider;
+
+    @Column(name = "provider_id", nullable = false)
+    private String providerId;
+
+    @Builder
+    private MemberOAuthJpaEntity(Long memberId, OAuthProvider provider, String providerId) {
+        this.memberId = memberId;
+        this.provider = provider;
+        this.providerId = providerId;
+    }
+
+    public static MemberOAuthJpaEntity from(MemberOAuth memberOAuth) {
+        return MemberOAuthJpaEntity.builder()
+                .memberId(memberOAuth.getMemberId())
+                .provider(memberOAuth.getProvider())
+                .providerId(memberOAuth.getProviderId())
+                .build();
+    }
+
+    public MemberOAuth toDomain() {
+        return MemberOAuth.reconstruct(
+                this.id,
+                this.memberId,
+                this.provider,
+                this.providerId
+        );
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/entity/MemberOAuthJpaEntity.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/entity/MemberOAuthJpaEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +20,15 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "member_oauth")
+@Table(
+        name = "member_oauth",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_provider_provider_id",
+                        columnNames = {"provider", "provider_id"}
+                )
+        }
+)
 public class MemberOAuthJpaEntity extends BaseEntity {
 
     @Id

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/entity/MemberRefreshTokenJpaEntity.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/entity/MemberRefreshTokenJpaEntity.java
@@ -36,7 +36,6 @@ public class MemberRefreshTokenJpaEntity extends BaseEntity {
     @Column(name = "token_id", nullable = false, length = 100)
     private String tokenId;
 
-    // 만료 시각을 남겨두면 운영에서 만료 토큰 정리 배치를 붙이기 쉽습니다.
     @Column(name = "expires_at", nullable = false)
     private LocalDateTime expiresAt;
 

--- a/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/entity/MemberRefreshTokenJpaEntity.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/adapter/out/persistence/entity/MemberRefreshTokenJpaEntity.java
@@ -1,0 +1,66 @@
+package com.leets.blog.authentication.adapter.out.persistence.entity;
+
+import com.leets.blog.authentication.domain.MemberRefreshToken;
+import com.leets.blog.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "member_refresh_token",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_member_refresh_token_token_id", columnNames = "token_id")
+        }
+)
+public class MemberRefreshTokenJpaEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "token_id", nullable = false, length = 100)
+    private String tokenId;
+
+    // 만료 시각을 남겨두면 운영에서 만료 토큰 정리 배치를 붙이기 쉽습니다.
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Builder
+    private MemberRefreshTokenJpaEntity(Long memberId, String tokenId, LocalDateTime expiresAt) {
+        this.memberId = memberId;
+        this.tokenId = tokenId;
+        this.expiresAt = expiresAt;
+    }
+
+    public static MemberRefreshTokenJpaEntity from(MemberRefreshToken memberRefreshToken) {
+        return MemberRefreshTokenJpaEntity.builder()
+                .memberId(memberRefreshToken.getMemberId())
+                .tokenId(memberRefreshToken.getTokenId())
+                .expiresAt(memberRefreshToken.getExpiresAt())
+                .build();
+    }
+
+    public MemberRefreshToken toDomain() {
+        return MemberRefreshToken.reconstruct(
+                id,
+                memberId,
+                tokenId,
+                expiresAt
+        );
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/port/in/command/AuthenticateMemberUseCase.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/port/in/command/AuthenticateMemberUseCase.java
@@ -2,10 +2,16 @@ package com.leets.blog.authentication.application.port.in.command;
 
 import com.leets.blog.authentication.application.port.in.command.dto.LoginCommand;
 import com.leets.blog.authentication.application.port.in.command.dto.LoginResult;
+import com.leets.blog.authentication.application.port.in.command.dto.KakaoLoginCommand;
+import com.leets.blog.authentication.application.port.in.command.dto.RefreshTokenCommand;
 import com.leets.blog.authentication.application.port.in.command.dto.SignUpCommand;
 
 public interface AuthenticateMemberUseCase {
     LoginResult signUp(SignUpCommand command);
 
     LoginResult login(LoginCommand command);
+
+    LoginResult loginWithKakao(KakaoLoginCommand command);
+
+    LoginResult refreshTokens(RefreshTokenCommand command);
 }

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/port/in/command/dto/KakaoLoginCommand.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/port/in/command/dto/KakaoLoginCommand.java
@@ -1,0 +1,11 @@
+package com.leets.blog.authentication.application.port.in.command.dto;
+
+import java.util.Objects;
+
+public record KakaoLoginCommand(
+        String authorizationCode
+) {
+    public KakaoLoginCommand {
+        Objects.requireNonNull(authorizationCode, "카카오 인가 코드는 필수입니다.");
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/port/in/command/dto/RefreshTokenCommand.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/port/in/command/dto/RefreshTokenCommand.java
@@ -1,0 +1,11 @@
+package com.leets.blog.authentication.application.port.in.command.dto;
+
+import java.util.Objects;
+
+public record RefreshTokenCommand(
+        String refreshToken
+) {
+    public RefreshTokenCommand {
+        Objects.requireNonNull(refreshToken, "리프레시 토큰은 필수입니다.");
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/port/out/ConsumeMemberRefreshTokenPort.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/port/out/ConsumeMemberRefreshTokenPort.java
@@ -1,0 +1,5 @@
+package com.leets.blog.authentication.application.port.out;
+
+public interface ConsumeMemberRefreshTokenPort {
+    boolean consume(String tokenId, Long memberId);
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/port/out/LoadMemberOAuthPort.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/port/out/LoadMemberOAuthPort.java
@@ -1,0 +1,9 @@
+package com.leets.blog.authentication.application.port.out;
+
+import com.leets.blog.authentication.domain.MemberOAuth;
+import com.leets.blog.authentication.domain.enums.OAuthProvider;
+import java.util.Optional;
+
+public interface LoadMemberOAuthPort {
+    Optional<MemberOAuth> findByProviderAndProviderId(OAuthProvider provider, String providerId);
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/port/out/SaveMemberOAuthPort.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/port/out/SaveMemberOAuthPort.java
@@ -1,0 +1,7 @@
+package com.leets.blog.authentication.application.port.out;
+
+import com.leets.blog.authentication.domain.MemberOAuth;
+
+public interface SaveMemberOAuthPort {
+    MemberOAuth save(MemberOAuth memberOAuth);
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/port/out/SaveMemberRefreshTokenPort.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/port/out/SaveMemberRefreshTokenPort.java
@@ -1,0 +1,7 @@
+package com.leets.blog.authentication.application.port.out;
+
+import com.leets.blog.authentication.domain.MemberRefreshToken;
+
+public interface SaveMemberRefreshTokenPort {
+    MemberRefreshToken save(MemberRefreshToken memberRefreshToken);
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/port/out/VerifyKakaoOAuthPort.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/port/out/VerifyKakaoOAuthPort.java
@@ -1,0 +1,7 @@
+package com.leets.blog.authentication.application.port.out;
+
+import com.leets.blog.authentication.application.port.out.dto.KakaoOAuthUserInfo;
+
+public interface VerifyKakaoOAuthPort {
+    KakaoOAuthUserInfo verifyAuthorizationCode(String authorizationCode);
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/port/out/dto/KakaoOAuthUserInfo.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/port/out/dto/KakaoOAuthUserInfo.java
@@ -1,0 +1,8 @@
+package com.leets.blog.authentication.application.port.out.dto;
+
+public record KakaoOAuthUserInfo(
+        String providerId,
+        String email,
+        String nickname
+) {
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/service/AuthenticationService.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/service/AuthenticationService.java
@@ -6,11 +6,14 @@ import com.leets.blog.authentication.application.port.in.command.dto.LoginComman
 import com.leets.blog.authentication.application.port.in.command.dto.LoginResult;
 import com.leets.blog.authentication.application.port.in.command.dto.RefreshTokenCommand;
 import com.leets.blog.authentication.application.port.in.command.dto.SignUpCommand;
+import com.leets.blog.authentication.application.port.out.ConsumeMemberRefreshTokenPort;
 import com.leets.blog.authentication.application.port.out.LoadMemberOAuthPort;
+import com.leets.blog.authentication.application.port.out.SaveMemberRefreshTokenPort;
 import com.leets.blog.authentication.application.port.out.SaveMemberOAuthPort;
 import com.leets.blog.authentication.application.port.out.VerifyKakaoOAuthPort;
 import com.leets.blog.authentication.application.port.out.dto.KakaoOAuthUserInfo;
 import com.leets.blog.authentication.domain.MemberOAuth;
+import com.leets.blog.authentication.domain.MemberRefreshToken;
 import com.leets.blog.authentication.domain.enums.OAuthProvider;
 import com.leets.blog.authentication.domain.exception.AuthenticationDomainException;
 import com.leets.blog.authentication.domain.exception.AuthenticationErrorCode;
@@ -41,6 +44,8 @@ public class AuthenticationService implements AuthenticateMemberUseCase {
     private final SaveMemberAuthPort saveMemberAuthPort;
     private final LoadMemberOAuthPort loadMemberOAuthPort;
     private final SaveMemberOAuthPort saveMemberOAuthPort;
+    private final SaveMemberRefreshTokenPort saveMemberRefreshTokenPort;
+    private final ConsumeMemberRefreshTokenPort consumeMemberRefreshTokenPort;
     private final VerifyKakaoOAuthPort verifyKakaoOAuthPort;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
@@ -94,11 +99,17 @@ public class AuthenticationService implements AuthenticateMemberUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public LoginResult refreshTokens(RefreshTokenCommand command) {
-        Long memberId = jwtTokenProvider.parseRefreshToken(command.refreshToken());
+        JwtTokenProvider.ParsedRefreshToken parsedRefreshToken = jwtTokenProvider.parseRefreshToken(command.refreshToken());
+        boolean consumed = consumeMemberRefreshTokenPort.consume(
+                parsedRefreshToken.tokenId(),
+                parsedRefreshToken.memberId()
+        );
+        if (!consumed) {
+            throw new AuthenticationDomainException(AuthenticationErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
 
-        Member member = loadMemberAuthPort.findById(memberId)
+        Member member = loadMemberAuthPort.findById(parsedRefreshToken.memberId())
                 .orElseThrow(() -> new AuthenticationDomainException(AuthenticationErrorCode.MEMBER_NOT_FOUND));
 
         return issueTokens(member);
@@ -106,13 +117,22 @@ public class AuthenticationService implements AuthenticateMemberUseCase {
 
     private LoginResult issueTokens(Member member) {
         List<String> roles = List.of(member.getRole().name());
+        JwtTokenProvider.IssuedRefreshToken issuedRefreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+
+        saveMemberRefreshTokenPort.save(
+                MemberRefreshToken.create(
+                        member.getId(),
+                        issuedRefreshToken.tokenId(),
+                        issuedRefreshToken.expiresAt()
+                )
+        );
 
         return LoginResult.builder()
                 .memberId(member.getId())
                 .email(member.getEmail())
                 .nickname(member.getNickname())
                 .accessToken(jwtTokenProvider.createAccessToken(member.getId(), roles))
-                .refreshToken(jwtTokenProvider.createRefreshToken(member.getId()))
+                .refreshToken(issuedRefreshToken.token())
                 .build();
     }
 

--- a/hanharam/src/main/java/com/leets/blog/authentication/application/service/AuthenticationService.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/application/service/AuthenticationService.java
@@ -1,9 +1,17 @@
 package com.leets.blog.authentication.application.service;
 
 import com.leets.blog.authentication.application.port.in.command.AuthenticateMemberUseCase;
+import com.leets.blog.authentication.application.port.in.command.dto.KakaoLoginCommand;
 import com.leets.blog.authentication.application.port.in.command.dto.LoginCommand;
 import com.leets.blog.authentication.application.port.in.command.dto.LoginResult;
+import com.leets.blog.authentication.application.port.in.command.dto.RefreshTokenCommand;
 import com.leets.blog.authentication.application.port.in.command.dto.SignUpCommand;
+import com.leets.blog.authentication.application.port.out.LoadMemberOAuthPort;
+import com.leets.blog.authentication.application.port.out.SaveMemberOAuthPort;
+import com.leets.blog.authentication.application.port.out.VerifyKakaoOAuthPort;
+import com.leets.blog.authentication.application.port.out.dto.KakaoOAuthUserInfo;
+import com.leets.blog.authentication.domain.MemberOAuth;
+import com.leets.blog.authentication.domain.enums.OAuthProvider;
 import com.leets.blog.authentication.domain.exception.AuthenticationDomainException;
 import com.leets.blog.authentication.domain.exception.AuthenticationErrorCode;
 import com.leets.blog.global.security.JwtTokenProvider;
@@ -12,6 +20,7 @@ import com.leets.blog.member.application.port.out.SaveMemberAuthPort;
 import com.leets.blog.member.domain.Member;
 import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -30,6 +39,9 @@ public class AuthenticationService implements AuthenticateMemberUseCase {
 
     private final LoadMemberAuthPort loadMemberAuthPort;
     private final SaveMemberAuthPort saveMemberAuthPort;
+    private final LoadMemberOAuthPort loadMemberOAuthPort;
+    private final SaveMemberOAuthPort saveMemberOAuthPort;
+    private final VerifyKakaoOAuthPort verifyKakaoOAuthPort;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -70,6 +82,28 @@ public class AuthenticationService implements AuthenticateMemberUseCase {
         return issueTokens(member);
     }
 
+    @Override
+    public LoginResult loginWithKakao(KakaoLoginCommand command) {
+        KakaoOAuthUserInfo kakaoUserInfo = verifyKakaoOAuthPort.verifyAuthorizationCode(command.authorizationCode());
+
+        return loadMemberOAuthPort.findByProviderAndProviderId(OAuthProvider.KAKAO, kakaoUserInfo.providerId())
+                .map(memberOAuth -> loadMemberAuthPort.findById(memberOAuth.getMemberId())
+                        .orElseThrow(() -> new AuthenticationDomainException(AuthenticationErrorCode.MEMBER_NOT_FOUND)))
+                .map(this::issueTokens)
+                .orElseGet(() -> registerKakaoMemberOrRequireLink(kakaoUserInfo));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public LoginResult refreshTokens(RefreshTokenCommand command) {
+        Long memberId = jwtTokenProvider.parseRefreshToken(command.refreshToken());
+
+        Member member = loadMemberAuthPort.findById(memberId)
+                .orElseThrow(() -> new AuthenticationDomainException(AuthenticationErrorCode.MEMBER_NOT_FOUND));
+
+        return issueTokens(member);
+    }
+
     private LoginResult issueTokens(Member member) {
         List<String> roles = List.of(member.getRole().name());
 
@@ -80,6 +114,30 @@ public class AuthenticationService implements AuthenticateMemberUseCase {
                 .accessToken(jwtTokenProvider.createAccessToken(member.getId(), roles))
                 .refreshToken(jwtTokenProvider.createRefreshToken(member.getId()))
                 .build();
+    }
+
+    private LoginResult registerKakaoMemberOrRequireLink(KakaoOAuthUserInfo kakaoUserInfo) {
+        String email = resolveEmail(kakaoUserInfo);
+
+        if (loadMemberAuthPort.existsByEmail(email)) {
+            throw new AuthenticationDomainException(AuthenticationErrorCode.ACCOUNT_LINK_REQUIRED);
+        }
+
+        String nickname = resolveNickname(kakaoUserInfo);
+        Member savedMember = saveMemberAuthPort.save(
+                Member.create(
+                        nickname,
+                        nickname,
+                        email,
+                        passwordEncoder.encode(UUID.randomUUID().toString())
+                )
+        );
+
+        saveMemberOAuthPort.save(
+                MemberOAuth.create(savedMember.getId(), OAuthProvider.KAKAO, kakaoUserInfo.providerId())
+        );
+
+        return issueTokens(savedMember);
     }
 
     private void validateSignUpInput(String name, String nickname, String email, String password) {
@@ -111,5 +169,21 @@ public class AuthenticationService implements AuthenticateMemberUseCase {
 
     private String normalizeEmail(String email) {
         return email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String resolveEmail(KakaoOAuthUserInfo kakaoUserInfo) {
+        if (kakaoUserInfo.email() == null || kakaoUserInfo.email().isBlank()) {
+            return "kakao_" + kakaoUserInfo.providerId() + "@temp.oauth.local";
+        }
+
+        return normalizeEmail(kakaoUserInfo.email());
+    }
+
+    private String resolveNickname(KakaoOAuthUserInfo kakaoUserInfo) {
+        if (kakaoUserInfo.nickname() == null || kakaoUserInfo.nickname().isBlank()) {
+            return "kakao_" + kakaoUserInfo.providerId();
+        }
+
+        return kakaoUserInfo.nickname().trim();
     }
 }

--- a/hanharam/src/main/java/com/leets/blog/authentication/domain/MemberOAuth.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/domain/MemberOAuth.java
@@ -1,0 +1,35 @@
+package com.leets.blog.authentication.domain;
+
+import com.leets.blog.authentication.domain.enums.OAuthProvider;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberOAuth {
+
+    private final Long id;
+    private final Long memberId;
+    private final OAuthProvider provider;
+    private final String providerId;
+
+    public static MemberOAuth create(Long memberId, OAuthProvider provider, String providerId) {
+        return MemberOAuth.builder()
+                .memberId(memberId)
+                .provider(provider)
+                .providerId(providerId)
+                .build();
+    }
+
+    public static MemberOAuth reconstruct(Long id, Long memberId, OAuthProvider provider, String providerId) {
+        return MemberOAuth.builder()
+                .id(id)
+                .memberId(memberId)
+                .provider(provider)
+                .providerId(providerId)
+                .build();
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/domain/MemberRefreshToken.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/domain/MemberRefreshToken.java
@@ -1,0 +1,40 @@
+package com.leets.blog.authentication.domain;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberRefreshToken {
+
+    private final Long id;
+    private final Long memberId;
+    private final String tokenId;
+    private final LocalDateTime expiresAt;
+
+    public static MemberRefreshToken create(Long memberId, String tokenId, LocalDateTime expiresAt) {
+        return MemberRefreshToken.builder()
+                .memberId(memberId)
+                .tokenId(tokenId)
+                .expiresAt(expiresAt)
+                .build();
+    }
+
+    public static MemberRefreshToken reconstruct(
+            Long id,
+            Long memberId,
+            String tokenId,
+            LocalDateTime expiresAt
+    ) {
+        return MemberRefreshToken.builder()
+                .id(id)
+                .memberId(memberId)
+                .tokenId(tokenId)
+                .expiresAt(expiresAt)
+                .build();
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/domain/enums/OAuthProvider.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/domain/enums/OAuthProvider.java
@@ -1,0 +1,5 @@
+package com.leets.blog.authentication.domain.enums;
+
+public enum OAuthProvider {
+    KAKAO
+}

--- a/hanharam/src/main/java/com/leets/blog/authentication/domain/exception/AuthenticationErrorCode.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/domain/exception/AuthenticationErrorCode.java
@@ -22,7 +22,8 @@ public enum AuthenticationErrorCode implements BaseCode {
     INVALID_PROFILE_INPUT(HttpStatus.BAD_REQUEST, "AUTH-011", "이름과 닉네임은 필수입니다."),
     ACCOUNT_LINK_REQUIRED(HttpStatus.CONFLICT, "AUTH-012", "동일한 이메일의 계정이 존재합니다. 계정 연동 페이지에서 연동해주세요."),
     OAUTH_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH-013", "OAuth 인증 처리에 실패했습니다."),
-    OAUTH_CONFIGURATION_MISSING(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-014", "OAuth 설정이 누락되었습니다.");
+    OAUTH_CONFIGURATION_MISSING(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-014", "OAuth 설정이 누락되었습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-015", "저장된 리프레시 토큰을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/hanharam/src/main/java/com/leets/blog/authentication/domain/exception/AuthenticationErrorCode.java
+++ b/hanharam/src/main/java/com/leets/blog/authentication/domain/exception/AuthenticationErrorCode.java
@@ -13,13 +13,16 @@ public enum AuthenticationErrorCode implements BaseCode {
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "AUTH-002", "올바른 이메일 형식이 아닙니다."),
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "AUTH-003", "비밀번호는 8자 이상 64자 이하이며 영문과 숫자를 포함해야 합니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH-004", "이메일 또는 비밀번호가 올바르지 않습니다."),
-    INVALID_PROFILE_INPUT(HttpStatus.BAD_REQUEST, "AUTH-011", "이름과 닉네임은 필수입니다."),
     WRONG_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "AUTH-005", "잘못된 JWT 서명입니다."),
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-006", "만료된 JWT 토큰입니다."),
     UNSUPPORTED_JWT(HttpStatus.UNAUTHORIZED, "AUTH-007", "지원되지 않는 JWT 토큰입니다."),
     INVALID_JWT(HttpStatus.UNAUTHORIZED, "AUTH-008", "유효하지 않은 JWT 토큰입니다."),
     INVALID_AUTH_HEADER(HttpStatus.UNAUTHORIZED, "AUTH-009", "Authorization 헤더 형식이 올바르지 않습니다."),
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH-010", "회원을 찾을 수 없습니다.");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH-010", "회원을 찾을 수 없습니다."),
+    INVALID_PROFILE_INPUT(HttpStatus.BAD_REQUEST, "AUTH-011", "이름과 닉네임은 필수입니다."),
+    ACCOUNT_LINK_REQUIRED(HttpStatus.CONFLICT, "AUTH-012", "동일한 이메일의 계정이 존재합니다. 계정 연동 페이지에서 연동해주세요."),
+    OAUTH_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH-013", "OAuth 인증 처리에 실패했습니다."),
+    OAUTH_CONFIGURATION_MISSING(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-014", "OAuth 설정이 누락되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/hanharam/src/main/java/com/leets/blog/global/config/RestClientConfig.java
+++ b/hanharam/src/main/java/com/leets/blog/global/config/RestClientConfig.java
@@ -1,0 +1,26 @@
+package com.leets.blog.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean(name = "kakaoRestClient")
+    public RestClient kakaoRestClient(
+            RestClient.Builder restClientBuilder,
+            @Value("${app.oauth.kakao.connect-timeout-millis:3000}") int connectTimeoutMillis,
+            @Value("${app.oauth.kakao.read-timeout-millis:5000}") int readTimeoutMillis
+    ) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(connectTimeoutMillis);
+        requestFactory.setReadTimeout(readTimeoutMillis);
+
+        return restClientBuilder
+                .requestFactory(requestFactory)
+                .build();
+    }
+}

--- a/hanharam/src/main/java/com/leets/blog/global/config/SecurityConfig.java
+++ b/hanharam/src/main/java/com/leets/blog/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.leets.blog.global.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -38,8 +39,18 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(SWAGGER_PATHS).permitAll()
-                        .requestMatchers("/error", "/test/**", "/api/v1/auth/**").permitAll()
-                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/v1/posts/**").permitAll()
+                        .requestMatchers("/error").permitAll()
+                        .requestMatchers("/test/**").permitAll()
+                        .requestMatchers(HttpMethod.POST,
+                                "/api/v1/auth/signup",
+                                "/api/v1/auth/login",
+                                "/api/v1/auth/login/kakao",
+                                "/api/v1/auth/refresh")
+                        .permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/posts",
+                                "/api/v1/posts/*")
+                        .permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex.authenticationEntryPoint(apiAuthenticationEntryPoint))

--- a/hanharam/src/main/java/com/leets/blog/global/security/JwtTokenProvider.java
+++ b/hanharam/src/main/java/com/leets/blog/global/security/JwtTokenProvider.java
@@ -68,8 +68,17 @@ public class JwtTokenProvider {
         return validateToken(token, accessTokenSecret);
     }
 
+    public boolean validateRefreshToken(String token) {
+        return validateToken(token, refreshTokenSecret);
+    }
+
     public Long parseAccessToken(String token) {
         return Long.parseLong(parseClaims(token, accessTokenSecret).getSubject());
+    }
+
+    public Long parseRefreshToken(String token) {
+        validateRefreshToken(token);
+        return Long.parseLong(parseClaims(token, refreshTokenSecret).getSubject());
     }
 
     public List<String> getRolesFromAccessToken(String token) {

--- a/hanharam/src/main/java/com/leets/blog/global/security/JwtTokenProvider.java
+++ b/hanharam/src/main/java/com/leets/blog/global/security/JwtTokenProvider.java
@@ -9,9 +9,12 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -52,16 +55,24 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String createRefreshToken(Long memberId) {
+    public IssuedRefreshToken createRefreshToken(Long memberId) {
         Date now = new Date();
         Date validityDate = new Date(now.getTime() + refreshTokenValidityInMilliseconds);
+        String tokenId = UUID.randomUUID().toString();
 
-        return Jwts.builder()
+        String token = Jwts.builder()
+                .id(tokenId)
                 .subject(String.valueOf(memberId))
                 .issuedAt(now)
                 .expiration(validityDate)
                 .signWith(refreshTokenSecret)
                 .compact();
+
+        return new IssuedRefreshToken(
+                token,
+                tokenId,
+                toLocalDateTime(validityDate)
+        );
     }
 
     public boolean validateAccessToken(String token) {
@@ -76,9 +87,19 @@ public class JwtTokenProvider {
         return Long.parseLong(parseClaims(token, accessTokenSecret).getSubject());
     }
 
-    public Long parseRefreshToken(String token) {
+    public ParsedRefreshToken parseRefreshToken(String token) {
         validateRefreshToken(token);
-        return Long.parseLong(parseClaims(token, refreshTokenSecret).getSubject());
+        Claims claims = parseClaims(token, refreshTokenSecret);
+        String tokenId = claims.getId();
+        if (tokenId == null || tokenId.isBlank()) {
+            throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_JWT);
+        }
+
+        return new ParsedRefreshToken(
+                Long.parseLong(claims.getSubject()),
+                tokenId,
+                toLocalDateTime(claims.getExpiration())
+        );
     }
 
     public List<String> getRolesFromAccessToken(String token) {
@@ -117,5 +138,25 @@ public class JwtTokenProvider {
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();
+    }
+
+    private LocalDateTime toLocalDateTime(Date date) {
+        return date.toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
+    }
+
+    public record IssuedRefreshToken(
+            String token,
+            String tokenId,
+            LocalDateTime expiresAt
+    ) {
+    }
+
+    public record ParsedRefreshToken(
+            Long memberId,
+            String tokenId,
+            LocalDateTime expiresAt
+    ) {
     }
 }

--- a/hanharam/src/main/java/com/leets/blog/member/adapter/out/persistence/MemberPersistenceAdapter.java
+++ b/hanharam/src/main/java/com/leets/blog/member/adapter/out/persistence/MemberPersistenceAdapter.java
@@ -43,6 +43,12 @@ public class MemberPersistenceAdapter implements LoadMemberPort, LoadMemberAuthP
     }
 
     @Override
+    public Optional<Member> findById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .map(MemberJpaEntity::toDomain);
+    }
+
+    @Override
     public Optional<Member> findByEmail(String email) {
         return memberRepository.findByEmail(email)
                 .map(MemberJpaEntity::toDomain);

--- a/hanharam/src/main/java/com/leets/blog/member/application/port/out/LoadMemberAuthPort.java
+++ b/hanharam/src/main/java/com/leets/blog/member/application/port/out/LoadMemberAuthPort.java
@@ -4,6 +4,8 @@ import com.leets.blog.member.domain.Member;
 import java.util.Optional;
 
 public interface LoadMemberAuthPort {
+    Optional<Member> findById(Long memberId);
+
     Optional<Member> findByEmail(String email);
 
     boolean existsByEmail(String email);

--- a/hanharam/src/main/resources/application.yml
+++ b/hanharam/src/main/resources/application.yml
@@ -9,3 +9,9 @@ jwt:
   refresh-token-secret: "local-refresh-token-secret-key-for-blog-project-2026"
   access-token-validity-in-seconds: 3600
   refresh-token-validity-in-seconds: 1209600
+
+app:
+  oauth:
+    kakao:
+      connect-timeout-millis: 3000
+      read-timeout-millis: 5000


### PR DESCRIPTION


## 1. 과제 요구사항 중 구현한 내용
카카오 로그인을 `authorization code -> 백엔드 토큰 교환` 방식으로 구현했습니다.  
SPA가 카카오 callback에서 `code`를 받은 뒤, 백엔드 `POST /api/v1/auth/login/kakao` API로 전달하면 서버가 카카오 토큰 교환, 사용자 정보 조회, 자동 회원가입/로그인, JWT 발급까지 처리하도록 구성했습니다.  
추가로 refresh token 기반 토큰 재발급 API도 함께 추가했습니다.


## 2. 핵심 변경 사항

**주요 변경 사항**
- `POST /api/v1/auth/login/kakao` 추가
- 카카오 `authorization code`를 백엔드가 직접 access token으로 교환
- 카카오 사용자 정보 조회 후 기존 연동 계정이면 바로 로그인
- 신규 카카오 사용자면 자동 회원가입 후 로그인
- 카카오 이메일이 없을 경우 임시 이메일(`kakao_{providerId}@temp.oauth.local`)로 자동 회원가입
- 동일 이메일의 일반 회원이 이미 존재하지만 카카오 연동 정보가 없으면 `AUTH-012` 반환
- 카카오 연동 정보 저장용 `member_oauth` 도입
- `POST /api/v1/auth/refresh` 추가
- refresh token으로 access/refresh token을 모두 재발급하는 rotation 흐름 추가
- 보안 설정을 실제 운영 기준에 가깝게 조정
  공개해야 하는 엔드포인트만 `permitAll`
  나머지는 인증 필요

**로그인 흐름**
1. 프론트가 카카오 authorize URL로 이동
2. 카카오가 SPA redirect URI로 `?code=...` 리다이렉트
3. 프론트가 `authorization code`를 읽어서 `POST /api/v1/auth/login/kakao` 호출
4. 백엔드가 카카오 토큰 교환 및 사용자 정보 조회
5. 기존 연동 회원이면 로그인
6. 신규 회원이면 자동 생성 후 로그인
7. access token / refresh token 반환

**정책**
- 카카오 로그인은 SPA callback -> 백엔드 API 전달 방식 사용
- 카카오 이메일이 없으면 임시 이메일 생성 후 가입
- 같은 이메일의 일반 회원이 이미 존재하면 자동 연동하지 않고 계정 연동 페이지로 유도
- refresh token 재발급 시 access token과 refresh token을 모두 다시 발급

**API**
카카오 로그인:
```http
POST /api/v1/auth/login/kakao
Content-Type: application/json

{
  "authorizationCode": "..."
}
```

토큰 재발급:
```http
POST /api/v1/auth/refresh
Content-Type: application/json

{
  "refreshToken": "..."
}
```

**에러 정책**
- `AUTH-012`
  동일한 이메일의 일반 회원이 이미 존재하고, 카카오 연동 정보는 없는 경우
  자동 로그인/자동 연동하지 않고 계정 연동 유도

- 운영 단계에서는 refresh token 저장소 기반 1회용 rotation으로 확장


## 3. 실행 및 검증 결과


<img width="582" height="955" alt="스크린샷 2026-05-19 시간: 21 01 10" src="https://github.com/user-attachments/assets/2f6246c1-e11d-4b09-9acf-bb8bc4ee6206" />

<img width="1106" height="240" alt="image" src="https://github.com/user-attachments/assets/df6c6ce0-0afa-4d94-b6ea-d5f35a5c26e9" />


## 4. 완료 사항

<!-- 완료한 작업을 번호 목록으로 작성해주세요. -->

1. 카카오 로그인
2. 토큰 재발급
3.


## 5. 추가 사항

- 관련 이슈: closed #279 


## 제출 체크리스트

- [ ] PR 제목이 규칙에 맞다
- [ ] base가 `{이름}/main` 브랜치다
- [ ] compare가 `{이름}/{숫자}주차` 브랜치다
- [ ] 프로젝트가 정상 실행된다
- [ ] 본인을 Assignee로 지정했다
- [ ] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고

<!--
BE: rootTiket, soyesenna
FE: One-HyeWon, woneeee
-->
