### PR TITLE
[7주차] 이건희/[feat] 카카오 OAuth 로그인

### DIFF
--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/config/SecurityConfig.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/signup", "/login", "/auth/reissue").permitAll()
+                        .requestMatchers("/auth/signup", "/login", "/auth/reissue", "/auth/kakao/callback").permitAll()
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
                         .anyRequest().authenticated()

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/controller/AuthApi.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/controller/AuthApi.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "03. Auth API", description = "회원가입 및 로그인 API")
 public interface AuthApi {
@@ -43,4 +44,11 @@ public interface AuthApi {
                             examples = @ExampleObject(value = "{\"isSuccess\": false, \"code\": \"AUTH401_4\", \"message\": \"유효하지 않은 Refresh Token입니다.\", \"result\": null}")))
     })
     ApiResponse<AuthResponseDTO.TokenResDTO> reissue(@RequestBody AuthRequestDTO.ReissueDTO request);
+
+    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 받아 서비스 Access Token과 Refresh Token을 발급합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카카오 로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH401_2", description = "유효하지 않은 카카오 인가 코드 또는 토큰")
+    })
+    ApiResponse<AuthResponseDTO.TokenResDTO> kakaoLogin(@RequestParam String code);
 }

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/controller/AuthController.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/controller/AuthController.java
@@ -7,9 +7,11 @@ import com.leets.assignment.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -44,5 +46,14 @@ public class AuthController implements AuthApi {
     ) {
         AuthResponseDTO.TokenResDTO result = authService.reissue(request);
         return ApiResponse.onSuccess("AUTH200_2", "토큰 재발급이 성공했습니다.", result);
+    }
+
+    @Override
+    @GetMapping("/auth/kakao/callback")
+    public ApiResponse<AuthResponseDTO.TokenResDTO> kakaoLogin(
+            @RequestParam String code
+    ) {
+        AuthResponseDTO.TokenResDTO result = authService.kakaoLogin(code);
+        return ApiResponse.onSuccess("AUTH200_3", "카카오 로그인이 성공했습니다.", result);
     }
 }

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/oauth/KakaoClient.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/oauth/KakaoClient.java
@@ -1,0 +1,80 @@
+package com.leets.assignment.domain.auth.oauth;
+
+import com.leets.assignment.domain.auth.exception.AuthException;
+import com.leets.assignment.domain.auth.exception.code.AuthErrorCode;
+import com.leets.assignment.domain.auth.oauth.dto.KakaoTokenResponse;
+import com.leets.assignment.domain.auth.oauth.dto.KakaoUserInfoResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoClient {
+
+    private static final String AUTHORIZATION_CODE = "authorization_code";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final RestClient restClient = RestClient.create();
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    public KakaoUserInfoResponse getUserInfo(String code) {
+        KakaoTokenResponse tokenResponse = requestToken(code);
+        return requestUserInfo(tokenResponse.accessToken());
+    }
+
+    private KakaoTokenResponse requestToken(String code) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", AUTHORIZATION_CODE);
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        try {
+            KakaoTokenResponse response = restClient.post()
+                    .uri("https://kauth.kakao.com/oauth/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(body)
+                    .retrieve()
+                    .body(KakaoTokenResponse.class);
+            if (response == null || response.accessToken() == null || response.accessToken().isBlank()) {
+                log.warn("Kakao token response does not contain access token.");
+                throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+            }
+            return response;
+        } catch (RestClientException e) {
+            log.warn("Kakao token request failed. redirectUri={}, message={}", redirectUri, e.getMessage());
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    private KakaoUserInfoResponse requestUserInfo(String accessToken) {
+        try {
+            KakaoUserInfoResponse response = restClient.get()
+                    .uri("https://kapi.kakao.com/v2/user/me")
+                    .header("Authorization", BEARER_PREFIX + accessToken)
+                    .retrieve()
+                    .body(KakaoUserInfoResponse.class);
+            if (response == null || response.id() == null) {
+                log.warn("Kakao user info response does not contain user id.");
+                throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+            }
+            return response;
+        } catch (RestClientException e) {
+            log.warn("Kakao user info request failed. message={}", e.getMessage());
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
+    }
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/oauth/dto/KakaoTokenResponse.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/oauth/dto/KakaoTokenResponse.java
@@ -1,0 +1,17 @@
+package com.leets.assignment.domain.auth.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoTokenResponse(
+        @JsonProperty("access_token")
+        String accessToken,
+        @JsonProperty("token_type")
+        String tokenType,
+        @JsonProperty("refresh_token")
+        String refreshToken,
+        @JsonProperty("expires_in")
+        Long expiresIn
+) {
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/oauth/dto/KakaoUserInfoResponse.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/oauth/dto/KakaoUserInfoResponse.java
@@ -1,0 +1,54 @@
+package com.leets.assignment.domain.auth.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoUserInfoResponse(
+        Long id,
+        @JsonProperty("kakao_account")
+        KakaoAccount kakaoAccount
+) {
+
+    public String getProviderId() {
+        return String.valueOf(id);
+    }
+
+    public String getEmailOrDefault() {
+        if (kakaoAccount != null && kakaoAccount.email != null && !kakaoAccount.email.isBlank()) {
+            return kakaoAccount.email;
+        }
+        return getProviderId() + "@kakao.local";
+    }
+
+    public String getNicknameOrDefault() {
+        String nickname = null;
+
+        if (kakaoAccount != null && kakaoAccount.profile != null) {
+            nickname = kakaoAccount.profile.nickname;
+        }
+
+        if (nickname == null || nickname.isBlank()) {
+            return "kakao_" + getProviderId();
+        }
+
+        return nickname;
+    }
+
+    public String getNameOrDefault() {
+        return getNicknameOrDefault();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record KakaoAccount(
+            String email,
+            Profile profile
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Profile(
+            String nickname
+    ) {
+    }
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/service/AuthService.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/auth/service/AuthService.java
@@ -5,6 +5,9 @@ import com.leets.assignment.domain.auth.dto.AuthResponseDTO;
 import com.leets.assignment.domain.auth.exception.AuthException;
 import com.leets.assignment.domain.auth.exception.code.AuthErrorCode;
 import com.leets.assignment.domain.auth.jwt.JwtProvider;
+import com.leets.assignment.domain.auth.oauth.KakaoClient;
+import com.leets.assignment.domain.auth.oauth.dto.KakaoUserInfoResponse;
+import com.leets.assignment.domain.user.entity.AuthProvider;
 import com.leets.assignment.domain.user.entity.User;
 import com.leets.assignment.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +23,7 @@ public class AuthService {
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final KakaoClient kakaoClient;
 
     @Transactional
     public AuthResponseDTO.SignupResDTO signup(AuthRequestDTO.SignupDTO request) {
@@ -31,6 +35,7 @@ public class AuthService {
                 .nickname(request.getNickname())
                 .name(request.getName())
                 .password(passwordEncoder.encode(request.getPassword()))
+                .provider(AuthProvider.LOCAL)
                 .build();
 
         User savedUser = userService.save(user);
@@ -59,5 +64,47 @@ public class AuthService {
         User user = userService.findByEmail(email);
 
         return jwtProvider.createTokenResponse(user);
+    }
+
+    @Transactional
+    public AuthResponseDTO.TokenResDTO kakaoLogin(String code) {
+        KakaoUserInfoResponse kakaoUserInfo = kakaoClient.getUserInfo(code);
+
+        User user = userService.findByProviderAndProviderId(AuthProvider.KAKAO, kakaoUserInfo.getProviderId())
+                .orElseGet(() -> createKakaoUser(kakaoUserInfo));
+
+        return jwtProvider.createTokenResponse(user);
+    }
+
+    private User createKakaoUser(KakaoUserInfoResponse kakaoUserInfo) {
+        String nickname = limitLength(kakaoUserInfo.getNicknameOrDefault(), 50);
+        String email = kakaoUserInfo.getEmailOrDefault();
+
+        if (userService.existsByNickname(nickname)) {
+            nickname = limitLength("kakao_" + kakaoUserInfo.getProviderId(), 50);
+        }
+
+        if (userService.existsByEmail(email)) {
+            email = kakaoUserInfo.getProviderId() + "@kakao.local";
+        }
+
+        User user = User.builder()
+                .email(email)
+                .nickname(nickname)
+                .name(limitLength(kakaoUserInfo.getNameOrDefault(), 50))
+                .password("")
+                .provider(AuthProvider.KAKAO)
+                .providerId(kakaoUserInfo.getProviderId())
+                .build();
+
+        return userService.save(user);
+    }
+
+    private String limitLength(String value, int maxLength) {
+        if (value.length() <= maxLength) {
+            return value;
+        }
+
+        return value.substring(0, maxLength);
     }
 }

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/user/entity/AuthProvider.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/user/entity/AuthProvider.java
@@ -1,0 +1,6 @@
+package com.leets.assignment.domain.user.entity;
+
+public enum AuthProvider {
+    LOCAL,
+    KAKAO
+}

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/user/entity/User.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/user/entity/User.java
@@ -27,11 +27,20 @@ public class User extends BaseEntity {
     @Column(name = "email", nullable = false, unique = true)
     private String email;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", length = 20)
+    private AuthProvider provider;
+
+    @Column(name = "provider_id", unique = true)
+    private String providerId;
+
     @Builder
-    private User(String nickname, String name, String password, String email) {
+    private User(String nickname, String name, String password, String email, AuthProvider provider, String providerId) {
         this.nickname = nickname;
         this.name = name;
         this.password = password;
         this.email = email;
+        this.provider = provider;
+        this.providerId = providerId;
     }
 }

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/user/repository/UserRepository.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.leets.assignment.domain.user.repository;
 
+import com.leets.assignment.domain.user.entity.AuthProvider;
 import com.leets.assignment.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -13,4 +14,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
 }

--- a/LeeKunHee/src/main/java/com/leets/assignment/domain/user/service/UserService.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.leets.assignment.domain.user.service;
 
+import com.leets.assignment.domain.user.entity.AuthProvider;
 import com.leets.assignment.domain.user.entity.User;
 import com.leets.assignment.domain.user.exception.UserException;
 import com.leets.assignment.domain.user.exception.code.UserErrorCode;
@@ -7,6 +8,8 @@ import com.leets.assignment.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +34,10 @@ public class UserService {
     public User findByEmail(String email) {
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    public Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId) {
+        return userRepository.findByProviderAndProviderId(provider, providerId);
     }
 
     public void validateEmailNotDuplicated(String email) {

--- a/LeeKunHee/src/main/java/com/leets/assignment/global/config/SwaggerConfig.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/global/config/SwaggerConfig.java
@@ -1,15 +1,27 @@
 package com.leets.assignment.global.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
+    private static final String JWT_SECURITY_SCHEME = "bearerAuth";
+
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement().addList(JWT_SECURITY_SCHEME))
+                .components(new Components()
+                        .addSecuritySchemes(JWT_SECURITY_SCHEME, new SecurityScheme()
+                                .name(JWT_SECURITY_SCHEME)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")))
                 .info(new Info()
                         .title("Leets Blog API")
                         .version("1.0.0"));

--- a/LeeKunHee/src/main/java/com/leets/assignment/global/exception/GlobalExceptionHandler.java
+++ b/LeeKunHee/src/main/java/com/leets/assignment/global/exception/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -94,6 +95,20 @@ public class GlobalExceptionHandler {
                         .isSuccess(false)
                         .code("COMMON400_1")
                         .message("잘못된 요청입니다. JSON 형식을 확인해주세요.")
+                        .result(null)
+                        .build()
+        );
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException e
+    ) {
+        return ResponseEntity.badRequest().body(
+                ApiResponse.<Void>builder()
+                        .isSuccess(false)
+                        .code("COMMON400_2")
+                        .message("필수 요청 파라미터가 누락되었습니다: " + e.getParameterName())
                         .result(null)
                         .build()
         );

--- a/LeeKunHee/src/main/resources/application.properties
+++ b/LeeKunHee/src/main/resources/application.properties
@@ -28,3 +28,7 @@ springdoc.override-with-generic-response=true
 jwt.secret=leets-assignment-jwt-secret-key-must-be-at-least-32-bytes
 jwt.access-token-expiration-ms=3600000
 jwt.refresh-token-expiration-ms=1209600000
+
+# Kakao OAuth
+kakao.client-id=d04a0a170207b6c627431c0f0305a262
+kakao.redirect-uri=http://localhost:8080/auth/kakao/callback


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

카카오 OAuth 로그인 구현


## 2. 핵심 변경 사항

- GET /auth/kakao/callback API 추가
- 카카오 토큰 요청/사용자 정보 조회용 KakaoClient 추가
- 카카오 응답 DTO 추가
- User 엔티티에 provider, providerId 필드 추가
- 카카오 유저 자동 회원가입 및 재로그인 처리
- 카카오 로그인 콜백 경로를 Security permitAll에 추가
- application.properties에 카카오 REST API 키와 Redirect URI 설정 추가


## 3. 실행 및 검증 결과

로그인 응답
<img width="1276" height="264" alt="카카오로그인" src="https://github.com/user-attachments/assets/a1f68003-7dd8-4024-8d39-e421554fc39e" />


## 4. 완료 사항

<!-- 완료한 작업을 번호 목록으로 작성해주세요. -->

1. 카카오 OAuth 로그인 구현
2. 카카오 사용자 정보 조회 및 자동 회원가입 처리
3. 기존 카카오 사용자 재로그인 처리
4. 서버 JWT Access Token / Refresh Token 발급
5. JWT 인증 흐름 및 테스트 통과 확인


## 5. 추가 사항

- 관련 이슈: `closed #288 

## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [ ] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고
