### PR TITLE
[7주차] 이예서[feat] 로그인 OAuth 로그인

### DIFF
--- a/leeyeseo/.gitignore
+++ b/leeyeseo/.gitignore
@@ -5,6 +5,10 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+# 로컬 비밀 설정 파일
+application-local.yaml
+**/application-local.yaml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/leeyeseo/src/main/java/com/example/blog/config/RestTemplateConfig.java
+++ b/leeyeseo/src/main/java/com/example/blog/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.example.blog.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/leeyeseo/src/main/java/com/example/blog/domain/auth/controller/AuthController.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/auth/controller/AuthController.java
@@ -5,15 +5,21 @@ import com.example.blog.dto.auth.LoginRequest;
 import com.example.blog.dto.auth.ReissueRequest;
 import com.example.blog.dto.auth.SignupRequest;
 import com.example.blog.dto.auth.TokenResponse;
+import com.example.blog.dto.auth.kakao.KakaoLoginRequest;
 import com.example.blog.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @Tag(name = "Auth", description = "회원가입/로그인 API")
 @RestController
@@ -22,6 +28,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+
+    @Value("${kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    @Value("${kakao.authorization-uri}")
+    private String kakaoAuthorizationUri;
 
     // POST /auth/signup - 회원가입
     @Operation(
@@ -53,5 +68,33 @@ public class AuthController {
     @PostMapping("/reissue")
     public ApiResponse<TokenResponse> reissue(@Valid @RequestBody ReissueRequest request) {
         return ApiResponse.onSuccess(authService.reissue(request));
+    }
+
+    // GET /auth/kakao - 카카오 로그인 URL 발급 (편의용)
+    @Operation(
+            summary = "카카오 로그인 URL 발급",
+            description = "사용자를 카카오 로그인 페이지로 보낼 URL을 반환합니다. " +
+                    "프론트엔드는 이 URL로 사용자를 리다이렉트하고, " +
+                    "사용자가 동의하면 카카오가 redirect_uri로 인가 코드를 전달합니다."
+    )
+    @GetMapping("/kakao")
+    public ApiResponse<String> getKakaoLoginUrl() {
+        String encodedRedirectUri = URLEncoder.encode(kakaoRedirectUri, StandardCharsets.UTF_8);
+        String url = kakaoAuthorizationUri
+                + "?response_type=code"
+                + "&client_id=" + kakaoClientId
+                + "&redirect_uri=" + encodedRedirectUri;
+        return ApiResponse.onSuccess(url);
+    }
+
+    // POST /auth/kakao/login - 카카오 로그인
+    @Operation(
+            summary = "카카오 로그인",
+            description = "카카오에서 발급받은 인가 코드로 우리 서비스의 accessToken과 refreshToken을 발급받습니다. " +
+                    "최초 로그인 시 자동으로 회원가입까지 처리됩니다."
+    )
+    @PostMapping("/kakao/login")
+    public ApiResponse<TokenResponse> kakaoLogin(@Valid @RequestBody KakaoLoginRequest request) {
+        return ApiResponse.onSuccess(authService.kakaoLogin(request.getCode()));
     }
 }

--- a/leeyeseo/src/main/java/com/example/blog/domain/auth/service/AuthService.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/auth/service/AuthService.java
@@ -132,8 +132,8 @@ public class AuthService {
             nickname = kakaoNickname + "_" + providerId;
         }
 
-        // 카카오 사용자는 비밀번호 사용 안 하지만, 컬럼이 nullable=false라 랜덤 값으로 채움
-        String randomPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+        // 카카오 사용자는 비밀번호 검증을 거치지 않으므로, nullable=false 제약만 만족시키는 랜덤 값으로 채움 (인코딩 불필요)
+        String randomPassword = UUID.randomUUID().toString();
 
         // 카카오 프로필 이미지 추출
         String profileImage = extractProfileImage(userInfo);

--- a/leeyeseo/src/main/java/com/example/blog/domain/auth/service/AuthService.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.example.blog.domain.auth.service;
 
 import com.example.blog.domain.auth.entity.RefreshToken;
 import com.example.blog.domain.auth.repository.RefreshTokenRepository;
+import com.example.blog.domain.user.entity.Provider;
 import com.example.blog.domain.user.entity.Role;
 import com.example.blog.domain.user.entity.User;
 import com.example.blog.domain.user.repository.UserRepository;
@@ -9,7 +10,10 @@ import com.example.blog.dto.auth.LoginRequest;
 import com.example.blog.dto.auth.ReissueRequest;
 import com.example.blog.dto.auth.SignupRequest;
 import com.example.blog.dto.auth.TokenResponse;
+import com.example.blog.dto.auth.kakao.KakaoTokenResponse;
+import com.example.blog.dto.auth.kakao.KakaoUserInfoResponse;
 import com.example.blog.exception.*;
+import com.example.blog.global.oauth.KakaoOAuthClient;
 import com.example.blog.global.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -17,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +31,7 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private final KakaoOAuthClient kakaoOAuthClient;
 
     // 회원가입
     @Transactional
@@ -49,6 +55,7 @@ public class AuthService {
                 .nickname(request.getNickname())
                 .phoneNumber(request.getPhoneNumber())
                 .role(Role.USER)
+                .provider(Provider.LOCAL)
                 .build();
         userRepository.save(user);
 
@@ -91,7 +98,85 @@ public class AuthService {
         return issueTokens(user);
     }
 
+    // 카카오 로그인 (신규)
+    @Transactional
+    public TokenResponse kakaoLogin(String code) {
+        // 1. 인가 코드로 카카오 액세스 토큰 발급
+        KakaoTokenResponse tokenResponse = kakaoOAuthClient.getAccessToken(code);
+
+        // 2. 카카오 액세스 토큰으로 사용자 정보 조회
+        KakaoUserInfoResponse userInfo = kakaoOAuthClient.getUserInfo(tokenResponse.getAccessToken());
+
+        // 3. 기존 카카오 회원 조회, 없으면 자동 회원가입
+        String providerId = String.valueOf(userInfo.getId());
+        User user = userRepository.findByProviderAndProviderId(Provider.KAKAO, providerId)
+                .orElseGet(() -> createKakaoUser(userInfo, providerId));
+
+        // 4. 우리 서비스 JWT 발급
+        return issueTokens(user);
+    }
+
     // ===== private helper =====
+
+    // 카카오 사용자 자동 회원가입
+    private User createKakaoUser(KakaoUserInfoResponse userInfo, String providerId) {
+        // 카카오는 이메일을 못 받으므로 가짜 이메일 생성
+        String fakeEmail = "kakao_" + providerId + "@kakao.local";
+
+        // 카카오 닉네임 추출 (kakao_account.profile 우선, 없으면 properties)
+        String kakaoNickname = extractNickname(userInfo);
+
+        // 닉네임 중복 시 카카오 ID 일부 붙여서 고유하게 변경
+        String nickname = kakaoNickname;
+        if (userRepository.existsByNickname(nickname)) {
+            nickname = kakaoNickname + "_" + providerId;
+        }
+
+        // 카카오 사용자는 비밀번호 사용 안 하지만, 컬럼이 nullable=false라 랜덤 값으로 채움
+        String randomPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+
+        // 카카오 프로필 이미지 추출
+        String profileImage = extractProfileImage(userInfo);
+
+        User newUser = User.builder()
+                .email(fakeEmail)
+                .password(randomPassword)
+                .name(kakaoNickname)
+                .nickname(nickname)
+                .profileImage(profileImage)
+                .role(Role.USER)
+                .provider(Provider.KAKAO)
+                .providerId(providerId)
+                .build();
+
+        return userRepository.save(newUser);
+    }
+
+    // 카카오 응답에서 닉네임 추출
+    private String extractNickname(KakaoUserInfoResponse userInfo) {
+        if (userInfo.getKakaoAccount() != null
+                && userInfo.getKakaoAccount().getProfile() != null
+                && userInfo.getKakaoAccount().getProfile().getNickname() != null) {
+            return userInfo.getKakaoAccount().getProfile().getNickname();
+        }
+        if (userInfo.getProperties() != null
+                && userInfo.getProperties().getNickname() != null) {
+            return userInfo.getProperties().getNickname();
+        }
+        return "카카오사용자";
+    }
+
+    // 카카오 응답에서 프로필 이미지 URL 추출
+    private String extractProfileImage(KakaoUserInfoResponse userInfo) {
+        if (userInfo.getKakaoAccount() != null
+                && userInfo.getKakaoAccount().getProfile() != null) {
+            return userInfo.getKakaoAccount().getProfile().getProfileImageUrl();
+        }
+        if (userInfo.getProperties() != null) {
+            return userInfo.getProperties().getProfileImage();
+        }
+        return null;
+    }
 
     // 토큰 발급 + RefreshToken DB 저장 공통 로직
     private TokenResponse issueTokens(User user) {

--- a/leeyeseo/src/main/java/com/example/blog/domain/user/entity/Provider.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/user/entity/Provider.java
@@ -1,0 +1,6 @@
+package com.example.blog.domain.user.entity;
+
+public enum Provider {
+    LOCAL,    // 일반 이메일 회원가입
+    KAKAO     // 카카오 OAuth 로그인
+}

--- a/leeyeseo/src/main/java/com/example/blog/domain/user/entity/User.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/user/entity/User.java
@@ -47,6 +47,16 @@ public class User extends BaseEntity {
     @Builder.Default
     private Role role = Role.USER;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false, length = 20)
+    @Comment("로그인 제공자 (LOCAL/KAKAO)")
+    @Builder.Default
+    private Provider provider = Provider.LOCAL;
+
+    @Column(name = "provider_id", length = 100)
+    @Comment("OAuth 제공자가 발급한 사용자 식별자 (카카오 ID 등)")
+    private String providerId;
+
     // 비밀번호 암호화 후 갱신 (회원가입 시 사용)
     public void encodePassword(String encodedPassword) {
         this.password = encodedPassword;

--- a/leeyeseo/src/main/java/com/example/blog/domain/user/repository/UserRepository.java
+++ b/leeyeseo/src/main/java/com/example/blog/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.example.blog.domain.user.repository;
 
+import com.example.blog.domain.user.entity.Provider;
 import com.example.blog.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -15,4 +16,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 닉네임 중복 체크 (회원가입 시 사용)
     boolean existsByNickname(String nickname);
+
+    // OAuth 제공자 + 제공자 ID로 사용자 조회 (카카오 로그인 시 사용)
+    Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
 }

--- a/leeyeseo/src/main/java/com/example/blog/dto/auth/kakao/KakaoLoginRequest.java
+++ b/leeyeseo/src/main/java/com/example/blog/dto/auth/kakao/KakaoLoginRequest.java
@@ -1,0 +1,17 @@
+package com.example.blog.dto.auth.kakao;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "카카오 로그인 요청 DTO")
+public class KakaoLoginRequest {
+
+    @Schema(description = "카카오 인가 코드 (카카오 로그인 후 redirect URI로 전달받음)",
+            example = "abc123def456")
+    @NotBlank(message = "인가 코드는 필수입니다.")
+    private String code;
+}

--- a/leeyeseo/src/main/java/com/example/blog/dto/auth/kakao/KakaoTokenResponse.java
+++ b/leeyeseo/src/main/java/com/example/blog/dto/auth/kakao/KakaoTokenResponse.java
@@ -1,0 +1,34 @@
+package com.example.blog.dto.auth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * 카카오 토큰 발급 API 응답
+ * POST https://kauth.kakao.com/oauth/token
+ */
+@Getter
+@NoArgsConstructor
+@ToString
+public class KakaoTokenResponse {
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    private Integer refreshTokenExpiresIn;
+
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/leeyeseo/src/main/java/com/example/blog/dto/auth/kakao/KakaoUserInfoResponse.java
+++ b/leeyeseo/src/main/java/com/example/blog/dto/auth/kakao/KakaoUserInfoResponse.java
@@ -1,0 +1,64 @@
+package com.example.blog.dto.auth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * 카카오 사용자 정보 조회 API 응답
+ * GET https://kapi.kakao.com/v2/user/me
+ */
+@Getter
+@NoArgsConstructor
+@ToString
+public class KakaoUserInfoResponse {
+
+    @JsonProperty("id")
+    private Long id;   // 카카오 회원번호 (고유 식별자)
+
+    @JsonProperty("properties")
+    private Properties properties;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @NoArgsConstructor
+    @ToString
+    public static class Properties {
+
+        @JsonProperty("nickname")
+        private String nickname;
+
+        @JsonProperty("profile_image")
+        private String profileImage;
+
+        @JsonProperty("thumbnail_image")
+        private String thumbnailImage;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @ToString
+    public static class KakaoAccount {
+
+        @JsonProperty("profile")
+        private Profile profile;
+
+        @JsonProperty("email")
+        private String email;   // 비즈 앱 전환 시에만 받을 수 있음
+
+        @Getter
+        @NoArgsConstructor
+        @ToString
+        public static class Profile {
+
+            @JsonProperty("nickname")
+            private String nickname;
+
+            @JsonProperty("profile_image_url")
+            private String profileImageUrl;
+        }
+    }
+}

--- a/leeyeseo/src/main/java/com/example/blog/exception/GlobalExceptionHandler.java
+++ b/leeyeseo/src/main/java/com/example/blog/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.example.blog.exception;
 
 import com.example.blog.global.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -228,6 +230,7 @@ public class GlobalExceptionHandler {
     // 서버 내부 오류 500
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("서버 내부 오류 발생", e);
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.onFailure(

--- a/leeyeseo/src/main/java/com/example/blog/global/oauth/KakaoOAuthClient.java
+++ b/leeyeseo/src/main/java/com/example/blog/global/oauth/KakaoOAuthClient.java
@@ -25,6 +25,9 @@ public class KakaoOAuthClient {
     @Value("${kakao.client-id}")
     private String clientId;
 
+    @Value("${kakao.client-secret}")
+    private String clientSecret;
+
     @Value("${kakao.redirect-uri}")
     private String redirectUri;
 
@@ -43,14 +46,13 @@ public class KakaoOAuthClient {
      * POST https://kauth.kakao.com/oauth/token
      */
     public KakaoTokenResponse getAccessToken(String code) {
-        // HTTP 헤더 설정
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        // HTTP 바디 설정 (x-www-form-urlencoded)
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
         body.add("redirect_uri", redirectUri);
         body.add("code", code);
 

--- a/leeyeseo/src/main/java/com/example/blog/global/oauth/KakaoOAuthClient.java
+++ b/leeyeseo/src/main/java/com/example/blog/global/oauth/KakaoOAuthClient.java
@@ -1,0 +1,115 @@
+package com.example.blog.global.oauth;
+
+import com.example.blog.dto.auth.kakao.KakaoTokenResponse;
+import com.example.blog.dto.auth.kakao.KakaoUserInfoResponse;
+import com.example.blog.exception.InvalidTokenException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+public class KakaoOAuthClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${kakao.token-uri}")
+    private String tokenUri;
+
+    @Value("${kakao.user-info-uri}")
+    private String userInfoUri;
+
+    public KakaoOAuthClient(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    /**
+     * 1단계: 인가 코드로 카카오 액세스 토큰 발급
+     * POST https://kauth.kakao.com/oauth/token
+     */
+    public KakaoTokenResponse getAccessToken(String code) {
+        // HTTP 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        // HTTP 바디 설정 (x-www-form-urlencoded)
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        try {
+            ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
+                    tokenUri,
+                    HttpMethod.POST,
+                    request,
+                    KakaoTokenResponse.class
+            );
+
+            KakaoTokenResponse tokenResponse = response.getBody();
+            if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
+                log.warn("카카오 토큰 응답이 비어있습니다.");
+                throw new InvalidTokenException();
+            }
+
+            log.info("카카오 액세스 토큰 발급 성공");
+            return tokenResponse;
+
+        } catch (RestClientException e) {
+            log.warn("카카오 토큰 발급 실패: {}", e.getMessage());
+            throw new InvalidTokenException();
+        }
+    }
+
+    /**
+     * 2단계: 카카오 액세스 토큰으로 사용자 정보 조회
+     * GET https://kapi.kakao.com/v2/user/me
+     */
+    public KakaoUserInfoResponse getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<KakaoUserInfoResponse> response = restTemplate.exchange(
+                    userInfoUri,
+                    HttpMethod.GET,
+                    request,
+                    KakaoUserInfoResponse.class
+            );
+
+            KakaoUserInfoResponse userInfo = response.getBody();
+            if (userInfo == null || userInfo.getId() == null) {
+                log.warn("카카오 사용자 정보 응답이 비어있습니다.");
+                throw new InvalidTokenException();
+            }
+
+            log.info("카카오 사용자 정보 조회 성공: kakaoId={}", userInfo.getId());
+            return userInfo;
+
+        } catch (RestClientException e) {
+            log.warn("카카오 사용자 정보 조회 실패: {}", e.getMessage());
+            throw new InvalidTokenException();
+        }
+    }
+}

--- a/leeyeseo/src/main/resources/application.yaml
+++ b/leeyeseo/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: local
   datasource:
     url: jdbc:h2:mem:testdb
     driver-class-name: org.h2.Driver
@@ -14,6 +16,14 @@ spring:
 
 # JWT 설정
 jwt:
-  secret: LeetsBackendKx5_93Jv_1Rz_lQwT9pXe3bD7sUaFzYtAbCdEfGhIjKlMnOpQrStUvWxYz
-  access-token-expiration: 1800000
-  refresh-token-expiration: 1209600000
+  secret: ${JWT_SECRET}
+  access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:1800000}
+  refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:1209600000}
+
+# 카카오 OAuth 설정
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/auth/kakao/callback}
+  authorization-uri: https://kauth.kakao.com/oauth/authorize
+  token-uri: https://kauth.kakao.com/oauth/token
+  user-info-uri: https://kapi.kakao.com/v2/user/me

--- a/leeyeseo/src/main/resources/application.yaml
+++ b/leeyeseo/src/main/resources/application.yaml
@@ -23,6 +23,7 @@ jwt:
 # 카카오 OAuth 설정
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
   redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/auth/kakao/callback}
   authorization-uri: https://kauth.kakao.com/oauth/authorize
   token-uri: https://kauth.kakao.com/oauth/token


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용
- [x] 카카오 OAuth 회원가입/로그인 구현
- [x] 카카오 사용자 식별 (provider + providerId)
- [x] 자동 회원가입 + 자동 로그인 통합 처리
- [x] 6주차 JWT 시스템과 통합 (동일한 TokenResponse 응답)

## 2. 핵심 변경 사항

### 신규 패키지/파일
- **`global/oauth/`** — 카카오 OAuth 외부 통신
  - `KakaoOAuthClient` — RestTemplate으로 카카오 토큰 발급 + 사용자 정보 조회
- **`dto/auth/kakao/`** — 카카오 OAuth DTO
  - `KakaoLoginRequest` / `KakaoTokenResponse` / `KakaoUserInfoResponse`
- **`config/RestTemplateConfig`** — RestTemplate Bean 등록

### 기존 코드 수정
- `User` 엔티티에 `provider`, `providerId` 필드 추가 + `Provider` enum 신규 (LOCAL/KAKAO)
- `UserRepository`에 `findByProviderAndProviderId` 추가
- `AuthService.kakaoLogin(code)` 메서드 추가
- `AuthController`에 `GET /auth/kakao`, `POST /auth/kakao/login` 추가
- JWT/카카오 설정을 `application-local.yaml`로 분리 (gitignore)

## 3. 실행 및 검증 결과
- `GET /auth/kakao` → 카카오 로그인 URL 응답 확인
- 브라우저로 카카오 페이지에서 로그인 + 동의
- `POST /auth/kakao/login` → 인가코드로 우리 서비스 JWT 발급 성공
<img width="689" height="592" alt="스크린샷 2026-05-19 오후 10 32 26" src="https://github.com/user-attachments/assets/85c4b44f-9506-470a-ae43-ce0c9f5f5aa3" />

<img width="306" height="231" alt="image" src="https://github.com/user-attachments/assets/d8abf5f9-9297-4e7b-96ef-bc5819a9b71c" />

## 4. 완료 사항
1. 카카오 OAuth 클라이언트 구현
2. 카카오 사용자 자동 회원가입 로직
3. 가짜 이메일 생성 (`kakao_{providerId}@kakao.local`)
4. 닉네임 중복 시 카카오 ID 일부 붙여서 고유화
5. 환경변수 분리로 보안 강화

## 5. 추가 사항
- 관련 이슈: closed #258

## 제출 체크리스트
- [x] PR 제목이 규칙에 맞다
- [x] base가 `이예서/main` 브랜치다
- [x] compare가 `이예서/7주차` 브랜치다
- [x] 본인을 Assignee로 지정했다

