### PR TITLE
[7주차] 남유정/[feat] 카카오 OAuth 로그인

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Local secrets ###
+src/main/resources/application-local.yaml

--- a/src/main/java/com/example/leets7th/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/leets7th/domain/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.example.leets7th.domain.auth.dto.LoginRequest;
 import com.example.leets7th.domain.auth.dto.SignUpRequest;
 import com.example.leets7th.domain.auth.dto.TokenResponse;
 import com.example.leets7th.domain.auth.service.AuthService;
+import com.example.leets7th.domain.auth.service.KakaoOAuthService;
 import com.example.leets7th.global.common.ApiResponse;
 import com.example.leets7th.global.util.CookieProvider;
 import jakarta.servlet.http.HttpServletResponse;
@@ -24,6 +25,7 @@ public class AuthController implements AuthControllerDocs {
     private static final String REFRESH_TOKEN_COOKIE = "refreshToken";
 
     private final AuthService authService;
+    private final KakaoOAuthService kakaoOAuthService;
     private final CookieProvider cookieProvider;
 
     @PostMapping("/signup")
@@ -57,5 +59,20 @@ public class AuthController implements AuthControllerDocs {
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+    @GetMapping("/kakao")
+    public ResponseEntity<Void> kakaoLogin() {
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .header("Location", kakaoOAuthService.getKakaoLoginUrl())
+                .build();
+    }
 
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<ApiResponse<Void>> kakaoCallback(
+            @RequestParam String code,
+            HttpServletResponse response) {
+        TokenResponse tokens = kakaoOAuthService.kakaoLogin(code);
+        cookieProvider.addCookie(response, ACCESS_TOKEN_COOKIE, tokens.accessToken(), Duration.ofHours(1));
+        cookieProvider.addCookie(response, REFRESH_TOKEN_COOKIE, tokens.refreshToken(), Duration.ofDays(14));
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
 }

--- a/src/main/java/com/example/leets7th/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/leets7th/domain/auth/controller/AuthController.java
@@ -5,11 +5,11 @@ import com.example.leets7th.domain.auth.dto.SignUpRequest;
 import com.example.leets7th.domain.auth.dto.TokenResponse;
 import com.example.leets7th.domain.auth.service.AuthService;
 import com.example.leets7th.global.common.ApiResponse;
+import com.example.leets7th.global.util.CookieProvider;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,6 +24,7 @@ public class AuthController implements AuthControllerDocs {
     private static final String REFRESH_TOKEN_COOKIE = "refreshToken";
 
     private final AuthService authService;
+    private final CookieProvider cookieProvider;
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signUp(@Valid @RequestBody SignUpRequest request) {
@@ -35,8 +36,8 @@ public class AuthController implements AuthControllerDocs {
     public ResponseEntity<ApiResponse<Void>> login(@Valid @RequestBody LoginRequest request,
                                                     HttpServletResponse response) {
         TokenResponse tokens = authService.login(request);
-        addCookie(response, ACCESS_TOKEN_COOKIE, tokens.accessToken(), Duration.ofHours(1));
-        addCookie(response, REFRESH_TOKEN_COOKIE, tokens.refreshToken(), Duration.ofDays(14));
+        cookieProvider.addCookie(response, ACCESS_TOKEN_COOKIE, tokens.accessToken(), Duration.ofHours(1));
+        cookieProvider.addCookie(response, REFRESH_TOKEN_COOKIE, tokens.refreshToken(), Duration.ofDays(14));
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
@@ -45,34 +46,16 @@ public class AuthController implements AuthControllerDocs {
             @CookieValue(name = "refreshToken") String refreshToken,
             HttpServletResponse response) {
         String newAccessToken = authService.refresh(refreshToken);
-        addCookie(response, ACCESS_TOKEN_COOKIE, newAccessToken, Duration.ofHours(1));
+        cookieProvider.addCookie(response, ACCESS_TOKEN_COOKIE, newAccessToken, Duration.ofHours(1));
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response) {
-        deleteCookie(response, ACCESS_TOKEN_COOKIE);
-        deleteCookie(response, REFRESH_TOKEN_COOKIE);
+        cookieProvider.deleteCookie(response, ACCESS_TOKEN_COOKIE);
+        cookieProvider.deleteCookie(response, REFRESH_TOKEN_COOKIE);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
-    private void addCookie(HttpServletResponse response, String name, String value, Duration maxAge) {
-        ResponseCookie cookie = ResponseCookie.from(name, value)
-                .httpOnly(true)
-                .path("/")
-                .maxAge(maxAge)
-                .sameSite("Strict")
-                .build();
-        response.addHeader("Set-Cookie", cookie.toString());
-    }
 
-    private void deleteCookie(HttpServletResponse response, String name) {
-        ResponseCookie cookie = ResponseCookie.from(name, "")
-                .httpOnly(true)
-                .path("/")
-                .maxAge(Duration.ZERO)
-                .sameSite("Strict")
-                .build();
-        response.addHeader("Set-Cookie", cookie.toString());
-    }
 }

--- a/src/main/java/com/example/leets7th/domain/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/com/example/leets7th/domain/auth/controller/AuthControllerDocs.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Auth", description = "인증 관련 API")
 public interface AuthControllerDocs {
@@ -41,4 +42,15 @@ public interface AuthControllerDocs {
     @Operation(summary = "로그아웃", description = "accessToken, refreshToken 쿠키를 삭제합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그아웃 성공")
     ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response);
+
+    @Operation(summary = "카카오 로그인 페이지로 이동", description = "카카오 OAuth 인가 URL로 리다이렉트합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "302", description = "카카오 로그인 페이지로 리다이렉트")
+    ResponseEntity<Void> kakaoLogin();
+
+    @Operation(summary = "카카오 로그인 콜백", description = "카카오로부터 인가 코드를 받아 로그인/회원가입 처리 후 JWT 쿠키를 발급합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "502", description = "카카오 인증 실패")
+    })
+    ResponseEntity<ApiResponse<Void>> kakaoCallback(@RequestParam String code, HttpServletResponse response);
 }

--- a/src/main/java/com/example/leets7th/domain/auth/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/example/leets7th/domain/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,11 @@
+package com.example.leets7th.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("token_type") String tokenType,
+        @JsonProperty("refresh_token") String refreshToken,
+        @JsonProperty("expires_in") int expiresIn
+) {
+}

--- a/src/main/java/com/example/leets7th/domain/auth/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/com/example/leets7th/domain/auth/dto/KakaoUserInfoResponse.java
@@ -1,0 +1,34 @@
+package com.example.leets7th.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserInfoResponse(
+        Long id,
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+    public record KakaoAccount(
+            String email,
+            KakaoProfile profile
+    ) {
+    }
+
+    public record KakaoProfile(
+            String nickname
+    ) {
+    }
+
+    public String email() {
+        if (kakaoAccount != null && kakaoAccount.email() != null) {
+            return kakaoAccount.email();
+        }
+        return "kakao_" + id + "@kakao.com";
+    }
+
+    public String nickname() {
+        if (kakaoAccount != null && kakaoAccount.profile() != null
+                && kakaoAccount.profile().nickname() != null) {
+            return kakaoAccount.profile().nickname();
+        }
+        return "kakao_" + id;
+    }
+}

--- a/src/main/java/com/example/leets7th/domain/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/example/leets7th/domain/auth/dto/TokenRefreshRequest.java
@@ -1,9 +1,0 @@
-package com.example.leets7th.domain.auth.dto;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record TokenRefreshRequest(
-        @NotBlank
-        String refreshToken
-) {
-}

--- a/src/main/java/com/example/leets7th/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/leets7th/domain/auth/service/AuthService.java
@@ -27,10 +27,10 @@ public class AuthService {
 
     @Transactional
     public void signUp(SignUpRequest request) {
-        if (userRepository.existsByEmail(request.email())) {
-            throw new DuplicateEmailException();
-        }
-        if (userRepository.existsByNickname(request.nickname())) {
+        if (userRepository.existsByEmailOrNickname(request.email(), request.nickname())) {
+            if (userRepository.existsByEmail(request.email())) {
+                throw new DuplicateEmailException();
+            }
             throw new DuplicateNicknameException();
         }
 

--- a/src/main/java/com/example/leets7th/domain/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/example/leets7th/domain/auth/service/KakaoOAuthService.java
@@ -1,0 +1,112 @@
+package com.example.leets7th.domain.auth.service;
+
+import com.example.leets7th.domain.auth.dto.KakaoTokenResponse;
+import com.example.leets7th.domain.auth.dto.KakaoUserInfoResponse;
+import com.example.leets7th.domain.auth.dto.TokenResponse;
+import com.example.leets7th.domain.user.entity.User;
+import com.example.leets7th.domain.user.repository.UserRepository;
+import com.example.leets7th.global.exception.KakaoAuthException;
+import com.example.leets7th.global.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class KakaoOAuthService {
+
+    private static final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final RestClient restClient;
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.client-secret}")
+    private String clientSecret;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    public String getKakaoLoginUrl() {
+        return "https://kauth.kakao.com/oauth/authorize"
+                + "?response_type=code"
+                + "&client_id=" + clientId
+                + "&redirect_uri=" + redirectUri;
+    }
+
+    @Transactional
+    public TokenResponse kakaoLogin(String code) {
+        KakaoTokenResponse kakaoToken = fetchKakaoToken(code);
+        KakaoUserInfoResponse userInfo = fetchKakaoUserInfo(kakaoToken.accessToken());
+
+        User user = userRepository.findByKakaoId(userInfo.id())
+                .orElseGet(() -> registerKakaoUser(userInfo));
+
+        String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getRole());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId());
+        user.updateRefreshToken(refreshToken);
+
+        return new TokenResponse(accessToken, refreshToken);
+    }
+
+    private KakaoTokenResponse fetchKakaoToken(String code) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        try {
+            return restClient.post()
+                    .uri(KAKAO_TOKEN_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(params)
+                    .retrieve()
+                    .body(KakaoTokenResponse.class);
+        } catch (RestClientException e) {
+            throw new KakaoAuthException();
+        }
+    }
+
+    private KakaoUserInfoResponse fetchKakaoUserInfo(String kakaoAccessToken) {
+        try {
+            return restClient.get()
+                    .uri(KAKAO_USER_INFO_URL)
+                    .header("Authorization", "Bearer " + kakaoAccessToken)
+                    .retrieve()
+                    .body(KakaoUserInfoResponse.class);
+        } catch (RestClientException e) {
+            throw new KakaoAuthException();
+        }
+    }
+
+    private User registerKakaoUser(KakaoUserInfoResponse userInfo) {
+        String nickname = resolveUniqueNickname(userInfo.nickname(), userInfo.id());
+        String tempPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+        User user = User.createByKakao(userInfo.id(), userInfo.email(), nickname, tempPassword);
+        return userRepository.save(user);
+    }
+
+    private String resolveUniqueNickname(String base, Long kakaoId) {
+        if (!userRepository.existsByNickname(base)) {
+            return base;
+        }
+        return base + "_" + kakaoId;
+    }
+}

--- a/src/main/java/com/example/leets7th/domain/user/entity/User.java
+++ b/src/main/java/com/example/leets7th/domain/user/entity/User.java
@@ -40,6 +40,8 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
+    private Long kakaoId;
+
     private String refreshToken;
 
     private LocalDateTime deletedAt;
@@ -54,6 +56,16 @@ public class User extends BaseEntity {
         User user = new User();
         user.email = email;
         user.password = encodedPassword;
+        user.nickname = nickname;
+        user.role = UserRole.USER;
+        return user;
+    }
+
+    public static User createByKakao(Long kakaoId, String email, String nickname, String encodedTempPassword) {
+        User user = new User();
+        user.kakaoId = kakaoId;
+        user.email = email;
+        user.password = encodedTempPassword;
         user.nickname = nickname;
         user.role = UserRole.USER;
         return user;

--- a/src/main/java/com/example/leets7th/domain/user/entity/User.java
+++ b/src/main/java/com/example/leets7th/domain/user/entity/User.java
@@ -22,13 +22,13 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = true, length = 100)
     private String email;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 255)
     private String password;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = true, length = 30)
     private String nickname;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/leets7th/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/leets7th/domain/user/repository/UserRepository.java
@@ -14,4 +14,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     boolean existsByEmailOrNickname(String email, String nickname);
+
+    Optional<User> findByKakaoId(Long kakaoId);
 }

--- a/src/main/java/com/example/leets7th/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/leets7th/domain/user/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
+
+    boolean existsByEmailOrNickname(String email, String nickname);
 }

--- a/src/main/java/com/example/leets7th/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/leets7th/global/config/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.client.RestClient;
 
 @Configuration
 @EnableWebSecurity
@@ -52,5 +53,10 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public RestClient restClient() {
+        return RestClient.create();
     }
 }

--- a/src/main/java/com/example/leets7th/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/leets7th/global/exception/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "DUPLICATE_NICKNAME", "이미 사용 중인 닉네임입니다."),
 
+    // 502
+    KAKAO_AUTH_FAILED(HttpStatus.BAD_GATEWAY, "KAKAO_AUTH_FAILED", "카카오 인증에 실패했습니다."),
+
     // 404
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_NOT_FOUND", "해당 게시글을 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_NOT_FOUND", "해당 댓글을 찾을 수 없습니다."),

--- a/src/main/java/com/example/leets7th/global/exception/KakaoAuthException.java
+++ b/src/main/java/com/example/leets7th/global/exception/KakaoAuthException.java
@@ -1,0 +1,8 @@
+package com.example.leets7th.global.exception;
+
+public class KakaoAuthException extends BusinessException {
+
+    public KakaoAuthException() {
+        super(ErrorCode.KAKAO_AUTH_FAILED);
+    }
+}

--- a/src/main/java/com/example/leets7th/global/util/CookieProvider.java
+++ b/src/main/java/com/example/leets7th/global/util/CookieProvider.java
@@ -1,0 +1,25 @@
+package com.example.leets7th.global.util;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+public class CookieProvider {
+
+    public void addCookie(HttpServletResponse response, String name, String value, Duration maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .path("/")
+                .maxAge(maxAge)
+                .sameSite("Strict")
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public void deleteCookie(HttpServletResponse response, String name) {
+        addCookie(response, name, "", Duration.ZERO);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: leets-7th
+  profiles:
+    active: local
 
   datasource:
     url: ${DB_URL}
@@ -24,3 +26,8 @@ springdoc:
     path: /swagger-ui.html
   api-docs:
     path: /api-docs
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET:}
+  redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/auth/kakao/callback}


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

 - 카카오 OAuth 로그인 구현 (GET /auth/kakao, GET /auth/kakao/callback)


## 2. 핵심 변경 사항

  - KakaoOAuthService — 카카오 인가 코드로 토큰 발급, 사용자 정보 조회, 신규 유저 자동 회원가입 처리
  - KakaoTokenResponse, KakaoUserInfoResponse — 카카오 API 응답 DTO (record)
  - KakaoAuthException — 카카오 인증 실패 시 예외 처리
  - User — kakaoId 필드 및 createByKakao() 팩토리 메서드 추가
  - UserRepository — findByKakaoId() 쿼리 메서드 추가
  - AuthController / AuthControllerDocs — 카카오 로그인 엔드포인트 2개 추가
  - application.yaml — kakao.client-id, client-secret, redirect-uri 설정 추가
  - .gitignore — application-local.yaml 추가 (시크릿 정보 보호)



## 3. 실행 및 검증 결과

<img width="587" height="179" alt="스크린샷 2026-05-19 222150" src="https://github.com/user-attachments/assets/9eb1ca59-2c45-42db-a5ec-1b49d32c92fd" />


## 4. 완료 사항

  1. 카카오 OAuth 인가 코드 방식 로그인 구현
  2. 최초 로그인 시 자동 회원가입 처리 (kakaoId 기반 중복 가입 방지)
  3. 닉네임 중복 시 닉네임_kakaoId 형식으로 자동 처리
  4. Swagger 문서 분리 (AuthControllerDocs 인터페이스에 어노테이션 작성)
  5. 시크릿 키는 application-local.yaml로 분리하여 gitignore 처리



## 5. 추가 사항

- 관련 이슈: `closed #남유!--
제목: [주차] {이름}/[타입] {작업 내용}
예시: [1주차] 조혜원/[feat] 초기 프로젝트 설정
-->

## 1. 과제 요구사항 중 구현한 내용

 - 카카오 OAuth 로그인 구현 (GET /auth/kakao, GET /auth/kakao/callback)


## 2. 핵심 변경 사항

  - KakaoOAuthService — 카카오 인가 코드로 토큰 발급, 사용자 정보 조회, 신규 유저 자동 회원가입 처리
  - KakaoTokenResponse, KakaoUserInfoResponse — 카카오 API 응답 DTO (record)
  - KakaoAuthException — 카카오 인증 실패 시 예외 처리
  - User — kakaoId 필드 및 createByKakao() 팩토리 메서드 추가
  - UserRepository — findByKakaoId() 쿼리 메서드 추가
  - AuthController / AuthControllerDocs — 카카오 로그인 엔드포인트 2개 추가
  - application.yaml — kakao.client-id, client-secret, redirect-uri 설정 추가
  - .gitignore — application-local.yaml 추가 (시크릿 정보 보호)



## 3. 실행 및 검증 결과

<img width="587" height="179" alt="스크린샷 2026-05-19 222150" src="https://github.com/user-attachments/assets/9eb1ca59-2c45-42db-a5ec-1b49d32c92fd" />


## 4. 완료 사항

  1. 카카오 OAuth 인가 코드 방식 로그인 구현
  2. 최초 로그인 시 자동 회원가입 처리 (kakaoId 기반 중복 가입 방지)
  3. 닉네임 중복 시 닉네임_kakaoId 형식으로 자동 처리
  4. Swagger 문서 분리 (AuthControllerDocs 인터페이스에 어노테이션 작성)
  5. 시크릿 키는 application-local.yaml로 분리하여 gitignore 처리



## 5. 추가 사항

- 관련 이슈: closed #
<!-- 리뷰 시 참고할 포인트나 남은 작업이 있다면 작성해주세요. -->


## 제출 체크리스트

- [X] PR 제목이 규칙에 맞다
- [X] base가 `{이름}/main` 브랜치다
- [X] compare가 `{이름}/{숫자}주차` 브랜치다
- [X] 프로젝트가 정상 실행된다
- [X] 본인을 Assignee로 지정했다
- [X] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고

<!--
BE: rootTiket, soyesenna
FE: One-HyeWon, woneeee
-->
