### PR TITLE
[7주차] 조연준/[feat] 카카오 OAuth 로그인

### DIFF
--- a/src/main/java/com/example/leets_exercise1/auth/config/RestClientConfig.java
+++ b/src/main/java/com/example/leets_exercise1/auth/config/RestClientConfig.java
@@ -1,0 +1,13 @@
+package com.example.leets_exercise1.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+    @Bean
+    public RestClient restClient() {
+        return RestClient.create();
+    }
+}

--- a/src/main/java/com/example/leets_exercise1/auth/controller/AuthController.java
+++ b/src/main/java/com/example/leets_exercise1/auth/controller/AuthController.java
@@ -1,8 +1,10 @@
 package com.example.leets_exercise1.auth.controller;
 
+import com.example.leets_exercise1.auth.dto.request.KakaoLoginRequest;
 import com.example.leets_exercise1.auth.dto.request.LoginRequest;
 import com.example.leets_exercise1.auth.dto.request.SignUpRequest;
 import com.example.leets_exercise1.auth.dto.request.TokenReissueRequest;
+import com.example.leets_exercise1.auth.dto.response.KakaoLoginUrlResponse;
 import com.example.leets_exercise1.auth.dto.response.LoginResponse;
 import com.example.leets_exercise1.auth.dto.response.SignUpResponse;
 import com.example.leets_exercise1.auth.dto.response.TokenReissueResponse;
@@ -12,8 +14,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,6 +36,21 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
         return ResponseEntity.ok(ApiResponse.success("2000", "로그인에 성공했습니다.", authService.login(request)));
+    }
+
+    @GetMapping("/kakao/url")
+    public ResponseEntity<ApiResponse<KakaoLoginUrlResponse>> getKakaoLoginUrl() {
+        return ResponseEntity.ok(ApiResponse.success("2002", "카카오 로그인 URL 조회에 성공했습니다.", authService.getKakaoLoginUrl()));
+    }
+
+    @PostMapping("/kakao/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> kakaoLogin(@Valid @RequestBody KakaoLoginRequest request) {
+        return ResponseEntity.ok(ApiResponse.success("2003", "카카오 로그인에 성공했습니다.", authService.kakaoLogin(request)));
+    }
+
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<ApiResponse<LoginResponse>> kakaoCallback(@RequestParam String code) {
+        return ResponseEntity.ok(ApiResponse.success("2003", "카카오 로그인에 성공했습니다.", authService.kakaoLogin(new KakaoLoginRequest(code))));
     }
 
     @PostMapping("/reissue")

--- a/src/main/java/com/example/leets_exercise1/auth/dto/kakao/KakaoTokenResponse.java
+++ b/src/main/java/com/example/leets_exercise1/auth/dto/kakao/KakaoTokenResponse.java
@@ -1,0 +1,21 @@
+package com.example.leets_exercise1.auth.dto.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoTokenResponse {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+}

--- a/src/main/java/com/example/leets_exercise1/auth/dto/kakao/KakaoUserInfoResponse.java
+++ b/src/main/java/com/example/leets_exercise1/auth/dto/kakao/KakaoUserInfoResponse.java
@@ -1,0 +1,41 @@
+package com.example.leets_exercise1.auth.dto.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfoResponse {
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @NoArgsConstructor
+    public static class KakaoAccount {
+        private String email;
+        private Profile profile;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Profile {
+        private String nickname;
+    }
+
+    public String getEmail() {
+        if (kakaoAccount == null || kakaoAccount.getEmail() == null) {
+            return "kakao_" + id + "@kakao.local";
+        }
+        return kakaoAccount.getEmail();
+    }
+
+    public String getNickname() {
+        if (kakaoAccount == null || kakaoAccount.getProfile() == null || kakaoAccount.getProfile().getNickname() == null) {
+            return "kakao_" + id;
+        }
+        return kakaoAccount.getProfile().getNickname();
+    }
+}

--- a/src/main/java/com/example/leets_exercise1/auth/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/example/leets_exercise1/auth/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,16 @@
+package com.example.leets_exercise1.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoLoginRequest {
+    @NotBlank(message = "인가 코드는 필수입니다.")
+    private String code;
+
+    public KakaoLoginRequest(String code) {
+        this.code = code;
+    }
+}

--- a/src/main/java/com/example/leets_exercise1/auth/dto/response/KakaoLoginUrlResponse.java
+++ b/src/main/java/com/example/leets_exercise1/auth/dto/response/KakaoLoginUrlResponse.java
@@ -1,0 +1,10 @@
+package com.example.leets_exercise1.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class KakaoLoginUrlResponse {
+    private String loginUrl;
+}

--- a/src/main/java/com/example/leets_exercise1/auth/exception/KakaoLoginFailedException.java
+++ b/src/main/java/com/example/leets_exercise1/auth/exception/KakaoLoginFailedException.java
@@ -1,0 +1,7 @@
+package com.example.leets_exercise1.auth.exception;
+
+public class KakaoLoginFailedException extends RuntimeException {
+    public KakaoLoginFailedException() {
+        super("카카오 로그인에 실패했습니다.");
+    }
+}

--- a/src/main/java/com/example/leets_exercise1/auth/security/SecurityConfig.java
+++ b/src/main/java/com/example/leets_exercise1/auth/security/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .formLogin(formLogin -> formLogin.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/signup", "/auth/login", "/auth/reissue").permitAll()
+                        .requestMatchers("/auth/signup", "/auth/login", "/auth/reissue", "/auth/kakao/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/health").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/example/leets_exercise1/auth/service/AuthService.java
+++ b/src/main/java/com/example/leets_exercise1/auth/service/AuthService.java
@@ -1,8 +1,10 @@
 package com.example.leets_exercise1.auth.service;
 
 import com.example.leets_exercise1.auth.dto.request.LoginRequest;
+import com.example.leets_exercise1.auth.dto.request.KakaoLoginRequest;
 import com.example.leets_exercise1.auth.dto.request.SignUpRequest;
 import com.example.leets_exercise1.auth.dto.request.TokenReissueRequest;
+import com.example.leets_exercise1.auth.dto.response.KakaoLoginUrlResponse;
 import com.example.leets_exercise1.auth.dto.response.LoginResponse;
 import com.example.leets_exercise1.auth.dto.response.SignUpResponse;
 import com.example.leets_exercise1.auth.dto.response.TokenReissueResponse;
@@ -11,6 +13,10 @@ public interface AuthService {
     SignUpResponse signUp(SignUpRequest request);
 
     LoginResponse login(LoginRequest request);
+
+    KakaoLoginUrlResponse getKakaoLoginUrl();
+
+    LoginResponse kakaoLogin(KakaoLoginRequest request);
 
     TokenReissueResponse reissue(TokenReissueRequest request);
 }

--- a/src/main/java/com/example/leets_exercise1/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/leets_exercise1/auth/service/AuthServiceImpl.java
@@ -1,13 +1,18 @@
 package com.example.leets_exercise1.auth.service;
 
+import com.example.leets_exercise1.auth.dto.kakao.KakaoTokenResponse;
+import com.example.leets_exercise1.auth.dto.kakao.KakaoUserInfoResponse;
+import com.example.leets_exercise1.auth.dto.request.KakaoLoginRequest;
 import com.example.leets_exercise1.auth.dto.request.LoginRequest;
 import com.example.leets_exercise1.auth.dto.request.SignUpRequest;
 import com.example.leets_exercise1.auth.dto.request.TokenReissueRequest;
+import com.example.leets_exercise1.auth.dto.response.KakaoLoginUrlResponse;
 import com.example.leets_exercise1.auth.dto.response.LoginResponse;
 import com.example.leets_exercise1.auth.dto.response.SignUpResponse;
 import com.example.leets_exercise1.auth.dto.response.TokenReissueResponse;
 import com.example.leets_exercise1.auth.exception.EmailAlreadyExistsException;
 import com.example.leets_exercise1.auth.exception.InvalidLoginException;
+import com.example.leets_exercise1.auth.exception.KakaoLoginFailedException;
 import com.example.leets_exercise1.auth.exception.NicknameAlreadyExistsException;
 import com.example.leets_exercise1.auth.exception.RefreshTokenNotFoundException;
 import com.example.leets_exercise1.auth.jwt.JwtTokenProvider;
@@ -18,18 +23,41 @@ import com.example.leets_exercise1.domain.user.User;
 import com.example.leets_exercise1.repository.RefreshTokenRepository;
 import com.example.leets_exercise1.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AuthServiceImpl implements AuthService {
+    private static final String KAKAO_AUTHORIZE_URL = "https://kauth.kakao.com/oauth/authorize";
+    private static final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RestClient restClient;
+
+    @Value("${kakao.client-id:}")
+    private String kakaoClientId;
+
+    @Value("${kakao.redirect-uri:}")
+    private String kakaoRedirectUri;
+
+    @Value("${kakao.client-secret:}")
+    private String kakaoClientSecret;
 
     @Override
     @Transactional
@@ -64,6 +92,127 @@ public class AuthServiceImpl implements AuthService {
             throw new InvalidLoginException();
         }
 
+        return issueTokenResponse(user);
+    }
+
+    @Override
+    public KakaoLoginUrlResponse getKakaoLoginUrl() {
+        validateKakaoProperties();
+
+        String loginUrl = UriComponentsBuilder.fromUriString(KAKAO_AUTHORIZE_URL)
+                .queryParam("client_id", kakaoClientId)
+                .queryParam("redirect_uri", kakaoRedirectUri)
+                .queryParam("response_type", "code")
+                .build()
+                .toUriString();
+
+        return KakaoLoginUrlResponse.builder()
+                .loginUrl(loginUrl)
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public LoginResponse kakaoLogin(KakaoLoginRequest request) {
+        validateKakaoProperties();
+
+        KakaoTokenResponse tokenResponse = requestKakaoToken(request.getCode());
+        if (tokenResponse == null || !StringUtils.hasText(tokenResponse.getAccessToken())) {
+            throw new KakaoLoginFailedException();
+        }
+        KakaoUserInfoResponse userInfo = requestKakaoUserInfo(tokenResponse.getAccessToken());
+        User user = findOrCreateKakaoUser(userInfo);
+
+        return issueTokenResponse(user);
+    }
+
+    @Override
+    public TokenReissueResponse reissue(TokenReissueRequest request) {
+        if (!jwtTokenProvider.validateToken(request.getRefreshToken())) {
+            throw new RefreshTokenNotFoundException();
+        }
+
+        RefreshToken savedToken = refreshTokenRepository.findByRefreshToken(request.getRefreshToken())
+                .orElseThrow(RefreshTokenNotFoundException::new);
+        User user = savedToken.getUser();
+
+        return TokenReissueResponse.builder()
+                .accessToken(jwtTokenProvider.createAccessToken(user.getId(), user.getEmail()))
+                .build();
+    }
+
+    private KakaoTokenResponse requestKakaoToken(String code) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", kakaoClientId);
+        body.add("redirect_uri", kakaoRedirectUri);
+        body.add("code", code);
+        if (StringUtils.hasText(kakaoClientSecret)) {
+            body.add("client_secret", kakaoClientSecret);
+        }
+
+        try {
+            return restClient.post()
+                    .uri(KAKAO_TOKEN_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(body)
+                    .retrieve()
+                    .body(KakaoTokenResponse.class);
+        } catch (RestClientException e) {
+            throw new KakaoLoginFailedException();
+        }
+    }
+
+    private KakaoUserInfoResponse requestKakaoUserInfo(String kakaoAccessToken) {
+        if (!StringUtils.hasText(kakaoAccessToken)) {
+            throw new KakaoLoginFailedException();
+        }
+
+        try {
+            return restClient.get()
+                    .uri(KAKAO_USER_INFO_URL)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + kakaoAccessToken)
+                    .retrieve()
+                    .body(KakaoUserInfoResponse.class);
+        } catch (RestClientException e) {
+            throw new KakaoLoginFailedException();
+        }
+    }
+
+    private User findOrCreateKakaoUser(KakaoUserInfoResponse userInfo) {
+        if (userInfo == null || userInfo.getId() == null) {
+            throw new KakaoLoginFailedException();
+        }
+
+        String providerId = String.valueOf(userInfo.getId());
+        return userRepository.findByProviderAndProviderId(AuthProvider.KAKAO, providerId)
+                .or(() -> userRepository.findByEmail(userInfo.getEmail()))
+                .orElseGet(() -> userRepository.save(User.builder()
+                        .age(0)
+                        .name(userInfo.getNickname())
+                        .email(userInfo.getEmail())
+                        .nickname(createUniqueNickname(userInfo.getNickname(), providerId))
+                        .password("")
+                        .role(Role.USER)
+                        .provider(AuthProvider.KAKAO)
+                        .providerId(providerId)
+                        .build()));
+    }
+
+    private String createUniqueNickname(String nickname, String providerId) {
+        String baseNickname = StringUtils.hasText(nickname) ? nickname : "kakao_" + providerId;
+        String uniqueNickname = baseNickname;
+        int suffix = 1;
+
+        while (userRepository.existsByNickname(uniqueNickname)) {
+            uniqueNickname = baseNickname + "_" + providerId + "_" + suffix;
+            suffix++;
+        }
+
+        return uniqueNickname;
+    }
+
+    private LoginResponse issueTokenResponse(User user) {
         String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getEmail());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId(), user.getEmail());
 
@@ -85,18 +234,9 @@ public class AuthServiceImpl implements AuthService {
                 .build();
     }
 
-    @Override
-    public TokenReissueResponse reissue(TokenReissueRequest request) {
-        if (!jwtTokenProvider.validateToken(request.getRefreshToken())) {
-            throw new RefreshTokenNotFoundException();
+    private void validateKakaoProperties() {
+        if (!StringUtils.hasText(kakaoClientId) || !StringUtils.hasText(kakaoRedirectUri)) {
+            throw new KakaoLoginFailedException();
         }
-
-        RefreshToken savedToken = refreshTokenRepository.findByRefreshToken(request.getRefreshToken())
-                .orElseThrow(RefreshTokenNotFoundException::new);
-        User user = savedToken.getUser();
-
-        return TokenReissueResponse.builder()
-                .accessToken(jwtTokenProvider.createAccessToken(user.getId(), user.getEmail()))
-                .build();
     }
 }

--- a/src/main/java/com/example/leets_exercise1/domain/user/User.java
+++ b/src/main/java/com/example/leets_exercise1/domain/user/User.java
@@ -47,6 +47,9 @@ public class User {
     @Column(nullable = false, length = 20)
     private AuthProvider provider;
 
+    @Column(name = "provider_id", length = 100)
+    private String providerId;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -65,7 +68,7 @@ public class User {
     private List<Report> reports = new ArrayList<>();
 
     @Builder
-    public User(Integer age, String name, String email, String nickname, String password, Role role, AuthProvider provider) {
+    public User(Integer age, String name, String email, String nickname, String password, Role role, AuthProvider provider, String providerId) {
         this.age = age;
         this.name = name;
         this.email = email;
@@ -73,5 +76,6 @@ public class User {
         this.password = password == null ? "" : password;
         this.role = role == null ? Role.USER : role;
         this.provider = provider == null ? AuthProvider.LOCAL : provider;
+        this.providerId = providerId;
     }
 }

--- a/src/main/java/com/example/leets_exercise1/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/leets_exercise1/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.leets_exercise1.exception;
 
 import com.example.leets_exercise1.auth.exception.EmailAlreadyExistsException;
 import com.example.leets_exercise1.auth.exception.InvalidLoginException;
+import com.example.leets_exercise1.auth.exception.KakaoLoginFailedException;
 import com.example.leets_exercise1.auth.exception.NicknameAlreadyExistsException;
 import com.example.leets_exercise1.auth.exception.RefreshTokenNotFoundException;
 import com.example.leets_exercise1.common.response.ApiResponse;
@@ -83,6 +84,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(RefreshTokenNotFoundException.class)
     public ResponseEntity<ApiResponse<Map<String, Object>>> handleRefreshTokenNotFoundException(RefreshTokenNotFoundException e) {
         return error(HttpStatus.UNAUTHORIZED, "4011", e.getMessage());
+    }
+
+    @ExceptionHandler(KakaoLoginFailedException.class)
+    public ResponseEntity<ApiResponse<Map<String, Object>>> handleKakaoLoginFailedException(KakaoLoginFailedException e) {
+        return error(HttpStatus.BAD_REQUEST, "4005", e.getMessage());
     }
 
     @ExceptionHandler(NoResourceFoundException.class)

--- a/src/main/java/com/example/leets_exercise1/repository/UserRepository.java
+++ b/src/main/java/com/example/leets_exercise1/repository/UserRepository.java
@@ -1,12 +1,15 @@
 package com.example.leets_exercise1.repository;
 
 import com.example.leets_exercise1.domain.user.User;
+import com.example.leets_exercise1.domain.user.AuthProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
 
     boolean existsByEmail(String email);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,7 @@ spring.jpa.defer-datasource-initialization=true
 springdoc.swagger-ui.path=/swagger-ui.html
 
 jwt.secret=leets-exercise1-local-development-jwt-secret-key-2026
+
+kakao.client-id=686b69322f558da97e6c676293d9612d
+kakao.redirect-uri=${KAKAO_REDIRECT_URI:http://localhost:8081/auth/kakao/callback}
+kakao.client-secret=${KAKAO_CLIENT_SECRET:}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,5 +1,5 @@
-INSERT INTO users (id, age, name, email, nickname, password, role, provider, created_at, updated_at)
-VALUES (100, 24, 'sample user', 'sample@example.com', 'sample-user', '$2a$10$2bMWiPi4yWjY/dYpY2hTneTOwp9LbWgU5nfCNLqYC9Ub5PTJT1KdS', 'USER', 'LOCAL', NOW(), NOW());
+INSERT INTO users (id, age, name, email, nickname, password, role, provider, provider_id, created_at, updated_at)
+VALUES (100, 24, 'sample user', 'sample@example.com', 'sample-user', '$2a$10$2bMWiPi4yWjY/dYpY2hTneTOwp9LbWgU5nfCNLqYC9Ub5PTJT1KdS', 'USER', 'LOCAL', NULL, NOW(), NOW());
 
 INSERT INTO post (id, user_id, title, content, description, created_at, updated_at, deleted_at, active)
 VALUES (100, 100, 'sample post', 'sample content', 'sample description', NOW(), NOW(), NULL, TRUE);


### PR DESCRIPTION
## 작업 내용
- 카카오 OAuth 로그인 기능을 구현했습니다.
- 카카오 인가 코드 기반 토큰 발급 로직을 추가했습니다.
- 카카오 사용자 정보 조회 후 신규 회원가입 또는 기존 사용자 로그인을 처리하도록 구현했습니다.
- 기존 JWT 인증 방식과 연결하여 accessToken / refreshToken을 발급하도록 구현했습니다.
- 카카오 로그인 URL 조회 및 callback API를 추가했습니다.

## API
- `GET /auth/kakao/url`
- `GET /auth/kakao/callback`
- `POST /auth/kakao/login`

## 설정
카카오 Developers에 아래 Redirect URI 등록이 필요합니다.

```text
http://localhost:8081/auth/kakao/callback
```
<img width="1055" height="901" alt="카카오 로그인 url 받기" src="https://github.com/user-attachments/assets/4715dff8-cd10-41e2-bd5a-0857d662ea3b" />