### PR TITLE
[7주차] 이교형[feat] 카카오 OAuth 로그인 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ out/
 # OS generated files
 .DS_Store
 Thumbs.db
+
+# yaml
+*.yml
+*.yaml

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/leets_project/LeetsProjectApplication.java
+++ b/src/main/java/com/example/leets_project/LeetsProjectApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
-@ConfigurationPropertiesScan("com.example.leets_project.common.security.jwt")
+@ConfigurationPropertiesScan("com.example.leets_project.common.security.jwt, com.example.leets_project.domain.auth.oauth.kakao" )
 @SpringBootApplication
 public class LeetsProjectApplication {
 

--- a/src/main/java/com/example/leets_project/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/leets_project/common/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.example.leets_project.common.security.jwt.JwtAccessDeniedHandler;
 import com.example.leets_project.common.security.jwt.JwtAuthenticationEntryPoint;
 import com.example.leets_project.common.security.jwt.JwtAuthenticationFilter;
 import com.example.leets_project.common.security.jwt.JwtProperties;
+import com.example.leets_project.domain.auth.oauth.kakao.KakaoOAuthProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -23,7 +24,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({JwtProperties.class, KakaoOAuthProperties.class})
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -44,7 +45,7 @@ public class SecurityConfig {
                 )
                 // URL 권한 설정
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**", "/api/users/signup").permitAll()
+                        .requestMatchers("/api/auth/**","/oauth/kakao/callback", "/api/users/signup").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/h2-console/**", "/error").permitAll()

--- a/src/main/java/com/example/leets_project/common/config/WebClientConfig.java
+++ b/src/main/java/com/example/leets_project/common/config/WebClientConfig.java
@@ -1,0 +1,25 @@
+package com.example.leets_project.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    // OAuth 전용(인가 코드 교환, 토큰 갱신..)
+    @Bean
+    public WebClient kakaoAuthWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://kauth.kakao.com")
+                .build();
+    }
+
+    // 오픈 API 전용(유저 프로필 조회, 목록 조회..)
+    @Bean
+    public WebClient kakaoApiWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://kapi.kakao.com")
+                .build();
+    }
+}

--- a/src/main/java/com/example/leets_project/common/response/ErrorCode.java
+++ b/src/main/java/com/example/leets_project/common/response/ErrorCode.java
@@ -47,7 +47,11 @@ public enum ErrorCode {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_4003", "만료된 토큰입니다."),
     INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "AUTH_4004", "토큰 타입이 올바르지 않습니다."),
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_4005", "이메일 또는 비밀번호가 올바르지 않습니다."),
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_4040", "리프레시 토큰이 존재하지 않습니다.");
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_4040", "리프레시 토큰이 존재하지 않습니다."),
+    // Kakao
+    KAKAO_TOKEN_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "KAKAO_4000", "카카오 토큰 요청에 실패했습니다."),
+    KAKAO_USER_INFO_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "KAKAO_4001", "카카오 사용자 정보 요청에 실패했습니다."),
+    KAKAO_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "KAKAO_4002", "카카오 계정 이메일이 존재하지 않습니다.");
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/com/example/leets_project/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/leets_project/common/security/jwt/JwtTokenProvider.java
@@ -16,7 +16,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Date;
+import java.util.HexFormat;
 import java.util.List;
 
 @Slf4j
@@ -152,5 +156,16 @@ public class JwtTokenProvider {
             return bearerToken.substring(BEARER_PREFIX.length());
         }
         return null;
+    }
+
+    // DB 해킹 -> refresh token 탈취 방지 -> 복호화(해싱)
+    public String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] encoded = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(encoded);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm is not available", e);
+        }
     }
 }

--- a/src/main/java/com/example/leets_project/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/leets_project/domain/auth/entity/RefreshToken.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 @Entity
@@ -21,21 +22,25 @@ public class RefreshToken {
     @Column(nullable = false, unique = true)
     private Long userId;
 
-    @Column(nullable = false, length = 500)
-    private String token;
+    @Column(nullable = false, length = 128)
+    private String tokenHash;
 
     @Column(nullable = false)
-    private LocalDateTime expiresAt;
+    private Instant expiresAt;
 
     @Builder
-    public RefreshToken(Long userId, String token, LocalDateTime expiresAt) {
+    private RefreshToken(Long userId, String tokenHash, Instant expiresAt) {
         this.userId = userId;
-        this.token = token;
+        this.tokenHash = tokenHash;
         this.expiresAt = expiresAt;
     }
 
-    public void rotate(String newToken, LocalDateTime expiresAt) {
-        this.token = newToken;
+    public void rotate(String tokenHash, Instant expiresAt) {
+        this.tokenHash = tokenHash;
         this.expiresAt = expiresAt;
+    }
+
+    public boolean isExpired(Instant now) {
+        return expiresAt.isBefore(now);
     }
 }

--- a/src/main/java/com/example/leets_project/domain/auth/oauth/kakao/KakaoOAuthClient.java
+++ b/src/main/java/com/example/leets_project/domain/auth/oauth/kakao/KakaoOAuthClient.java
@@ -1,0 +1,85 @@
+package com.example.leets_project.domain.auth.oauth.kakao;
+
+import com.example.leets_project.common.exception.GeneralException;
+import com.example.leets_project.common.response.ErrorCode;
+import com.example.leets_project.domain.auth.oauth.kakao.dto.KakaoTokenResponse;
+import com.example.leets_project.domain.auth.oauth.kakao.dto.KakaoUserInfo;
+import com.example.leets_project.domain.auth.oauth.kakao.dto.KakaoUserResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthClient {
+
+    @Qualifier("kakaoAuthWebClient")
+    private final WebClient kakaoAuthWebClient;
+
+    @Qualifier("kakaoApiWebClient")
+    private final WebClient kakaoApiWebClient;
+
+    private final KakaoOAuthProperties properties;
+
+    // 인가 코드를 카카오 토큰 인증 서버에 전송 -> Access Token 획득
+    public KakaoTokenResponse requestToken(String code) {
+        try {
+            BodyInserters.FormInserter<String> formData = BodyInserters
+                    .fromFormData("grant_type", "authorization_code")
+                    .with("client_id", properties.clientId())
+                    .with("redirect_uri", properties.redirectUri())
+                    .with("code", code);
+
+            if (properties.clientSecret() != null && !properties.clientSecret().isBlank()) {
+                formData.with("client_secret", properties.clientSecret());
+            }
+
+            return kakaoAuthWebClient.post()
+                    .uri("/oauth/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(formData)
+                    .retrieve()
+                    .bodyToMono(KakaoTokenResponse.class)
+                    .block();
+        // 소셜 로그인 실패시 상세 로그 띄우기
+        } catch (WebClientResponseException e) {
+            log.error("카카오 토큰 요청 실패 status={}, body={}",
+                    e.getStatusCode(),
+                    e.getResponseBodyAsString()
+            );
+            throw new GeneralException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
+        } catch (Exception e) {
+            log.error("카카오 토큰 요청 실패", e);
+            throw new GeneralException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
+        }
+    }
+
+    // 카카오 액세스 토큰 Bearer 헤더에 실어 카카오 서버로부터 유저 개인정보 상세 조회
+    public KakaoUserInfo requestUserInfo(String accessToken) {
+        try {
+            KakaoUserResponse response = kakaoApiWebClient.get()
+                    .uri("/v2/user/me")
+                    .headers(headers -> headers.setBearerAuth(accessToken))
+                    .retrieve()
+                    .bodyToMono(KakaoUserResponse.class)
+                    .block();
+
+            if (response == null || response.id() == null) {
+                throw new GeneralException(ErrorCode.KAKAO_USER_INFO_REQUEST_FAILED);
+            }
+
+            return KakaoUserInfo.from(response);
+
+        } catch (GeneralException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new GeneralException(ErrorCode.KAKAO_USER_INFO_REQUEST_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/example/leets_project/domain/auth/oauth/kakao/KakaoOAuthProperties.java
+++ b/src/main/java/com/example/leets_project/domain/auth/oauth/kakao/KakaoOAuthProperties.java
@@ -1,0 +1,10 @@
+package com.example.leets_project.domain.auth.oauth.kakao;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.kakao")
+public record KakaoOAuthProperties(
+        String clientId,
+        String clientSecret,
+        String redirectUri
+) {}

--- a/src/main/java/com/example/leets_project/domain/auth/oauth/kakao/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/example/leets_project/domain/auth/oauth/kakao/dto/KakaoTokenResponse.java
@@ -1,0 +1,23 @@
+package com.example.leets_project.domain.auth.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoTokenResponse(
+        @JsonProperty("access_token")
+        String accessToken,
+
+        @JsonProperty("token_type")
+        String tokenType,
+
+        @JsonProperty("refresh_token")
+        String refreshToken,
+
+        @JsonProperty("expires_in")
+        Integer expiresIn,
+
+        @JsonProperty("scope")
+        String scope,
+
+        @JsonProperty("refresh_token_expires_in")
+        Integer refreshTokenExpiresIn
+) {}

--- a/src/main/java/com/example/leets_project/domain/auth/oauth/kakao/dto/KakaoUserInfo.java
+++ b/src/main/java/com/example/leets_project/domain/auth/oauth/kakao/dto/KakaoUserInfo.java
@@ -1,0 +1,27 @@
+package com.example.leets_project.domain.auth.oauth.kakao.dto;
+
+public record KakaoUserInfo(
+        String providerId,
+        String email,
+        String nickname,
+        String profileImageUrl
+) { // 개인정보 제공 동의 여부에 따른 null 값 방지
+    public static KakaoUserInfo from(KakaoUserResponse response) {
+        KakaoUserResponse.KakaoAccount account = response.kakaoAccount();
+        KakaoUserResponse.Profile profile = account != null ? account.profile() : null;
+
+        String nickname = profile != null ? profile.nickname() : null;
+        String profileImageUrl = profile != null ? profile.profileImageUrl() : null;
+
+        if (nickname == null && response.properties() != null) {
+            nickname = response.properties().nickname();
+        }
+
+        return new KakaoUserInfo(
+                String.valueOf(response.id()),
+                account != null ? account.email() : null,
+                nickname,
+                profileImageUrl
+        );
+    }
+}

--- a/src/main/java/com/example/leets_project/domain/auth/oauth/kakao/dto/KakaoUserResponse.java
+++ b/src/main/java/com/example/leets_project/domain/auth/oauth/kakao/dto/KakaoUserResponse.java
@@ -1,0 +1,22 @@
+package com.example.leets_project.domain.auth.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserResponse(
+        Long id,
+        @JsonProperty("kakao_account")
+        KakaoAccount kakaoAccount,
+        Properties properties
+) {
+    public record KakaoAccount(String email, Profile profile) {}
+
+    public record Profile(
+            String nickname,
+            @JsonProperty("profile_image_url")
+            String profileImageUrl,
+            @JsonProperty("thumbnail_image_url")
+            String thumbnailImageUrl
+    ) {}
+
+    public record Properties(String nickname) {}
+}

--- a/src/main/java/com/example/leets_project/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/leets_project/domain/auth/repository/RefreshTokenRepository.java
@@ -9,7 +9,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     Optional<RefreshToken> findByUserId(Long userId);
 
-    Optional<RefreshToken> findByToken(String token);
 
     void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/leets_project/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/leets_project/domain/auth/service/AuthService.java
@@ -6,11 +6,10 @@ import com.example.leets_project.common.security.jwt.JwtProperties;
 import com.example.leets_project.common.security.jwt.JwtTokenProvider;
 import com.example.leets_project.common.security.jwt.TokenType;
 import com.example.leets_project.domain.auth.entity.RefreshToken;
+import com.example.leets_project.domain.auth.oauth.kakao.dto.KakaoUserInfo;
 import com.example.leets_project.domain.auth.repository.RefreshTokenRepository;
-import com.example.leets_project.domain.auth.web.dto.LoginRequest;
-import com.example.leets_project.domain.auth.web.dto.LoginResponse;
-import com.example.leets_project.domain.auth.web.dto.SignUpRequest;
-import com.example.leets_project.domain.auth.web.dto.TokenResponse;
+import com.example.leets_project.domain.auth.web.dto.*;
+import com.example.leets_project.domain.user.entity.AuthProvider;
 import com.example.leets_project.domain.user.entity.User;
 import com.example.leets_project.domain.user.repository.UserRepository;
 import io.jsonwebtoken.Claims;
@@ -22,6 +21,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 @Slf4j
@@ -35,6 +35,7 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtProperties jwtProperties;
     private final PasswordEncoder passwordEncoder;
+    private final KakaoOAuthService kakaoOAuthService;
 
     // 회원가입
     @Transactional
@@ -47,6 +48,8 @@ public class AuthService {
                 .nickname(request.nickname())
                 .email(request.email())
                 .password(passwordEncoder.encode(request.password()))
+                .authProvider(AuthProvider.LOCAL)
+                .providerId(null)
                 .build());
 
         log.info("회원가입 완료: email={}", request.email());
@@ -67,7 +70,7 @@ public class AuthService {
 
         return new LoginResult(
                 new LoginResponse(
-                        new TokenResponse(accessToken),
+                        TokenResponse.bearer(accessToken),
                         new LoginResponse.UserInfoResponse(
                                 user.getId(), user.getEmail(), user.getNickname())
                 ),
@@ -92,11 +95,11 @@ public class AuthService {
                 user.getId(), user.getEmail(), user.getRole().name());
         String newRefreshToken = jwtTokenProvider.generateRefreshToken(userId);
 
-        storedToken.rotate(newRefreshToken, calculateExpiryDate());
+        storedToken.rotate(jwtTokenProvider.sha256(newRefreshToken), calculateExpiryDate());
 
         log.info("토큰 재발급 성공: userId={}", userId);
 
-        return new ReissueResult(new TokenResponse(newAccessToken), newRefreshToken);
+        return new ReissueResult(TokenResponse.bearer(newAccessToken), newRefreshToken);
     }
     // 로그아웃
     @Transactional
@@ -112,6 +115,59 @@ public class AuthService {
         } catch (JwtException e) {
             log.warn("로그아웃 - 유효하지 않은 토큰");
         }
+    }
+
+    // 카카오 소셜 로그인/회원가입 처리
+    @Transactional
+    public LoginResult loginWithKakao(KakaoLoginRequest request) {
+        // 인가 코드로 카카오 API 호출해 유저 정보 획득
+        KakaoUserInfo kakaoUser = kakaoOAuthService.getUserInfo(request.code());
+
+        // 이미 가입된 유저인지 검증 후 신규 가입 진행
+        User user = userRepository
+                .findByAuthProviderAndProviderId(AuthProvider.KAKAO, kakaoUser.providerId())
+                .orElseGet(() -> createKakaoUser(kakaoUser));
+
+        return issueLoginTokens(user);
+    }
+
+    // 카카오 신규 유저 데이터베이스 등록
+    private User createKakaoUser(KakaoUserInfo kakaoUser) {
+        String nickname = kakaoUser.nickname() != null && !kakaoUser.nickname().isBlank()
+                ? kakaoUser.nickname()
+                : "kakao_" + kakaoUser.providerId();
+
+        return userRepository.save(User.builder()
+                .email(kakaoUser.email())
+                .nickname(nickname)
+                .name(nickname)
+                .password(null)
+                .authProvider(AuthProvider.KAKAO)
+                .providerId(kakaoUser.providerId())
+                .build());
+    }
+
+    // 소셜/로컬 공통 로그인 토큰 발급 헬퍼
+    private LoginResult issueLoginTokens(User user) {
+        String accessToken = jwtTokenProvider.generateAccessToken(
+                user.getId(),
+                user.getEmail(),
+                user.getRole().name()
+        );
+
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getId());
+        saveOrRotateRefreshToken(user.getId(), refreshToken);
+
+        LoginResponse response = new LoginResponse(
+                TokenResponse.bearer(accessToken),
+                new LoginResponse.UserInfoResponse(
+                        user.getId(),
+                        user.getEmail(),
+                        user.getNickname()
+                )
+        );
+
+        return new LoginResult(response, refreshToken);
     }
 
     public record LoginResult(LoginResponse loginResponse, String refreshToken) {}
@@ -146,12 +202,13 @@ public class AuthService {
     }
 
     private void validateStoredToken(RefreshToken storedToken, String refreshToken, Long userId) {
-        if (!storedToken.getToken().equals(refreshToken)) {
+        String refreshTokenHash = jwtTokenProvider.sha256(refreshToken);
+        if (!storedToken.getTokenHash().equals(refreshTokenHash)) {
             refreshTokenRepository.delete(storedToken);
             log.warn("RefreshToken 재사용 감지: userId={}", userId);
             throw new GeneralException(ErrorCode.INVALID_TOKEN);
         }
-        if (storedToken.getExpiresAt().isBefore(LocalDateTime.now())) {
+        if (storedToken.isExpired(Instant.now())) {
             refreshTokenRepository.delete(storedToken);
             log.warn("RefreshToken 만료: userId={}", userId);
             throw new GeneralException(ErrorCode.EXPIRED_TOKEN);
@@ -159,21 +216,21 @@ public class AuthService {
     }
     // Refresh token 저장/순환
     private void saveOrRotateRefreshToken(Long userId, String refreshToken) {
-        LocalDateTime expiresAt = calculateExpiryDate();
+        String tokenHash = jwtTokenProvider.sha256(refreshToken);
+        Instant expiresAt = calculateExpiryDate();
         refreshTokenRepository.findByUserId(userId)
                 .ifPresentOrElse(
-                        token -> token.rotate(refreshToken, expiresAt),
+                        token -> token.rotate(tokenHash, expiresAt),
                         () -> refreshTokenRepository.save(RefreshToken.builder()
                                 .userId(userId)
-                                .token(refreshToken)
+                                .tokenHash(tokenHash)
                                 .expiresAt(expiresAt)
                                 .build())
                 );
     }
     // 만료일자 계산
-    private LocalDateTime calculateExpiryDate() {
-        return LocalDateTime.now()
-                .plusSeconds(jwtProperties.getRefreshTokenExpirationMillis() / 1000);
+    private Instant calculateExpiryDate() {
+        return Instant.now().plusMillis(jwtProperties.getRefreshTokenExpirationMillis());
     }
     // 이메일 중복 검증
     private void validateDuplicateEmail(String email) {

--- a/src/main/java/com/example/leets_project/domain/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/example/leets_project/domain/auth/service/KakaoOAuthService.java
@@ -1,0 +1,19 @@
+package com.example.leets_project.domain.auth.service;
+
+import com.example.leets_project.domain.auth.oauth.kakao.KakaoOAuthClient;
+import com.example.leets_project.domain.auth.oauth.kakao.dto.KakaoTokenResponse;
+import com.example.leets_project.domain.auth.oauth.kakao.dto.KakaoUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService {
+
+    private final KakaoOAuthClient kakaoOAuthClient;
+
+    public KakaoUserInfo getUserInfo(String code) {
+        KakaoTokenResponse token = kakaoOAuthClient.requestToken(code);
+        return kakaoOAuthClient.requestUserInfo(token.accessToken());
+    }
+}

--- a/src/main/java/com/example/leets_project/domain/auth/web/controller/AuthController.java
+++ b/src/main/java/com/example/leets_project/domain/auth/web/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.example.leets_project.common.response.SuccessCode;
 import com.example.leets_project.common.security.jwt.JwtProperties;
 import com.example.leets_project.common.util.CookieUtil;
 import com.example.leets_project.domain.auth.service.AuthService;
+import com.example.leets_project.domain.auth.web.dto.KakaoLoginRequest;
 import com.example.leets_project.domain.auth.web.dto.LoginRequest;
 import com.example.leets_project.domain.auth.web.dto.SignUpRequest;
 import io.swagger.v3.oas.annotations.Operation;
@@ -74,6 +75,17 @@ public class AuthController {
         }
         cookieUtil.deleteRefreshTokenCookie(response);
         return GlobalResponse.onSuccess(SuccessCode.AUTH_LOGOUT);
+    }
+
+    // Kakao 로그인
+    @PostMapping("/kakao/login")
+    public ResponseEntity<GlobalResponse> kakaoLogin(@RequestBody @Valid KakaoLoginRequest request,
+                                                     HttpServletResponse response
+    ) {
+        AuthService.LoginResult result = authService.loginWithKakao(request);
+        addRefreshTokenCookie(response, result.refreshToken());
+
+        return GlobalResponse.onSuccess(SuccessCode.AUTH_LOGIN, result.loginResponse());
     }
 
     // RefreshToken 쿠키 설정

--- a/src/main/java/com/example/leets_project/domain/auth/web/controller/KakaoOAuthController.java
+++ b/src/main/java/com/example/leets_project/domain/auth/web/controller/KakaoOAuthController.java
@@ -1,0 +1,38 @@
+package com.example.leets_project.domain.auth.web.controller;
+
+import com.example.leets_project.common.response.GlobalResponse;
+import com.example.leets_project.common.response.SuccessCode;
+import com.example.leets_project.common.security.jwt.JwtProperties;
+import com.example.leets_project.common.util.CookieUtil;
+import com.example.leets_project.domain.auth.service.AuthService;
+import com.example.leets_project.domain.auth.web.dto.KakaoLoginRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class KakaoOAuthController {
+
+    private final AuthService authService;
+    private final CookieUtil cookieUtil;
+    private final JwtProperties jwtProperties;
+
+    @Operation(summary = "KakaoOAuth 로그인 API", description = "카카오 인증 서버로부터 Redirect 되는 Callback API")
+    @GetMapping("/oauth/kakao/callback")
+    public ResponseEntity<GlobalResponse> kakaoCallback(@RequestParam String code, HttpServletResponse response) {
+        AuthService.LoginResult result = authService.loginWithKakao(new KakaoLoginRequest(code));
+
+        cookieUtil.addRefreshTokenCookie(
+                response,
+                result.refreshToken(), // xss 공격 방어 위해 쿠키에 적재(스크립트 접근 불가)
+                jwtProperties.getRefreshTokenExpirationMillis()
+        );
+
+        return GlobalResponse.onSuccess(SuccessCode.AUTH_LOGIN, result.loginResponse());
+    }
+}

--- a/src/main/java/com/example/leets_project/domain/auth/web/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/example/leets_project/domain/auth/web/dto/KakaoLoginRequest.java
@@ -1,0 +1,11 @@
+package com.example.leets_project.domain.auth.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "카카오 로그인 요청")
+public record KakaoLoginRequest(
+        @Schema(description = "카카오 인가 코드", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "인가 코드는 필수입니다.")
+        String code
+) {}

--- a/src/main/java/com/example/leets_project/domain/auth/web/dto/TokenResponse.java
+++ b/src/main/java/com/example/leets_project/domain/auth/web/dto/TokenResponse.java
@@ -4,6 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "토큰 응답")
 public record TokenResponse(
-        @Schema(description = "Access Token (Bearer)", example = "eyJhbGci...")
-        String accessToken
-) {}
+        @Schema(description = "Access Token", example = "eyJhbGci...")
+        String accessToken,
+
+        @Schema(description = "토큰 타입", example = "Bearer")
+        String tokenType
+) {
+    public static TokenResponse bearer(String accessToken) {
+        return new TokenResponse(accessToken, "Bearer");
+    }
+}

--- a/src/main/java/com/example/leets_project/domain/user/entity/AuthProvider.java
+++ b/src/main/java/com/example/leets_project/domain/user/entity/AuthProvider.java
@@ -1,0 +1,6 @@
+package com.example.leets_project.domain.user.entity;
+
+public enum AuthProvider {
+    LOCAL,
+    KAKAO
+}

--- a/src/main/java/com/example/leets_project/domain/user/entity/User.java
+++ b/src/main/java/com/example/leets_project/domain/user/entity/User.java
@@ -25,18 +25,25 @@ public class User extends BaseEntity{
     @Column(nullable = false, length = 50) // 동명이인 가능 -> unique 값 제외
     private String name;
 
-    @Column(nullable = false, unique = true, length = 100)
+    @Column(unique = true, length = 100)// Kakao test 위해 잠시 nullable 해제
     private String email;
 
     @Column(nullable = false, unique = true, length = 50)
     private String nickname;
 
-    @Column(nullable = false)
+    @Column // Kakao test 위해 잠시 nullable 해제
     private String password;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AuthProvider authProvider;
+
+    @Column(length = 100)
+    private String providerId;
 
     // 양방향: User → Post
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -47,12 +54,14 @@ public class User extends BaseEntity{
     private List<Comment> comments = new ArrayList<>();
 
     @Builder
-    public User(String name, String email, String nickname, String password) {
+    public User(String name, String email, String nickname, String password, AuthProvider authProvider,  String providerId) {
         this.name = name;
         this.email = email;
         this.nickname = nickname;
         this.password = password;
         this.role = UserRole.USER;
+        this.authProvider = authProvider;
+        this.providerId = providerId;
     }
 }
 

--- a/src/main/java/com/example/leets_project/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/leets_project/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.example.leets_project.domain.user.repository;
 
+import com.example.leets_project.domain.user.entity.AuthProvider;
 import com.example.leets_project.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,4 +13,6 @@ public interface UserRepository extends JpaRepository<User,Long> {
     Optional<User> findByEmail(String email);
     // 닉네임 중복 확인
     boolean existsByNickname(String nickname);
+    Optional<User> findByAuthProviderAndProviderId(AuthProvider authProvider, String providerId);
 }
+

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,3 +17,19 @@ jwt:
   secret: dGhpcy1pcy1hLXNhbXBsZS1zZWNyZXQta2V5LWZvci1qd3QtZ2VuZXJhdGlvbi1ub3ctM
   access-token-expiration-millis: 1800000    # 30분 (30 * 60 * 1000)
   refresh-token-expiration-millis: 1209600000 # 14일 (14 * 24 * 60 * 60 * 1000)
+
+oauth:
+  kakao:
+    client-id: 37fd82a73958cea4cb4d43bd9b562048
+    client-secret: eGsgszGpDxrFg8M7vWqSjGBL45CwImN7
+    redirect-uri: http://localhost:8080/oauth/kakao/callback
+    auth-url: https://kauth.kakao.com/oauth/authorize
+    token-url: https://kauth.kakao.com/oauth/token
+    user-info-url: https://kapi.kakao.com/v2/user/me
+
+cookie:
+  secure: ${COOKIE_SECURE:false}
+
+app:
+  oauth:
+    redirect-url: ${OAUTH_REDIRECT_URL:http://localhost:8080/oauth/callback}


### PR DESCRIPTION
## 1. 과제 요구사항 중 구현한 내용

- 카카오 OAuth 로그인 구현

## 2. 핵심 변경 사항

- 카카오 OAuth 로그인 흐름 추가
카카오 인가 코드를 받아 카카오 access token으로 교환하고, 사용자 정보를 조회한 뒤 자체 JWT를 발급하도록 구현

- 카카오 신규 유저 자동 가입
카카오 최초 로그인 시 authProvider = KAKAO, providerId = 카카오 고유 ID 기준으로 사용자 자동 생성

- 카카오 기존 유저 로그인
이메일이 아니라 authProvider + providerId 조합으로 기존 카카오 계정을 식별

- 소셜 로그인 계정 지원
카카오 계정은 이메일 또는 비밀번호가 없을 수 있으므로 email, password를 nullable로 변경

- refresh token 해시 저장
refresh token 원문 대신 SHA-256 해시값을 DB에 저장하도록 변경
기존 방식대로 refresh token 원문을 DB에 저장하면, DB가 유출되었을 때 공격자가 해당 token을 그대로 사용해 access token을 재발급받을 수 있음 -> refresh token 원문을 바로 사용할 수 없게 만들어 피해 범위를 줄임

- refresh token rotation 유지
로그인 또는 재발급 시 기존 refresh token을 새 token으로 교체하고, DB에는 새 token의 해시값만 저장

- refresh token은 HttpOnly cookie로 전달
refresh token은 응답 body가 아니라 HttpOnly cookie로 내려줌으로 JavaScript에서 접근할 수 없기 때문-> XSS 공격에도 refresh token이 직접 탈취될 가능성을 줄이기 가능

## 3. 실행 및 검증 결과

<img width="1766" height="726" alt="image" src="https://github.com/user-attachments/assets/e13a6cf6-0dcd-439c-ac77-e95173f711b4" />

## 4. 완료 사항

1. 카카오 OAuth 로그인 구현 및 기존 코드 수정

## 5. 추가 사항

- 관련 이슈: `closed #304 `

## 제출 체크리스트

- [x] PR 제목이 규칙에 맞다
- [x] base가 `{이름}/main` 브랜치다
- [x] compare가 `{이름}/{숫자}주차` 브랜치다
- [x] 프로젝트가 정상 실행된다
- [x] 본인을 Assignee로 지정했다
- [x] 파트 담당 Reviewer를 지정했다
- [x] 리뷰 피드백을 반영한 뒤 머지/PR close를 진행한다

### Reviewer 참고
