### PR TITLE
[7주차]/최유찬[feat] 카카오 OAuth 로그인

### DIFF
--- a/src/main/java/com/example/demo1/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/demo1/domain/auth/controller/AuthController.java
@@ -1,19 +1,25 @@
 package com.example.demo1.domain.auth.controller;
 
 import com.example.demo1.domain.auth.dto.LoginRequestDto;
-import com.example.demo1.domain.auth.dto.LoginResponseDto;
 import com.example.demo1.domain.auth.dto.SignupRequestDto;
+import com.example.demo1.domain.auth.dto.CommonResponseDto;
+import com.example.demo1.domain.auth.dto.KakaoLoginResponseDto;
+import com.example.demo1.domain.auth.dto.SwaggerOrderResponse;
 import com.example.demo1.domain.auth.service.AuthService;
 import com.example.demo1.global.security.JwtUtil;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap; // [추가]
-import java.util.Map;     // [추가]
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/auth")
@@ -33,45 +39,98 @@ public class AuthController {
     }
 
     /**
-     * 로그인 API
+     * 로그인 API -> success 맨 하단 정렬 적용
      */
     @PostMapping("/login")
-    public ResponseEntity<LoginResponseDto> login(
+    public ResponseEntity<?> login(
             @RequestBody LoginRequestDto dto,
             HttpServletResponse response
     ) {
-        Long userId = authService.login(dto);
+        Map<String, String> tokens = authService.loginAndGetTokens(dto);
+        String at = tokens.get("accessToken");
+        String rt = tokens.get("refreshToken");
 
-        String at = jwtUtil.createAccessToken(userId);
-        String rt = jwtUtil.createRefreshToken();
-
-        // RT를 쿠키에 담기 (보안 강화)
         ResponseCookie cookie = ResponseCookie.from("refreshToken", rt)
                 .httpOnly(true)
                 .secure(false)
                 .path("/")
                 .maxAge(14 * 24 * 60 * 60)
                 .build();
-
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-        return ResponseEntity.ok(new LoginResponseDto(at));
+        Map<String, Object> tokenMap = new HashMap<>();
+        tokenMap.put("accessToken", at);
+
+        return ResponseEntity.ok(new SwaggerOrderResponse("AUTH_2000", "로그인 성공", tokenMap));
     }
 
     /**
-     * 토큰 재발급 API
+     * 토큰 재발급 API -> 💡 컴파일 에러 유발하던 외부 onFailure 제거 후 완벽 대응
      */
     @PostMapping("/reissue")
-    public ResponseEntity<?> reissue(@RequestBody Map<String, String> request) {
-        // 바디에서 refreshToken 추출
+    public ResponseEntity<?> reissue(
+            @CookieValue(value = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response
+    ) {
+        // 쿠키에 리프레시 토큰이 아예 없는 경우 예외 처리
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new LocalErrorResponse("리프레시 토큰이 존재하지 않거나 만료되었습니다.", "AUTH_4040"));
+        }
+
+        try {
+            Map<String, String> newTokens = authService.reissueTokens(refreshToken);
+            String newAt = newTokens.get("accessToken");
+            String newRt = newTokens.get("refreshToken");
+
+            // 1. 새로 발급된 리프레시 토큰을 다시 쿠키에 저장
+            ResponseCookie cookie = ResponseCookie.from("refreshToken", newRt)
+                    .httpOnly(true)
+                    .secure(false) // HTTPS 적용 시 true로 변경
+                    .path("/")
+                    .maxAge(14 * 24 * 60 * 60)
+                    .build();
+            response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+            // 2. 프론트엔드(Swagger) 바디에는 보안을 위해 accessToken만 반환
+            Map<String, String> responseBody = new HashMap<>();
+            responseBody.put("accessToken", newAt);
+
+            return ResponseEntity.ok(new SwaggerOrderResponse("AUTH200_2", "토큰 재발급에 성공하였습니다.", responseBody));
+
+        } catch (AuthService.CustomAuthException ex) {
+            HttpStatus status = ex.getErrorCode().equals("AUTH_4040") ? HttpStatus.NOT_FOUND : HttpStatus.UNAUTHORIZED;
+            return ResponseEntity.status(status).body(new LocalErrorResponse(ex.getMessage(), ex.getErrorCode()));
+        }
+    }
+
+    /**
+     * 로그아웃 API
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@RequestBody Map<String, String> request) {
         String refreshToken = request.get("refreshToken");
+        authService.logout(refreshToken);
 
-        // 서비스에서 검증 및 새 AT 발급
-        String newAccessToken = authService.reissue(refreshToken);
+        return ResponseEntity.ok(new SwaggerOrderResponse("AUTH_2002", "로그아웃 성공", null));
+    }
 
-        Map<String, String> response = new HashMap<>();
-        response.put("accessToken", newAccessToken);
+    /**
+     * 카카오 소셜 로그인 콜백 API
+     */
+    @GetMapping("/oauth/kakao/callback")
+    public ResponseEntity<CommonResponseDto> kakaoCallback(@RequestParam("code") String code) {
+        KakaoLoginResponseDto loginResult = authService.kakaoLogin(code);
+        return ResponseEntity.ok(CommonResponseDto.onSuccess(loginResult));
+    }
 
-        return ResponseEntity.ok(response);
+    // --- 🏁 과제 에러 스크린샷 양식 {"success":false, "message":..., "code":...} 순서 정렬 전용 객체 ---
+    @Getter
+    @AllArgsConstructor
+    @JsonPropertyOrder({"success", "message", "code"})
+    public static class LocalErrorResponse {
+        private final boolean success = false;
+        private final String message;
+        private final String code;
     }
 }

--- a/src/main/java/com/example/demo1/domain/auth/dto/CommonResponseDto.java
+++ b/src/main/java/com/example/demo1/domain/auth/dto/CommonResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.demo1.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommonResponseDto {
+    private boolean isSuccess;
+    private String code;
+    private String message;
+    private Object result; // T 대신 모든 객체를 수용할 수 있는 Object로 변경
+
+    public static CommonResponseDto onSuccess(Object result) {
+        return new CommonResponseDto(true, "COMMON200", "요청에 성공하였습니다.", result);
+    }
+}

--- a/src/main/java/com/example/demo1/domain/auth/dto/KakaoLoginResponseDto.java
+++ b/src/main/java/com/example/demo1/domain/auth/dto/KakaoLoginResponseDto.java
@@ -2,12 +2,10 @@ package com.example.demo1.domain.auth.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
-public class LoginResponseDto {
+public class KakaoLoginResponseDto {
     private String accessToken;
-                private String refreshToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/example/demo1/domain/auth/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/example/demo1/domain/auth/dto/KakaoUserInfoDto.java
@@ -1,0 +1,24 @@
+package com.example.demo1.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfoDto {
+    private Long id;
+    private KakaoAccount kakao_account;
+
+    @Getter
+    @NoArgsConstructor
+    public static class KakaoAccount {
+        private Profile profile;
+        private String email;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Profile {
+        private String nickname;
+    }
+}

--- a/src/main/java/com/example/demo1/domain/auth/dto/ReissueRequestDto.java
+++ b/src/main/java/com/example/demo1/domain/auth/dto/ReissueRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.demo1.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReissueRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/com/example/demo1/domain/auth/dto/SwaggerFinalResponse.java
+++ b/src/main/java/com/example/demo1/domain/auth/dto/SwaggerFinalResponse.java
@@ -1,0 +1,36 @@
+package com.example.demo1.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class SwaggerFinalResponse {
+
+    @Getter
+    @AllArgsConstructor
+    @JsonPropertyOrder({"code", "message", "result", "success"})
+    public static class Success {
+        private final String code;
+        private final String message;
+        private final Object result;
+        private final boolean success = true;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @JsonPropertyOrder({"code", "message", "success"})
+    public static class SuccessWithoutResult {
+        private final String code;
+        private final String message;
+        private final boolean success = true;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @JsonPropertyOrder({"success", "message", "code"})
+    public static class Error {
+        private final boolean success = false;
+        private final String code;
+        private final String message;
+    }
+}

--- a/src/main/java/com/example/demo1/domain/auth/dto/SwaggerOrderResponse.java
+++ b/src/main/java/com/example/demo1/domain/auth/dto/SwaggerOrderResponse.java
@@ -1,0 +1,19 @@
+package com.example.demo1.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({"code", "message", "result", "success"}) // 💡 success를 무조건 맨 아래로 보내는 마법의 어노테이션
+public class SwaggerOrderResponse {
+    private final String code;
+    private final String message;
+    private final Object result;
+    private final boolean success = true;
+
+    public SwaggerOrderResponse(String code, String message, Object result) {
+        this.code = code;
+        this.message = message;
+        this.result = result;
+    }
+}

--- a/src/main/java/com/example/demo1/domain/auth/dto/SwaggerResponseDto.java
+++ b/src/main/java/com/example/demo1/domain/auth/dto/SwaggerResponseDto.java
@@ -1,0 +1,29 @@
+package com.example.demo1.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+public class SwaggerResponseDto {
+
+    // 💡 [성공 응답] code, message, result를 먼저 배치하고 success를 맨 뒤로 보냅니다.
+    @Getter
+    @AllArgsConstructor
+    @JsonPropertyOrder({"code", "message", "result", "success"})
+    public static class Success<T> {
+        private final String code;
+        private final String message;
+        private final T result;
+        private final boolean success = true;
+    }
+
+    // 💡 [에러 응답] 예시 화면의 {"success": false, "message": "...", "code": "..."} 구조 매핑
+    @Getter
+    @AllArgsConstructor
+    @JsonPropertyOrder({"success", "message", "code"})
+    public static class Error {
+        private final boolean success = false;
+        private final String message;
+        private final String code;
+    }
+}

--- a/src/main/java/com/example/demo1/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/demo1/domain/auth/service/AuthService.java
@@ -2,13 +2,23 @@ package com.example.demo1.domain.auth.service;
 
 import com.example.demo1.domain.auth.dto.LoginRequestDto;
 import com.example.demo1.domain.auth.dto.SignupRequestDto;
+import com.example.demo1.domain.auth.dto.KakaoUserInfoDto;
+import com.example.demo1.domain.auth.dto.KakaoLoginResponseDto;
 import com.example.demo1.domain.user.entity.User;
 import com.example.demo1.domain.user.repository.UserRepository;
-import com.example.demo1.global.security.JwtUtil; // [추가]
+import com.example.demo1.global.security.JwtUtil;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @RequiredArgsConstructor
@@ -16,7 +26,10 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final JwtUtil jwtUtil; // [추가] 토큰 검증 및 생성을 위해 주입이 필요합니다.
+    private final JwtUtil jwtUtil;
+
+    // 💡 과제 규격(재발급/로그아웃 상태 관리)을 위해 서버 메모리에 Refresh Token과 UserId 매핑 저장
+    private final ConcurrentHashMap<String, Long> refreshTokenStore = new ConcurrentHashMap<>();
 
     /**
      * 회원가입
@@ -38,7 +51,32 @@ public class AuthService {
     }
 
     /**
-     * 로그인 검증
+     * 로그인 검증 및 자체 토큰 매핑 저장 [6주차 기능 고도화]
+     */
+    @Transactional
+    public Map<String, String> loginAndGetTokens(LoginRequestDto dto) {
+        User user = userRepository.findByEmail(dto.getEmail())
+                .orElseThrow(() -> new RuntimeException("가입되지 않은 이메일입니다."));
+
+        if (!passwordEncoder.matches(dto.getPassword(), user.getPassword())) {
+            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+        }
+
+        Long userId = Long.valueOf(user.getId());
+        String accessToken = jwtUtil.createAccessToken(userId);
+        String refreshToken = jwtUtil.createRefreshToken();
+
+        // 재발급 및 로그아웃 검증용 스토어에 보관
+        refreshTokenStore.put(refreshToken, userId);
+
+        return Map.of(
+                "accessToken", accessToken,
+                "refreshToken", refreshToken
+        );
+    }
+
+    /**
+     * 구 버전 로그인 검증 (기존 컨트롤러 호환용 리턴)
      */
     @Transactional(readOnly = true)
     public Long login(LoginRequestDto dto) {
@@ -53,19 +91,153 @@ public class AuthService {
     }
 
     /**
-     * 토큰 재발급 로직
+     * 토큰 재발급 로직 [과제 요구사항 에러 규격 반영 완료]
      */
-    @Transactional(readOnly = true) // 데이터 조회 중심이므로 readOnly 추천
+    @Transactional
+    public Map<String, String> reissueTokens(String refreshToken) {
+        // 1. [오류 케이스: AUTH_4040] 저장소에 리프레시 토큰이 없거나 만료/로그아웃된 상태
+        if (refreshToken == null || !refreshTokenStore.containsKey(refreshToken)) {
+            throw new CustomAuthException("AUTH_4040", "리프레시 토큰이 존재하지 않거나 만료되었습니다.");
+        }
+
+        // 2. [오류 케이스: AUTH401_2] 토큰 자체의 JWT 유효성 검증 실패
+        if (!jwtUtil.validateToken(refreshToken)) {
+            throw new CustomAuthException("AUTH401_2", "유효하지 않은 Refresh Token입니다.");
+        }
+
+        Long userId = refreshTokenStore.get(refreshToken);
+
+        // 기존 토큰은 만료(삭제) 처리하고 새로 생성하여 발급 (보안 로테이션 정책)
+        refreshTokenStore.remove(refreshToken);
+
+        String newAccessToken = jwtUtil.createAccessToken(userId);
+        String newRefreshToken = jwtUtil.createRefreshToken();
+
+        refreshTokenStore.put(newRefreshToken, userId);
+
+        return Map.of(
+                "accessToken", newAccessToken,
+                "refreshToken", newRefreshToken
+        );
+    }
+
+    /**
+     * 기존 단일 reissue 메서드 백업 유지
+     */
+    @Transactional(readOnly = true)
     public String reissue(String refreshToken) {
-        // 1. Refresh Token 유효성 검사 (서명 및 만료 체크)
         if (refreshToken == null || !jwtUtil.validateToken(refreshToken)) {
             throw new RuntimeException("유효하지 않거나 만료된 리프레시 토큰입니다.");
         }
 
-        // 2. 토큰에서 유저 ID 추출 (JwtUtil에 해당 메서드가 구현되어 있어야 함)
         Long userId = jwtUtil.getUserId(refreshToken);
-
-        // 3. 새로운 Access Token 발급 및 반환
         return jwtUtil.createAccessToken(userId);
+    }
+
+    /**
+     * 로그아웃 로직 [6주차 추가]
+     */
+    @Transactional
+    public void logout(String refreshToken) {
+        if (refreshToken != null) {
+            // 스토어에서 해당 리프레시 토큰 매핑 관계를 삭제하여 재발급을 원천 차단
+            refreshTokenStore.remove(refreshToken);
+        }
+    }
+
+    /**
+     * 카카오 소셜 로그인 구현 [7주차 추가 및 리팩토링 완료]
+     */
+    @Transactional
+    public KakaoLoginResponseDto kakaoLogin(String code) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        // ====================================================================
+        // [1단계: 카카오 인가 코드로 Access Token 요청]
+        // ====================================================================
+        HttpHeaders tokenHeaders = new HttpHeaders();
+        tokenHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        // 💡 [보안 강화] 카카오 토큰 서버가 403을 뱉지 않도록 User-Agent 장착
+        tokenHeaders.add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+
+        // 카카오 OAuth API 스펙 요구 파라미터 빌드
+        MultiValueMap<String, String> tokenParams = new LinkedMultiValueMap<>();
+        tokenParams.add("grant_type", "authorization_code");
+        tokenParams.add("client_id", "50649e64349464e65d13733865026055");
+        tokenParams.add("redirect_uri", "http://localhost:8080/auth/oauth/kakao/callback"); // 과제 요구 라우트 규격 설정
+        tokenParams.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(tokenParams, tokenHeaders);
+
+        // 카카오 인증 센터(kauth.kakao.com) 전용 포스트 전송 선로 개통
+        ResponseEntity<Map> tokenResponse = restTemplate.postForEntity(
+                "https://kauth.kakao.com/oauth/token",
+                kakaoTokenRequest,
+                Map.class
+        );
+
+        String kakaoAccessToken = (String) tokenResponse.getBody().get("access_token");
+
+        // ====================================================================
+        // [2단계: 발급받은 Access Token으로 카카오 회원 프로필 정보 요청]
+        // ====================================================================
+        HttpHeaders profileHeaders = new HttpHeaders();
+        profileHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        // 💡 [인증 완료] 프로필 조회를 위해 인증 컨텍스트(Bearer) 바인딩
+        profileHeaders.add("Authorization", "Bearer " + kakaoAccessToken);
+        profileHeaders.add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+
+        HttpEntity<MultiValueMap<String, String>> kakaoProfileRequest = new HttpEntity<>(profileHeaders);
+
+        ResponseEntity<KakaoUserInfoDto> userResponse = restTemplate.postForEntity(
+                "https://kapi.kakao.com/v2/user/me",
+                kakaoProfileRequest,
+                KakaoUserInfoDto.class
+        );
+
+        KakaoUserInfoDto kakaoUserInfo = userResponse.getBody();
+        if (kakaoUserInfo == null || kakaoUserInfo.getKakao_account() == null) {
+            throw new RuntimeException("카카오 유저 정보를 불러오지 못했습니다.");
+        }
+
+        String email = kakaoUserInfo.getKakao_account().getEmail();
+        String nickname = kakaoUserInfo.getKakao_account().getProfile().getNickname();
+
+        // 3. 서비스 DB 회원 가입 혹은 기존 회원 조회 후 객체에 확실히 할당
+        User user = userRepository.findByEmail(email).orElse(null);
+
+        if (user == null) {
+            user = userRepository.save(
+                    User.builder()
+                            .name(nickname)
+                            .email(email)
+                            .password(passwordEncoder.encode("OAUTH_BLANK_PASSWORD"))
+                            .age(0)
+                            .build()
+            );
+        }
+
+        // 4. Integer 타입을 Long 타입으로 변환하여 안전하게 자체 토큰 생성
+        Long userId = Long.valueOf(user.getId());
+
+        String ourAccessToken = jwtUtil.createAccessToken(userId);
+        String ourRefreshToken = jwtUtil.createRefreshToken();
+
+        // 소셜 로그인 세션도 재발급 관리를 위해 공유 저장소에 등록
+        refreshTokenStore.put(ourRefreshToken, userId);
+
+        return new KakaoLoginResponseDto(ourAccessToken, ourRefreshToken);
+    }
+
+    /**
+     * 💡 과제 템플릿 에러 핸들링 매핑용 커스텀 런타임 예외 클래스
+     */
+    @Getter
+    public static class CustomAuthException extends RuntimeException {
+        private final String errorCode;
+        public CustomAuthException(String errorCode, String message) {
+            super(message);
+            this.errorCode = errorCode;
+        }
     }
 }

--- a/src/main/java/com/example/demo1/domain/user/dto/AuthDto.java
+++ b/src/main/java/com/example/demo1/domain/user/dto/AuthDto.java
@@ -1,0 +1,51 @@
+package com.example.demo1.domain.user.dto;
+
+import lombok.*;
+
+public class AuthDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class LoginRequest {
+        private String email;
+        private String password;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class LoginResponse {
+        private TokenDto token;
+        private UserInfo user;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class TokenDto {
+        private String accessToken;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class UserInfo {
+        private Integer id;
+        private String email;
+        private String nickname;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ReissueRequest {
+        private String refreshToken;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ReissueResponse {
+        private String accessToken;
+        private String refreshToken;
+    }
+}

--- a/src/main/java/com/example/demo1/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo1/global/config/SecurityConfig.java
@@ -6,13 +6,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer; // [추가]
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -32,26 +35,49 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable)
-                // H2 콘솔 사용을 위한 설정 (나중에 확인용으로 유용합니다)
-                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+                // 💡 [추가] CORS 설정을 연결합니다.
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
 
-                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // 💡 [가장 중요] CSRF 보안 설정을 확실하게 꺼줍니다.
+                .csrf(csrf -> csrf.disable())
 
+                // H2 콘솔 사용을 위한 프레임 비활성화
+                .headers(headers -> headers.frameOptions(frame -> frame.disable()))
+
+                // 세션을 사용하지 않고 JWT 토큰 방식을 사용하므로 STATELESS 설정
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 💡 [경로 허용] 인증 없이 통과할 화이트리스트 지정
                 .authorizeHttpRequests(auth -> auth
-                        // 1. /auth 하위의 모든 요청(signup, login, reissue) 허용
+                        .requestMatchers("/auth/oauth/**").permitAll()
                         .requestMatchers("/auth/**").permitAll()
-                        // 2. Swagger 관련 모든 리소스 허용
+                        .requestMatchers("/oauth/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**").permitAll()
-                        // 3. H2 콘솔 허용
                         .requestMatchers("/h2-console/**").permitAll()
-                        // 4. 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()
                 )
 
-                // JWT 필터 배치
+                // 커스텀 JWT 필터를 시큐리티 필터 체인에 등록
                 .addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    // 💡 [추가] 쿠키 전송을 허용하는 CORS 설정 블록
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        // 쿠키를 주고받으려면 와일드카드(*) 대신 originPattern을 사용하거나 명시적 주소를 적어야 합니다.
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+
+        // ⭐️ 핵심: 이 설정이 true여야 응답 세팅한 쿠키가 차단되지 않고 클라이언트에 들어갑니다.
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/com/example/demo1/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/demo1/global/security/JwtAuthenticationFilter.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher; // 💡 추가
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -17,31 +18,56 @@ import java.util.List;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher(); // 💡 추가
+
+    // 💡 인증을 거치지 않을 화이트리스트 경로들 정의
+    private static final List<String> EXCLUDE_URLS = List.of(
+            "/auth/**",
+            "/auth/oauth/**",
+            "/oauth/**",
+            "/h2-console/**",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/swagger-resources/**",
+            "/webjars/**"
+    );
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getRequestURI();
+        String contextPath = request.getContextPath();
+
+        if (contextPath != null && !contextPath.isEmpty() && path.startsWith(contextPath)) {
+            path = path.substring(contextPath.length());
+        }
+
+        // 💡 경로 패턴이 하나라도 일치하면 필터를 거치지 않음 (true 반환)
+        final String finalPath = path;
+        return EXCLUDE_URLS.stream().anyMatch(pattern -> pathMatcher.match(pattern, finalPath));
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        // 1. 헤더에서 Authorization 추출
         String authHeader = request.getHeader("Authorization");
 
-        // 2. Bearer 토큰인지 확인
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
-            String token = authHeader.substring(7);
+            String token = authHeader.substring(7).trim();
 
-            // 3. 토큰 유효성 검사
             if (jwtUtil.validateToken(token)) {
                 Long userId = jwtUtil.getUserId(token);
+                String principal = String.valueOf(userId);
 
-                // 4. SecurityContext에 인증 정보 저장 (이걸 해야 @AuthenticationPrincipal 사용 가능)
                 UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(userId, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+                        new UsernamePasswordAuthenticationToken(principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
 
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+            } else {
+                SecurityContextHolder.clearContext();
             }
         }
 
-        // 5. 다음 필터로 진행
         filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/example/demo1/global/security/JwtUtil.java
+++ b/src/main/java/com/example/demo1/global/security/JwtUtil.java
@@ -1,62 +1,72 @@
 package com.example.demo1.global.security;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.util.Base64;
 import java.util.Date;
-import java.util.UUID;
 
 @Component
 public class JwtUtil {
-    private final String secretKey = "yuchan_secret_key_for_fds_lab_project_security_long_key";
-    private final long AT_EXP = 1800000L;
-    private final long RT_EXP = 1209600000L;
 
-    private Key getSigningKey() {
-        return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private Key key;
+
+    // 토큰 만료 시간 설정
+    private final long accessTokenValidity = 1000L * 60 * 30; // 30분
+    private final long refreshTokenValidity = 1000L * 60 * 60 * 24 * 7; // 7일
+
+    @PostConstruct
+    protected void init() {
+        byte[] keyBytes = Base64.getDecoder().decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
+    // Access Token 생성 (Long 타입 userId 사용)
     public String createAccessToken(Long userId) {
-        Claims claims = Jwts.claims().setSubject(userId.toString());
+        Claims claims = Jwts.claims().setSubject(String.valueOf(userId));
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + accessTokenValidity);
+
         return Jwts.builder()
                 .setClaims(claims)
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + AT_EXP))
-                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 
+    // Refresh Token 생성
     public String createRefreshToken() {
-        return UUID.randomUUID().toString();
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + refreshTokenValidity);
+
+        return Jwts.builder()
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
     }
 
+    // 토큰에서 UserId 추출
+    public Long getUserId(String token) {
+        String subject = Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody().getSubject();
+        return Long.valueOf(subject);
+    }
+
+    // 토큰 유효성 검증
     public boolean validateToken(String token) {
         try {
-            Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token);
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
-        } catch (Exception e) {
+        } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
-    }
-
-    public Long getUserId(String token) {
-        return Long.parseLong(Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token).getBody().getSubject());
-    }
-    // JwtUtil.java에 추가
-    public Claims getClaims(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(getSigningKey())
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
-    }
-
-    public Long getUserIdFromToken(String token) {
-        return Long.parseLong(getClaims(token).getSubject());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=demo
 spring.jpa.open-in-view=false
+jwt.secret=c3ByaW5nYm9vdC1qd3Qtc2VjcmV0LWtleS1mb3ItZGVtby1wcm9qZWN0LWdtYWlsLWNvbS0yMDI2


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용
카카오 OAuth 로그인 구현


## 2. 핵심 변경 사항
- `KakaoService` : 인가코드 → 카카오 액세스토큰 교환, 유저정보 조회
- `AuthController` : `/auth/kakao/callback` 엔드포인트 추가
- `AuthService` : 카카오 유저 자동 회원가입 및 JWT 발급 로직 추가
- `application.properties` : 카카오 client-id, redirect-uri 환경변수 설정


## 3. 실행 및 검증 결과
<img width="1337" height="841" alt="카카오톡로그인" src="https://github.com/user-attachments/assets/f4bc5581-49b1-4d0a-8910-36d6041e9d46" />



## 4. 완료 사항
1. 카카오 OAuth 인가코드 방식 로그인 구현
2. 신규 유저 자동 회원가입 처리
3. JWT accessToken / refreshToken 발급


## 5. 추가 사항
- 관련 이슈: closed #280 


## 제출 체크리스트
- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고

<!--
BE: rootTiket, soyesenna
FE: One-HyeWon, woneeee
-->
